### PR TITLE
Remove usage of `resourceInfo()` for symbolic name templates

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -465,7 +465,7 @@ Hello from Bicep!"));
     ""_generator"": {
       ""name"": ""bicep"",
       ""version"": ""dev"",
-      ""templateHash"": ""831867025312306238""
+      ""templateHash"": ""8036895127623403713""
     }
   },
   ""parameters"": {
@@ -495,7 +495,7 @@ Hello from Bicep!"));
         ""mode"": ""Incremental"",
         ""parameters"": {
           ""connectionString"": {
-            ""value"": ""[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('stgAccount').name, environment().suffixes.storage, listKeys(resourceInfo('stgAccount').id, '2019-06-01').keys[0].value)]""
+            ""value"": ""[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', toLower(parameters('accountName')), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', toLower(parameters('accountName'))), '2019-06-01').keys[0].value)]""
           }
         },
         ""template"": {

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -2923,7 +2923,7 @@ output bar string = server2::firewall.properties.startIpAddress
             result.Template.Should().HaveValueAtPath("$.resources['server2::db'].name", "[format('{0}/{1}', 'sql', 'cool-database2')]");
             result.Template.Should().HaveValueAtPath("$.resources['server2::firewall'].name", "[format('{0}/{1}', 'sql', 'test')]");
 
-            result.Template.Should().HaveValueAtPath("$.outputs['foo'].value", "[resourceInfo('server2::firewall').name]");
+            result.Template.Should().HaveValueAtPath("$.outputs['foo'].value", "test");
             result.Template.Should().HaveValueAtPath("$.outputs['bar'].value", "[reference('server2::firewall').startIpAddress]");
         }
 
@@ -4132,9 +4132,6 @@ var _subnets = {
 
 output aksRouteTable string = _subnets.aksPoolSys.routeTable
 "));
-
-            // verify the variable has been inlined
-            result.Template.Should().NotHaveValueAtPath("$.variables['_subnets']");
 
             var evaluated = TemplateEvaluator.Evaluate(result.Template);
             evaluated.Should().HaveValueAtPath("$.outputs['aksRouteTable'].value", "/subscriptions/f91a30fd-f403-4999-ae9f-ec37a6d81e13/resourceGroups/testResourceGroup/providers/Microsoft.Network/routeTables/aksRouteTable");

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "271562621716449034"
+      "templateHash": "9919460414504247412"
     }
   },
   "parameters": {
@@ -23,6 +23,10 @@
         "[variables('deployTimeVar')]",
         "[parameters('deployTimeParam')]"
       ]
+    },
+    "resourceIds": {
+      "a": "[resourceInfo('resA').id]",
+      "b": "[resourceInfo('resB').id]"
     }
   },
   "resources": {
@@ -59,10 +63,7 @@
       "apiVersion": "2020-01-01",
       "name": "resC",
       "properties": {
-        "resourceIds": {
-          "a": "[resourceInfo('resA').id]",
-          "b": "[resourceInfo('resB').id]"
-        }
+        "resourceIds": "[variables('resourceIds')]"
       },
       "dependsOn": [
         "resA",

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9919460414504247412"
+      "templateHash": "156273920754641258"
     }
   },
   "parameters": {
@@ -25,8 +25,8 @@
       ]
     },
     "resourceIds": {
-      "a": "[resourceInfo('resA').id]",
-      "b": "[resourceInfo('resB').id]"
+      "a": "[resourceId('My.Rp/myResourceType', 'resA')]",
+      "b": "[resourceId('My.Rp/myResourceType', 'resB')]"
     }
   },
   "resources": {
@@ -46,9 +46,9 @@
       "properties": {
         "dependencies": {
           "dependenciesA": [
-            "[resourceInfo('resA').id]",
-            "[resourceInfo('resA').name]",
-            "[resourceInfo('resA').type]",
+            "[resourceId('My.Rp/myResourceType', 'resA')]",
+            "resA",
+            "My.Rp/myResourceType",
             "[reference('resA').deployTime]",
             "[reference('resA').eTag]"
           ]
@@ -73,7 +73,7 @@
     "resD": {
       "type": "My.Rp/myResourceType/childType",
       "apiVersion": "2020-01-01",
-      "name": "[format('{0}/resD', resourceInfo('resC').name)]",
+      "name": "[format('{0}/resD', 'resC')]",
       "properties": {},
       "dependsOn": [
         "resC"
@@ -84,7 +84,7 @@
       "apiVersion": "2020-01-01",
       "name": "resC/resD",
       "properties": {
-        "resDRef": "[resourceInfo('resD').id]"
+        "resDRef": "[resourceId('My.Rp/myResourceType/childType', split(format('{0}/resD', 'resC'), '/')[0], split(format('{0}/resD', 'resC'), '/')[1])]"
       },
       "dependsOn": [
         "resD"
@@ -94,11 +94,11 @@
   "outputs": {
     "resourceAType": {
       "type": "string",
-      "value": "[resourceInfo('resA').type]"
+      "value": "My.Rp/myResourceType"
     },
     "resourceBId": {
       "type": "string",
-      "value": "[resourceInfo('resB').id]"
+      "value": "[resourceId('My.Rp/myResourceType', 'resB')]"
     },
     "resourceCProperties": {
       "type": "object",

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5072892237720150073"
+      "templateHash": "8647043276184354817"
     }
   },
   "parameters": {
@@ -221,7 +221,7 @@
       "properties": {
         "resolutionVirtualNetworks": [
           {
-            "id": "[resourceInfo(format('vnets[{0}]', add(parameters('index'), 1))).id]"
+            "id": "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-{1}', variables('vnetConfigurations')[copyIndex()].name, copyIndex()))]"
           }
         ]
       },
@@ -237,10 +237,10 @@
       "properties": {
         "resolutionVirtualNetworks": [
           {
-            "id": "[resourceInfo(format('vnets[{0}]', sub(parameters('index'), 1))).id]"
+            "id": "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-{1}', variables('vnetConfigurations')[copyIndex()].name, copyIndex()))]"
           },
           {
-            "id": "[resourceInfo(format('vnets[{0}]', mul(parameters('index'), 2))).id]"
+            "id": "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-{1}', variables('vnetConfigurations')[copyIndex()].name, copyIndex()))]"
           }
         ]
       },
@@ -701,19 +701,19 @@
     },
     "indexedCollectionName": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).name]"
+      "value": "[format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[copyIndex()].name, copyIndex())]"
     },
     "indexedCollectionId": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[copyIndex()].name, copyIndex()))]"
     },
     "indexedCollectionType": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).type]"
+      "value": "Microsoft.Storage/storageAccounts"
     },
     "indexedCollectionVersion": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).apiVersion]"
+      "value": "2019-06-01"
     },
     "indexedCollectionIdentity": {
       "type": "object",
@@ -740,19 +740,19 @@
     },
     "existingIndexedResourceName": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', mul(parameters('index'), 0))).name]"
+      "value": "[format('{0}-existing-{1}-{2}', parameters('name'), parameters('accounts')[copyIndex()].name, copyIndex())]"
     },
     "existingIndexedResourceId": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', mul(parameters('index'), 1))).id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', format('{0}-existing-{1}-{2}', parameters('name'), parameters('accounts')[copyIndex()].name, copyIndex()))]"
     },
     "existingIndexedResourceType": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', add(parameters('index'), 2))).type]"
+      "value": "Microsoft.Storage/storageAccounts"
     },
     "existingIndexedResourceApiVersion": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', sub(parameters('index'), 7))).apiVersion]"
+      "value": "2019-06-01"
     },
     "existingIndexedResourceLocation": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14142443566278829152"
+      "templateHash": "13911732419261916930"
     }
   },
   "parameters": {
@@ -221,7 +221,7 @@
       "properties": {
         "resolutionVirtualNetworks": [
           {
-            "id": "[resourceInfo(format('vnets[{0}]', add(parameters('index'), 1))).id]"
+            "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetConfigurations')[copyIndex()].name)]"
           }
         ]
       },
@@ -237,10 +237,10 @@
       "properties": {
         "resolutionVirtualNetworks": [
           {
-            "id": "[resourceInfo(format('vnets[{0}]', sub(parameters('index'), 1))).id]"
+            "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetConfigurations')[copyIndex()].name)]"
           },
           {
-            "id": "[resourceInfo(format('vnets[{0}]', mul(parameters('index'), 2))).id]"
+            "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetConfigurations')[copyIndex()].name)]"
           }
         ]
       },
@@ -815,19 +815,19 @@
     },
     "indexedCollectionName": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).name]"
+      "value": "[format('{0}-collection-{1}', parameters('name'), parameters('accounts')[copyIndex()].name)]"
     },
     "indexedCollectionId": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[copyIndex()].name))]"
     },
     "indexedCollectionType": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).type]"
+      "value": "Microsoft.Storage/storageAccounts"
     },
     "indexedCollectionVersion": {
       "type": "string",
-      "value": "[resourceInfo(format('storageAccounts[{0}]', parameters('index'))).apiVersion]"
+      "value": "2019-06-01"
     },
     "indexedCollectionIdentity": {
       "type": "object",
@@ -854,19 +854,19 @@
     },
     "existingIndexedResourceName": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', mul(parameters('index'), 0))).name]"
+      "value": "[format('{0}-existing-{1}', parameters('name'), parameters('accounts')[copyIndex()].name)]"
     },
     "existingIndexedResourceId": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', mul(parameters('index'), 1))).id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', format('{0}-existing-{1}', parameters('name'), parameters('accounts')[copyIndex()].name))]"
     },
     "existingIndexedResourceType": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', add(parameters('index'), 2))).type]"
+      "value": "Microsoft.Storage/storageAccounts"
     },
     "existingIndexedResourceApiVersion": {
       "type": "string",
-      "value": "[resourceInfo(format('existingStorageAccounts[{0}]', sub(parameters('index'), 7))).apiVersion]"
+      "value": "2019-06-01"
     },
     "existingIndexedResourceLocation": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18170097315916018511"
+      "templateHash": "9089331581017119406"
     }
   },
   "parameters": {
@@ -146,7 +146,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -194,8 +194,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -228,7 +228,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8343348345038017633"
+              "templateHash": "3908852693504940489"
             }
           },
           "parameters": {
@@ -247,7 +247,7 @@
           "outputs": {
             "myResourceId": {
               "type": "string",
-              "value": "[resourceInfo('myResource').id]"
+              "value": "[resourceId('Mock.Rp/mockResource', 'mockResource')]"
             }
           }
         }
@@ -280,7 +280,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8343348345038017633"
+              "templateHash": "3908852693504940489"
             }
           },
           "parameters": {
@@ -299,7 +299,7 @@
           "outputs": {
             "myResourceId": {
               "type": "string",
-              "value": "[resourceInfo('myResource').id]"
+              "value": "[resourceId('Mock.Rp/mockResource', 'mockResource')]"
             }
           }
         }
@@ -673,7 +673,7 @@
         "mode": "Incremental",
         "parameters": {
           "optionalString": {
-            "value": "[concat(resourceInfo('resWithDependencies').id, 'optionalWithAllParamsAndManualDependency')]"
+            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
           },
           "optionalInt": {
             "value": 42
@@ -751,7 +751,7 @@
         "mode": "Incremental",
         "parameters": {
           "optionalString": {
-            "value": "[concat(resourceInfo('resWithDependencies').id, 'optionalWithAllParamsAndManualDependency')]"
+            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
           },
           "optionalInt": {
             "value": 42
@@ -851,7 +851,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -899,8 +899,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -945,7 +945,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -993,8 +993,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1040,7 +1040,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1088,8 +1088,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1138,7 +1138,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1186,8 +1186,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1236,7 +1236,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1284,8 +1284,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1331,7 +1331,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1379,8 +1379,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1455,7 +1455,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1503,8 +1503,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1580,7 +1580,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1628,8 +1628,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }
@@ -1708,7 +1708,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13974283364562914389"
+              "templateHash": "5119314944459844001"
             }
           },
           "parameters": {
@@ -1756,8 +1756,8 @@
             "arrayOutput": {
               "type": "array",
               "value": [
-                "[resourceInfo('basicStorage').id]",
-                "[resourceInfo('dnsZone').id]"
+                "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+                "[resourceId('Mock.Rp/mockResource', 'myZone')]"
               ]
             }
           }

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15218392321084396916"
+      "templateHash": "14186230480445556503"
     }
   },
   "parameters": {
@@ -151,7 +151,7 @@
     },
     "loopChildOutput": {
       "type": "string",
-      "value": "[resourceInfo(format('loopParent::loopChild[{0}]', 0)).name]"
+      "value": "loopChild"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10717778024170373424"
+      "templateHash": "9808007941102328408"
     }
   },
   "variables": {
@@ -85,7 +85,7 @@
       "copy": {
         "count": "[length(range(0, length(variables('managementGroups'))))]",
         "input": {
-          "name": "[resourceInfo(format('yetAnotherSet[{0}]', range(0, length(variables('managementGroups')))[copyIndex()])).name]",
+          "name": "[concat(variables('managementGroups')[copyIndex()].name, '-two')]",
           "displayName": "[reference(format('yetAnotherSet[{0}]', range(0, length(variables('managementGroups')))[copyIndex()])).displayName]"
         }
       }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7085243670229967766"
+      "templateHash": "5761729311726706896"
     }
   },
   "parameters": {
@@ -36,6 +36,11 @@
     "hostingPlanName": "[parameters('applicationName')]",
     "location": "[resourceGroup().location]",
     "cosmosDbResourceId": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDb').account)]",
+    "_siteApiVersion": "[resourceInfo('site').apiVersion]",
+    "_siteType": "[resourceInfo('site').type]",
+    "resourceCRef": {
+      "id": "[resourceInfo('resourceC').id]"
+    },
     "setResourceCRef": true,
     "myInterpKey": "abc",
     "storageAccounts": [
@@ -239,7 +244,7 @@
             "aKind": "[reference('resourceA', '2020-01-01', 'full').kind]"
           }
         ],
-        "repro316": "[if(variables('setResourceCRef'), createObject('id', resourceInfo('resourceC').id), null())]"
+        "repro316": "[if(variables('setResourceCRef'), variables('resourceCRef'), null())]"
       },
       "dependsOn": [
         "resourceA",

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5761729311726706896"
+      "templateHash": "10573795545729257719"
     }
   },
   "parameters": {
@@ -36,10 +36,10 @@
     "hostingPlanName": "[parameters('applicationName')]",
     "location": "[resourceGroup().location]",
     "cosmosDbResourceId": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDb').account)]",
-    "_siteApiVersion": "[resourceInfo('site').apiVersion]",
-    "_siteType": "[resourceInfo('site').type]",
+    "_siteApiVersion": "2019-08-01",
+    "_siteType": "Microsoft.Web/sites",
     "resourceCRef": {
-      "id": "[resourceInfo('resourceC').id]"
+      "id": "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]"
     },
     "setResourceCRef": true,
     "myInterpKey": "abc",
@@ -191,10 +191,10 @@
       "apiVersion": "2019-10-01",
       "name": "nestedTemplate1",
       "properties": {
-        "otherId": "[resourceInfo('nested').id]",
-        "otherName": "[resourceInfo('nested').name]",
-        "otherVersion": "[resourceInfo('nested').apiVersion]",
-        "otherType": "[resourceInfo('nested').type]",
+        "otherId": "[resourceId('Microsoft.Resources/deployments', 'nestedTemplate1')]",
+        "otherName": "nestedTemplate1",
+        "otherVersion": "2019-10-01",
+        "otherType": "Microsoft.Resources/deployments",
         "otherThings": "[reference('nested').mode]"
       },
       "dependsOn": [
@@ -209,7 +209,7 @@
     "resourceB": {
       "type": "My.Rp/typeA/typeB",
       "apiVersion": "2020-01-01",
-      "name": "[format('{0}/myName', resourceInfo('resourceA').name)]",
+      "name": "[format('{0}/myName', 'resourceA')]",
       "dependsOn": [
         "resourceA"
       ]
@@ -217,12 +217,12 @@
     "resourceC": {
       "type": "My.Rp/typeA/typeB",
       "apiVersion": "2020-01-01",
-      "name": "[format('{0}/myName', resourceInfo('resourceA').name)]",
+      "name": "[format('{0}/myName', 'resourceA')]",
       "properties": {
-        "aId": "[resourceInfo('resourceA').id]",
-        "aType": "[resourceInfo('resourceA').type]",
-        "aName": "[resourceInfo('resourceA').name]",
-        "aApiVersion": "[resourceInfo('resourceA').apiVersion]",
+        "aId": "[resourceId('My.Rp/typeA', 'resourceA')]",
+        "aType": "My.Rp/typeA",
+        "aName": "resourceA",
+        "aApiVersion": "2020-01-01",
         "bProperties": "[reference('resourceB')]"
       },
       "dependsOn": [
@@ -237,10 +237,10 @@
       "properties": {
         "runtime": [
           {
-            "bId": "[resourceInfo('resourceB').id]",
-            "bType": "[resourceInfo('resourceB').type]",
-            "bName": "[resourceInfo('resourceB').name]",
-            "bApiVersion": "[resourceInfo('resourceB').apiVersion]",
+            "bId": "[resourceId('My.Rp/typeA/typeB', split(format('{0}/myName', 'resourceA'), '/')[0], split(format('{0}/myName', 'resourceA'), '/')[1])]",
+            "bType": "My.Rp/typeA/typeB",
+            "bName": "[format('{0}/myName', 'resourceA')]",
+            "bApiVersion": "2020-01-01",
             "aKind": "[reference('resourceA', '2020-01-01', 'full').kind]"
           }
         ],
@@ -310,11 +310,11 @@
       "apiVersion": "2020-01-01",
       "name": "extensionDependencies",
       "properties": {
-        "res1": "[resourceInfo('vmWithCondition').id]",
+        "res1": "[resourceId('Microsoft.Compute/virtualMachines', 'vmName')]",
         "res1runtime": "[reference('vmWithCondition').something]",
-        "res2": "[resourceInfo('extension1').id]",
+        "res2": "[extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension')]",
         "res2runtime": "[reference('extension1').something]",
-        "res3": "[resourceInfo('extension2').id]",
+        "res3": "[extensionResourceId(extensionResourceId(resourceId('Microsoft.Compute/virtualMachines', 'vmName'), 'My.Rp/extensionResource', 'extension'), 'My.Rp/extensionResource', 'extension')]",
         "res3runtime": "[reference('extension2').something]"
       },
       "dependsOn": [
@@ -621,11 +621,11 @@
   "outputs": {
     "siteApiVersion": {
       "type": "string",
-      "value": "[resourceInfo('site').apiVersion]"
+      "value": "2019-08-01"
     },
     "siteType": {
       "type": "string",
-      "value": "[resourceInfo('site').type]"
+      "value": "Microsoft.Web/sites"
     },
     "p1_subnet1prefix": {
       "type": "string",
@@ -633,15 +633,15 @@
     },
     "p1_subnet1name": {
       "type": "string",
-      "value": "[resourceInfo('p1_subnet1').name]"
+      "value": "subnet1"
     },
     "p1_subnet1type": {
       "type": "string",
-      "value": "[resourceInfo('p1_subnet1').type]"
+      "value": "Microsoft.Network/virtualNetworks/subnets"
     },
     "p1_subnet1id": {
       "type": "string",
-      "value": "[resourceInfo('p1_subnet1').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVnet', 'subnet1')]"
     },
     "p2_res2childprop": {
       "type": "string",
@@ -649,15 +649,15 @@
     },
     "p2_res2childname": {
       "type": "string",
-      "value": "[resourceInfo('p2_res2child').name]"
+      "value": "child2"
     },
     "p2_res2childtype": {
       "type": "string",
-      "value": "[resourceInfo('p2_res2child').type]"
+      "value": "Microsoft.Rp2/resource2/child2"
     },
     "p2_res2childid": {
       "type": "string",
-      "value": "[resourceInfo('p2_res2child').id]"
+      "value": "[extensionResourceId(resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1'), 'Microsoft.Rp2/resource2/child2', 'res2', 'child2')]"
     },
     "p3_res1childprop": {
       "type": "string",
@@ -665,15 +665,15 @@
     },
     "p3_res1childname": {
       "type": "string",
-      "value": "[resourceInfo('p3_child1').name]"
+      "value": "child1"
     },
     "p3_res1childtype": {
       "type": "string",
-      "value": "[resourceInfo('p3_child1').type]"
+      "value": "Microsoft.Rp1/resource1/child1"
     },
     "p3_res1childid": {
       "type": "string",
-      "value": "[resourceInfo('p3_child1').id]"
+      "value": "[resourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]"
     },
     "p4_res1childprop": {
       "type": "string",
@@ -681,15 +681,15 @@
     },
     "p4_res1childname": {
       "type": "string",
-      "value": "[resourceInfo('p4_child1').name]"
+      "value": "child1"
     },
     "p4_res1childtype": {
       "type": "string",
-      "value": "[resourceInfo('p4_child1').type]"
+      "value": "Microsoft.Rp1/resource1/child1"
     },
     "p4_res1childid": {
       "type": "string",
-      "value": "[resourceInfo('p4_child1').id]"
+      "value": "[tenantResourceId('Microsoft.Rp1/resource1/child1', 'res1', 'child1')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7957561682324694647"
+      "templateHash": "2098153364201229574"
     }
   },
   "parameters": {
@@ -96,13 +96,13 @@
               "properties": {
                 "primary": true
               },
-              "id": "[resourceInfo('nic1').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]"
             },
             {
               "properties": {
                 "primary": false
               },
-              "id": "[resourceInfo('nic2').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
             }
           ]
         },
@@ -178,7 +178,7 @@
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg2').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
               }
             }
           }
@@ -199,17 +199,17 @@
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnet1Name'))]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
         ],
         "networkSecurityGroup": {
-          "id": "[resourceInfo('nsg').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
       },
       "dependsOn": [
@@ -229,7 +229,7 @@
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnet2Name'))]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet2Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic"
             }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/aad-domainservices/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/aad-domainservices/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16039386562584845882"
+      "templateHash": "15754055514055338412"
     }
   },
   "parameters": {
@@ -206,7 +206,7 @@
       "properties": {
         "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
         "networkSecurityGroup": {
-          "id": "[resourceInfo('nsg').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
         }
       },
       "dependsOn": [
@@ -225,7 +225,7 @@
         "domainConfigurationType": "[parameters('domainConfigurationType')]",
         "replicaSets": [
           {
-            "subnetId": "[resourceInfo('subnet').id]",
+            "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
             "location": "[parameters('location')]"
           }
         ],

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/aadds-dual-region-replica-sets/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/aadds-dual-region-replica-sets/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4356980910469897906"
+      "templateHash": "13758972796220001574"
     }
   },
   "parameters": {
@@ -124,7 +124,7 @@
             "properties": {
               "addressPrefix": "10.0.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsgEUS').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'aadds-eus-nsg')]"
               }
             }
           }
@@ -200,7 +200,7 @@
             "properties": {
               "addressPrefix": "10.1.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsgWEU').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'aadds-weu-nsg')]"
               }
             }
           }
@@ -213,14 +213,14 @@
     "peerEUS": {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}-peering-{2}', resourceInfo('vnetEUS').name, resourceInfo('vnetEUS').name, resourceInfo('vnetWEU').name)]",
+      "name": "[format('{0}/{1}-peering-{2}', 'aadds-eus-vnet', 'aadds-eus-vnet', 'aadds-weu-vnet')]",
       "properties": {
         "allowVirtualNetworkAccess": true,
         "allowForwardedTraffic": true,
         "allowGatewayTransit": false,
         "useRemoteGateways": false,
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnetWEU').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', 'aadds-weu-vnet')]"
         }
       },
       "dependsOn": [
@@ -231,14 +231,14 @@
     "peerWEU": {
       "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}-peering-{2}', resourceInfo('vnetWEU').name, resourceInfo('vnetWEU').name, resourceInfo('vnetEUS').name)]",
+      "name": "[format('{0}/{1}-peering-{2}', 'aadds-weu-vnet', 'aadds-weu-vnet', 'aadds-eus-vnet')]",
       "properties": {
         "allowVirtualNetworkAccess": true,
         "allowForwardedTraffic": true,
         "allowGatewayTransit": false,
         "useRemoteGateways": false,
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnetEUS').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', 'aadds-eus-vnet')]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/aks-vmss-systemassigned-identity/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/aks-vmss-systemassigned-identity/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11559571680286830127"
+      "templateHash": "546289837928721149"
     }
   },
   "parameters": {
@@ -50,6 +50,7 @@
     }
   },
   "variables": {
+    "subnetRef": "[format('{0}/subnets/{1}', resourceInfo('vn').id, variables('subnetName'))]",
     "addressPrefix": "20.0.0.0/16",
     "subnetName": "Subnet01",
     "subnetPrefix": "20.0.0.0/24",
@@ -125,7 +126,7 @@
             "type": "VirtualMachineScaleSets",
             "osType": "Linux",
             "enableAutoScaling": false,
-            "vnetSubnetID": "[format('{0}/subnets/{1}', resourceInfo('vn').id, variables('subnetName'))]"
+            "vnetSubnetID": "[variables('subnetRef')]"
           }
         ],
         "servicePrincipalProfile": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/aks-vmss-systemassigned-identity/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/aks-vmss-systemassigned-identity/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "546289837928721149"
+      "templateHash": "10433663277526646851"
     }
   },
   "parameters": {
@@ -50,7 +50,7 @@
     }
   },
   "variables": {
-    "subnetRef": "[format('{0}/subnets/{1}', resourceInfo('vn').id, variables('subnetName'))]",
+    "subnetRef": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnetName'))]",
     "addressPrefix": "20.0.0.0/16",
     "subnetName": "Subnet01",
     "subnetPrefix": "20.0.0.0/24",
@@ -146,7 +146,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('aks').id]"
+      "value": "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]"
     },
     "apiServerAddress": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/NameValues.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/NameValues.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11465963401547040736"
+      "templateHash": "1203366722634930124"
     }
   },
   "parameters": {
@@ -66,8 +66,8 @@
       "copy": {
         "count": "[length(variables('apimNameValueSet'))]",
         "input": {
-          "nameValueId": "[resourceInfo(format('apiManagementNVPair[{0}]', copyIndex())).id]",
-          "nameValueName": "[resourceInfo(format('apiManagementNVPair[{0}]', copyIndex())).name]"
+          "nameValueId": "[resourceId('Microsoft.ApiManagement/service/namedValues', parameters('apimInstanceName'), variables('apimNameValueSet')[copyIndex()].displayName)]",
+          "nameValueName": "[variables('apimNameValueSet')[copyIndex()].displayName]"
         }
       }
     }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/groups.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/groups.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12966508422874822476"
+      "templateHash": "8099781985018259242"
     }
   },
   "parameters": {
@@ -57,8 +57,8 @@
       "copy": {
         "count": "[length(variables('groupsSet'))]",
         "input": {
-          "groupId": "[resourceInfo(format('apimGroup[{0}]', copyIndex())).id]",
-          "groupName": "[resourceInfo(format('apimGroup[{0}]', copyIndex())).name]"
+          "groupId": "[resourceId('Microsoft.ApiManagement/service/groups', parameters('apimInstanceName'), variables('groupsSet')[copyIndex()].groupName)]",
+          "groupName": "[variables('groupsSet')[copyIndex()].groupName]"
         }
       }
     }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2127656982266260806"
+      "templateHash": "8474947876549270925"
     }
   },
   "parameters": {
@@ -126,7 +126,7 @@
       "apiVersion": "2020-06-01-preview",
       "name": "[format('{0}/{1}', parameters('apimInstanceName'), 'applicationinsights')]",
       "properties": {
-        "loggerId": "[resourceInfo('apiManagementLogger').id]",
+        "loggerId": "[resourceId('Microsoft.ApiManagement/service/loggers', parameters('apimInstanceName'), parameters('appInsightsName'))]",
         "alwaysLog": "allErrors",
         "logClientIp": true,
         "sampling": {
@@ -151,7 +151,7 @@
         "mode": "Incremental",
         "parameters": {
           "apimInstanceName": {
-            "value": "[resourceInfo('apiManagement').name]"
+            "value": "[parameters('apimInstanceName')]"
           }
         },
         "template": {
@@ -163,7 +163,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12966508422874822476"
+              "templateHash": "8099781985018259242"
             }
           },
           "parameters": {
@@ -213,8 +213,8 @@
               "copy": {
                 "count": "[length(variables('groupsSet'))]",
                 "input": {
-                  "groupId": "[resourceInfo(format('apimGroup[{0}]', copyIndex())).id]",
-                  "groupName": "[resourceInfo(format('apimGroup[{0}]', copyIndex())).name]"
+                  "groupId": "[resourceId('Microsoft.ApiManagement/service/groups', parameters('apimInstanceName'), variables('groupsSet')[copyIndex()].groupName)]",
+                  "groupName": "[variables('groupsSet')[copyIndex()].groupName]"
                 }
               }
             }
@@ -237,7 +237,7 @@
         "mode": "Incremental",
         "parameters": {
           "apimInstanceName": {
-            "value": "[resourceInfo('apiManagement').name]"
+            "value": "[parameters('apimInstanceName')]"
           }
         },
         "template": {
@@ -320,7 +320,7 @@
         "mode": "Incremental",
         "parameters": {
           "apimInstanceName": {
-            "value": "[resourceInfo('apiManagement').name]"
+            "value": "[parameters('apimInstanceName')]"
           }
         },
         "template": {
@@ -332,7 +332,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11465963401547040736"
+              "templateHash": "1203366722634930124"
             }
           },
           "parameters": {
@@ -391,8 +391,8 @@
               "copy": {
                 "count": "[length(variables('apimNameValueSet'))]",
                 "input": {
-                  "nameValueId": "[resourceInfo(format('apiManagementNVPair[{0}]', copyIndex())).id]",
-                  "nameValueName": "[resourceInfo(format('apiManagementNVPair[{0}]', copyIndex())).name]"
+                  "nameValueId": "[resourceId('Microsoft.ApiManagement/service/namedValues', parameters('apimInstanceName'), variables('apimNameValueSet')[copyIndex()].displayName)]",
+                  "nameValueName": "[variables('apimNameValueSet')[copyIndex()].displayName]"
                 }
               }
             }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/app-config/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/app-config/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8068768144990634285"
+      "templateHash": "87364998234739268"
     }
   },
   "parameters": {
@@ -51,7 +51,7 @@
     "key1": {
       "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
       "apiVersion": "2020-07-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('config').name, parameters('keyValueNames')[0])]",
+      "name": "[format('{0}/{1}', parameters('configStoreName'), parameters('keyValueNames')[0])]",
       "properties": {
         "value": "[parameters('keyValueValues')[0]]",
         "contentType": "[parameters('contentType')]"
@@ -63,7 +63,7 @@
     "key2": {
       "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
       "apiVersion": "2020-07-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('config').name, parameters('keyValueNames')[1])]",
+      "name": "[format('{0}/{1}', parameters('configStoreName'), parameters('keyValueNames')[1])]",
       "properties": {
         "value": "[parameters('keyValueValues')[1]]",
         "contentType": "[parameters('contentType')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/app-service-regional-vnet-integration/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/app-service-regional-vnet-integration/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15241752625557139996"
+      "templateHash": "4598558986801209054"
     }
   },
   "parameters": {
@@ -101,7 +101,7 @@
       "location": "[parameters('location')]",
       "kind": "app",
       "properties": {
-        "serverFarmId": "[resourceInfo('appServicePlan').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
       },
       "dependsOn": [
         "appServicePlan",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/application-gateway-v2-autoscale-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/application-gateway-v2-autoscale-create/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10975496065499567677"
+      "templateHash": "2784423628703921716"
     }
   },
   "parameters": {
@@ -184,7 +184,7 @@
             "name": "appGatewayIpConfig",
             "properties": {
               "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('subnetName'))]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
               }
             }
           }
@@ -194,7 +194,7 @@
             "name": "appGatewayFrontendIP",
             "properties": {
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIP').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('appGwPublicIpName'))]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/avd-backplane/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/avd-backplane/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11242828152419533345"
+      "templateHash": "5540512387618228091"
     }
   },
   "parameters": {
@@ -77,7 +77,7 @@
       "properties": {
         "friendlyName": "[parameters('appgroupNameFriendlyName')]",
         "applicationGroupType": "[parameters('applicationgrouptype')]",
-        "hostPoolArmPath": "[resourceInfo('hp').id]"
+        "hostPoolArmPath": "[resourceId('Microsoft.DesktopVirtualization/hostPools', parameters('hostpoolName'))]"
       },
       "dependsOn": [
         "hp"
@@ -91,7 +91,7 @@
       "properties": {
         "friendlyName": "[parameters('workspaceNameFriendlyName')]",
         "applicationGroupReferences": [
-          "[resourceInfo('ag').id]"
+          "[resourceId('Microsoft.DesktopVirtualization/applicationGroups', parameters('appgroupName'))]"
         ]
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-automation-account/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-automation-account/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9757546648159903382"
+      "templateHash": "17040235421049991369"
     }
   },
   "parameters": {
@@ -63,7 +63,7 @@
       "scope": "[format('Microsoft.Automation/automationAccounts/{0}', variables('automationaccountName'))]",
       "name": "[variables('automationaccountDiagName')]",
       "properties": {
-        "workspaceId": "[resourceInfo('automation_log_analytics').id]",
+        "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('workspaceName'))]",
         "logs": [
           {
             "category": "JobLogs",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-bastion/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-bastion/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5579091808331217000"
+      "templateHash": "154498926542874954"
     }
   },
   "parameters": {
@@ -163,10 +163,10 @@
             "name": "IpConf",
             "properties": {
               "subnet": {
-                "id": "[resourceInfo('subnet').id]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), variables('bastionSubnetName'))]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIp').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpAddressName'))]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-sentinel/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-sentinel/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6446857309320902390"
+      "templateHash": "13311947683384646986"
     }
   },
   "parameters": {
@@ -35,13 +35,13 @@
     "solution": {
       "type": "Microsoft.OperationsManagement/solutions",
       "apiVersion": "2015-11-01-preview",
-      "name": "[format('SecurityInsights({0})', resourceInfo('workspace').name)]",
+      "name": "[format('SecurityInsights({0})', parameters('workspaceName'))]",
       "location": "[parameters('location')]",
       "properties": {
-        "workspaceResourceId": "[resourceInfo('workspace').id]"
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
       },
       "plan": {
-        "name": "[format('SecurityInsights({0})', resourceInfo('workspace').name)]",
+        "name": "[format('SecurityInsights({0})', parameters('workspaceName'))]",
         "product": "OMSGallery/SecurityInsights",
         "publisher": "Microsoft",
         "promotionCode": ""

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-spring-cloud/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-spring-cloud/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16084202925750353051"
+      "templateHash": "3735552247557332213"
     }
   },
   "parameters": {
@@ -54,7 +54,7 @@
     "app1": {
       "type": "Microsoft.AppPlatform/Spring/apps",
       "apiVersion": "2020-07-01",
-      "name": "[format('{0}/{1}', resourceInfo('service').name, parameters('app1Name'))]",
+      "name": "[format('{0}/{1}', parameters('serviceName'), parameters('app1Name'))]",
       "properties": {
         "public": true
       },
@@ -65,7 +65,7 @@
     "app1deployment": {
       "type": "Microsoft.AppPlatform/Spring/apps/deployments",
       "apiVersion": "2020-07-01",
-      "name": "[format('{0}/default', resourceInfo('app1').name)]",
+      "name": "[format('{0}/default', format('{0}/{1}', parameters('serviceName'), parameters('app1Name')))]",
       "properties": {
         "source": {
           "relativePath": "<default>",
@@ -79,7 +79,7 @@
     "app2": {
       "type": "Microsoft.AppPlatform/Spring/apps",
       "apiVersion": "2020-07-01",
-      "name": "[format('{0}/{1}', resourceInfo('service').name, parameters('app2Name'))]",
+      "name": "[format('{0}/{1}', parameters('serviceName'), parameters('app2Name'))]",
       "properties": {
         "public": false
       },
@@ -90,7 +90,7 @@
     "app2deployment": {
       "type": "Microsoft.AppPlatform/Spring/apps/deployments",
       "apiVersion": "2020-07-01",
-      "name": "[format('{0}/default', resourceInfo('app2').name)]",
+      "name": "[format('{0}/default', format('{0}/{1}', parameters('serviceName'), parameters('app2Name')))]",
       "properties": {
         "source": {
           "relativePath": "<default>",
@@ -104,7 +104,7 @@
     "app3": {
       "type": "Microsoft.AppPlatform/Spring/apps",
       "apiVersion": "2020-07-01",
-      "name": "[format('{0}/{1}', resourceInfo('service').name, parameters('app3Name'))]",
+      "name": "[format('{0}/{1}', parameters('serviceName'), parameters('app3Name'))]",
       "properties": {
         "public": false
       },
@@ -115,7 +115,7 @@
     "app3deployment": {
       "type": "Microsoft.AppPlatform/Spring/apps/deployments",
       "apiVersion": "2020-07-01",
-      "name": "[format('{0}/default', resourceInfo('app3').name)]",
+      "name": "[format('{0}/default', format('{0}/{1}', parameters('serviceName'), parameters('app3Name')))]",
       "properties": {
         "source": {
           "relativePath": "<default>",
@@ -137,13 +137,13 @@
         "mode": "Incremental",
         "parameters": {
           "app1Name": {
-            "value": "[resourceInfo('app1').name]"
+            "value": "[format('{0}/{1}', parameters('serviceName'), parameters('app1Name'))]"
           },
           "app2Name": {
-            "value": "[resourceInfo('app2').name]"
+            "value": "[format('{0}/{1}', parameters('serviceName'), parameters('app2Name'))]"
           },
           "app3Name": {
-            "value": "[resourceInfo('app3').name]"
+            "value": "[format('{0}/{1}', parameters('serviceName'), parameters('app3Name'))]"
           }
         },
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azurefirewall-create-with-zones/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azurefirewall-create-with-zones/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6190868281224326070"
+      "templateHash": "14122572110426561589"
     }
   },
   "parameters": {
@@ -60,7 +60,7 @@
     "subnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', resourceInfo('virtualNetwork').name, variables('azureFirewallSubnetName'))]",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName'))]",
       "properties": {
         "addressPrefix": "[parameters('azureFirewallSubnetAddressPrefix')]"
       },
@@ -93,10 +93,10 @@
             "name": "IpConf1",
             "properties": {
               "subnet": {
-                "id": "[resourceInfo('subnet').id]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), variables('azureFirewallSubnetName')), '/')[1])]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIP').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'publicIp1')]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-free/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-free/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17356835606305738272"
+      "templateHash": "10476492836388821853"
     }
   },
   "parameters": {
@@ -54,7 +54,7 @@
     "cosmosDB": {
       "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
       "apiVersion": "2021-04-15",
-      "name": "[format('{0}/{1}', resourceInfo('cosmosAccount').name, toLower(parameters('databaseName')))]",
+      "name": "[format('{0}/{1}', toLower(parameters('accountName')), toLower(parameters('databaseName')))]",
       "properties": {
         "resource": {
           "id": "[parameters('databaseName')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-private-endpoint/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-private-endpoint/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3031609877127756967"
+      "templateHash": "13718786306586873349"
     }
   },
   "parameters": {
@@ -51,7 +51,7 @@
     "subNet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/default', resourceInfo('virtualNetwork').name)]",
+      "name": "[format('{0}/default', parameters('virtualNetworkName'))]",
       "properties": {
         "addressPrefix": "172.20.0.0/24",
         "privateEndpointNetworkPolicies": "Disabled",
@@ -111,13 +111,13 @@
       "location": "[parameters('location')]",
       "properties": {
         "subnet": {
-          "id": "[resourceInfo('subNet').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/default', parameters('virtualNetworkName')), '/')[0], split(format('{0}/default', parameters('virtualNetworkName')), '/')[1])]"
         },
         "privateLinkServiceConnections": [
           {
             "name": "MyConnection",
             "properties": {
-              "privateLinkServiceId": "[resourceInfo('databaseAccount').id]",
+              "privateLinkServiceId": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('accountName'))]",
               "groupIds": [
                 "Sql"
               ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-webapp/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-webapp/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10480420087246664695"
+      "templateHash": "3308389195624837536"
     }
   },
   "parameters": {
@@ -127,7 +127,7 @@
       "name": "[variables('websiteName')]",
       "location": "[parameters('location')]",
       "properties": {
-        "serverFarmId": "[resourceInfo('hostingPlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
         "siteConfig": {
           "appSettings": [
             {
@@ -136,7 +136,7 @@
             },
             {
               "name": "CosmosDb:Key",
-              "value": "[listKeys(resourceInfo('cosmosAccount').id, '2021-04-15').primaryMasterKey]"
+              "value": "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), '2021-04-15').primaryMasterKey]"
             },
             {
               "name": "CosmosDb:DatabaseName",
@@ -157,7 +157,7 @@
     "srcControls": {
       "type": "Microsoft.Web/sites/sourcecontrols",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/web', resourceInfo('website').name)]",
+      "name": "[format('{0}/web', variables('websiteName'))]",
       "properties": {
         "repoUrl": "[parameters('repositoryUrl')]",
         "branch": "[parameters('branch')]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/custom-role-definition-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/custom-role-definition-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16773023555038804067"
+      "templateHash": "5361516921700292324"
     }
   },
   "parameters": {
@@ -43,7 +43,7 @@
       "apiVersion": "2020-04-01-preview",
       "name": "[guid(variables('roleName'), parameters('principalId'), subscription().subscriptionId)]",
       "properties": {
-        "roleDefinitionId": "[resourceInfo('definition').id]",
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', guid(variables('roleName')))]",
         "principalId": "[parameters('principalId')]"
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/cyclecloud/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/cyclecloud/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9757556931428374773"
+      "templateHash": "4813783068555428143"
     }
   },
   "parameters": {
@@ -103,7 +103,7 @@
             "properties": {
               "addressPrefix": "10.0.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'cc-nsg')]"
               }
             }
           }
@@ -134,10 +134,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[format('{0}/subnets/Default', resourceInfo('vnet').id)]"
+                "id": "[format('{0}/subnets/Default', resourceId('Microsoft.Network/virtualNetworks', 'cc-vnet'))]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'cycleserver-pip')]"
               }
             }
           }
@@ -172,7 +172,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceInfo('mid').id)]": {}
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'CycleCloud-MI'))]": {}
         }
       },
       "properties": {
@@ -213,7 +213,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', 'cycleserver-nic')]"
             }
           ]
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/data-factory-v2-blob-to-blob-copy/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/data-factory-v2-blob-to-blob-copy/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9205253290059600425"
+      "templateHash": "15796731128401531734"
     }
   },
   "parameters": {
@@ -60,7 +60,7 @@
     "blobContainer": {
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2021-04-01",
-      "name": "[format('{0}/default/{1}', resourceInfo('storageAccount').name, parameters('blobContainerName'))]",
+      "name": "[format('{0}/default/{1}', parameters('storageAccountName'), parameters('blobContainerName'))]",
       "dependsOn": [
         "storageAccount"
       ]
@@ -81,7 +81,7 @@
       "properties": {
         "type": "AzureBlobStorage",
         "typeProperties": {
-          "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}', resourceInfo('storageAccount').name, listKeys(resourceInfo('storageAccount').id, '2021-04-01').keys[0].value)]"
+          "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}', parameters('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value)]"
         }
       },
       "dependsOn": [
@@ -95,14 +95,14 @@
       "name": "[format('{0}/{1}', parameters('dataFactoryName'), variables('dataFactoryDataSetInName'))]",
       "properties": {
         "linkedServiceName": {
-          "referenceName": "[resourceInfo('dataFactoryLinkedService').name]",
+          "referenceName": "[variables('dataFactoryLinkedServiceName')]",
           "type": "LinkedServiceReference"
         },
         "type": "Binary",
         "typeProperties": {
           "location": {
             "type": "AzureBlobStorageLocation",
-            "container": "[resourceInfo('blobContainer').name]",
+            "container": "[format('{0}/default/{1}', parameters('storageAccountName'), parameters('blobContainerName'))]",
             "folderPath": "input",
             "fileName": "emp.txt"
           }
@@ -120,14 +120,14 @@
       "name": "[format('{0}/{1}', parameters('dataFactoryName'), variables('dataFactoryDataSetOutName'))]",
       "properties": {
         "linkedServiceName": {
-          "referenceName": "[resourceInfo('dataFactoryLinkedService').name]",
+          "referenceName": "[variables('dataFactoryLinkedServiceName')]",
           "type": "LinkedServiceReference"
         },
         "type": "Binary",
         "typeProperties": {
           "location": {
             "type": "AzureBlobStorageLocation",
-            "container": "[resourceInfo('blobContainer').name]",
+            "container": "[format('{0}/default/{1}', parameters('storageAccountName'), parameters('blobContainerName'))]",
             "folderPath": "output"
           }
         }
@@ -172,13 +172,13 @@
             },
             "inputs": [
               {
-                "referenceName": "[resourceInfo('dataFactoryDataSetIn').name]",
+                "referenceName": "[variables('dataFactoryDataSetInName')]",
                 "type": "DatasetReference"
               }
             ],
             "outputs": [
               {
-                "referenceName": "[resourceInfo('dataFactoryDataSetOut').name]",
+                "referenceName": "[variables('dataFactoryDataSetOutName')]",
                 "type": "DatasetReference"
               }
             ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/databricks-all-in-one-template-for-vnet-injection/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/databricks-all-in-one-template-for-vnet-injection/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14724832170672496651"
+      "templateHash": "8329915391087757270"
     }
   },
   "parameters": {
@@ -215,7 +215,7 @@
             "properties": {
               "addressPrefix": "[parameters('publicSubnetCidr')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
               },
               "delegations": [
                 {
@@ -232,7 +232,7 @@
             "properties": {
               "addressPrefix": "[parameters('privateSubnetCidr')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
               },
               "delegations": [
                 {
@@ -259,10 +259,10 @@
         "name": "[parameters('pricingTier')]"
       },
       "properties": {
-        "managedResourceGroupId": "[resourceInfo('managedResourceGroup').id]",
+        "managedResourceGroupId": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('managedResourceGroupName'))]",
         "parameters": {
           "customVirtualNetworkId": {
-            "value": "[resourceInfo('vnet').id]"
+            "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
           },
           "customPublicSubnetName": {
             "value": "[parameters('publicSubnetName')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/deployment-script-with-storage/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/deployment-script-with-storage/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6918186836298612330"
+      "templateHash": "18008192003209068101"
     }
   },
   "parameters": {
@@ -65,8 +65,8 @@
       "properties": {
         "azCliVersion": "2.0.80",
         "storageAccountSettings": {
-          "storageAccountName": "[resourceInfo('stg').name]",
-          "storageAccountKey": "[listKeys(resourceInfo('stg').id, '2019-06-01').keys[0].value]"
+          "storageAccountName": "[format('dscript{0}', uniqueString(resourceGroup().id))]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', format('dscript{0}', uniqueString(resourceGroup().id))), '2019-06-01').keys[0].value]"
         },
         "scriptContent": "[parameters('scriptToExecute')]",
         "cleanupPreference": "OnSuccess",
@@ -81,7 +81,7 @@
   "outputs": {
     "scriptLogs": {
       "type": "string",
-      "value": "[reference(format('{0}/logs/default', resourceInfo('dScript').id), resourceInfo('dScript').apiVersion, 'Full').properties.log]"
+      "value": "[reference(format('{0}/logs/default', resourceId('Microsoft.Resources/deploymentScripts', 'scriptWithStorage')), '2019-10-01-preview', 'Full').properties.log]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/event-grid-servicebus-queue/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/event-grid-servicebus-queue/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9724077181442966594"
+      "templateHash": "1826317629308019292"
     }
   },
   "parameters": {
@@ -41,7 +41,7 @@
     "queue": {
       "type": "Microsoft.ServiceBus/namespaces/queues",
       "apiVersion": "2017-04-01",
-      "name": "[format('{0}/{1}', resourceInfo('serviceBusNamespace').name, parameters('serviceBusQueueName'))]",
+      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName'))]",
       "properties": {
         "lockDuration": "PT5M",
         "maxSizeInMegabytes": 1024,
@@ -74,7 +74,7 @@
         "destination": {
           "endpointType": "ServiceBusQueue",
           "properties": {
-            "resourceId": "[resourceInfo('queue').id]"
+            "resourceId": "[resourceId('Microsoft.ServiceBus/namespaces/queues', split(format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName')), '/')[0], split(format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName')), '/')[1])]"
           }
         },
         "eventDeliverySchema": "EventGridSchema",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/eventhub-namespace/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/eventhub-namespace/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3346610195081320023"
+      "templateHash": "4717942573584928573"
     }
   },
   "parameters": {
@@ -47,7 +47,7 @@
     "eventHub": {
       "type": "Microsoft.EventHub/namespaces/eventhubs",
       "apiVersion": "2017-04-01",
-      "name": "[format('{0}/{1}', resourceInfo('eventHubNamespace').name, variables('eventHubName'))]",
+      "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubName'))]",
       "properties": {
         "messageRetentionInDays": 7,
         "partitionCount": 1

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-app-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-app-create/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13601427409074496277"
+      "templateHash": "14387219169303838344"
     }
   },
   "parameters": {
@@ -142,7 +142,7 @@
             "hostType": "Standard"
           }
         ],
-        "serverFarmId": "[resourceInfo('appService').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServiceName'))]",
         "reserved": false,
         "isXenon": false,
         "hyperV": false,
@@ -150,11 +150,11 @@
           "appSettings": [
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('storageAccount').name, environment().suffixes.storage, listKeys(resourceInfo('storageAccount').id, '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('storageAccount').name, environment().suffixes.storage, listKeys(resourceInfo('storageAccount').id, '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
             },
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
@@ -271,9 +271,9 @@
     "functionAppBinding": {
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', variables('functionAppName'), format('{0}.azurewebsites.net', resourceInfo('functionApp').name))]",
+      "name": "[format('{0}/{1}', variables('functionAppName'), format('{0}.azurewebsites.net', variables('functionAppName')))]",
       "properties": {
-        "siteName": "[resourceInfo('functionApp').name]",
+        "siteName": "[variables('functionAppName')]",
         "hostNameType": "Verified"
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-http-trigger/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-http-trigger/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2340195045377583716"
+      "templateHash": "1433713818141164207"
     }
   },
   "parameters": {
@@ -92,16 +92,16 @@
       "location": "[parameters('location')]",
       "kind": "functionapp",
       "properties": {
-        "serverFarmId": "[resourceInfo('plan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "siteConfig": {
           "appSettings": [
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('storageAccount').name, environment().suffixes.storage, listKeys(resourceInfo('storageAccount').id, '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('storageAccount').name, environment().suffixes.storage, listKeys(resourceInfo('storageAccount').id, '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
             },
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
@@ -132,7 +132,7 @@
     "function": {
       "type": "Microsoft.Web/sites/functions",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', resourceInfo('functionApp').name, variables('functionNameComputed'))]",
+      "name": "[format('{0}/{1}', variables('functionAppName'), variables('functionNameComputed'))]",
       "properties": {
         "config": {
           "disabled": false,
@@ -178,9 +178,9 @@
     "keyVaultSecret": {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2018-02-14",
-      "name": "[format('{0}/{1}', resourceInfo('keyVault').name, variables('functionAppKeySecretName'))]",
+      "name": "[format('{0}/{1}', variables('keyVaultName'), variables('functionAppKeySecretName'))]",
       "properties": {
-        "value": "[listKeys(format('{0}/host/default', resourceInfo('functionApp').id), resourceInfo('functionApp').apiVersion).functionKeys.default]"
+        "value": "[listKeys(format('{0}/host/default', resourceId('Microsoft.Web/sites', variables('functionAppName'))), '2020-06-01').functionKeys.default]"
       },
       "dependsOn": [
         "functionApp",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-premium-vnet-integration/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-premium-vnet-integration/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7044785535360318019"
+      "templateHash": "17789195672823044187"
     }
   },
   "parameters": {
@@ -167,7 +167,7 @@
       "location": "[parameters('location')]",
       "kind": "functionapp",
       "properties": {
-        "serverFarmId": "[resourceInfo('serverFarm').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
         "siteConfig": {
           "appSettings": [
             {
@@ -180,11 +180,11 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix= {1};AccountKey={2}', resourceInfo('storageAccount').name, environment().suffixes.storage, listKeys(resourceInfo('storageAccount').id, '2021-04-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix= {1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2};', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceInfo('storageAccount').id, '2021-04-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2};', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value)]"
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -213,7 +213,7 @@
       "apiVersion": "2020-06-01",
       "name": "[format('{0}/{1}', variables('functionAppName'), 'virtualNetwork')]",
       "properties": {
-        "subnetResourceId": "[resourceInfo('subnet').id]",
+        "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]",
         "swiftSupported": true
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2911260488967922211"
+      "templateHash": "14621610686863918372"
     }
   },
   "parameters": {
@@ -127,7 +127,7 @@
               "name": "[replace(replace(reference('defaultStorageAccount').primaryEndpoints.blob, 'https://', ''), '/', '')]",
               "isDefault": true,
               "container": "[parameters('clusterName')]",
-              "key": "[listKeys(resourceInfo('defaultStorageAccount').id, '2021-04-01').keys[0].value]"
+              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', format('storage{0}', uniqueString(resourceGroup().id))), '2021-04-01').keys[0].value]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5558949431244959190"
+      "templateHash": "7630033728684988517"
     }
   },
   "parameters": {
@@ -68,7 +68,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7238692845072077253"
+              "templateHash": "10785713100551846074"
             }
           },
           "parameters": {
@@ -99,11 +99,11 @@
           "outputs": {
             "name": {
               "type": "string",
-              "value": "[resourceInfo('vnet').name]"
+              "value": "[format('{0}-rg', parameters('prefix'))]"
             },
             "id": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-rg', parameters('prefix')))]"
             }
           }
         }
@@ -155,7 +155,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7238692845072077253"
+              "templateHash": "10785713100551846074"
             }
           },
           "parameters": {
@@ -186,11 +186,11 @@
           "outputs": {
             "name": {
               "type": "string",
-              "value": "[resourceInfo('vnet').name]"
+              "value": "[format('{0}-rg', parameters('prefix'))]"
             },
             "id": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-rg', parameters('prefix')))]"
             }
           }
         }
@@ -227,7 +227,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11041164400216467917"
+              "templateHash": "17250409949006673883"
             }
           },
           "parameters": {
@@ -266,7 +266,7 @@
                         "id": "[format('{0}/subnets/AzureFirewallSubnet', parameters('hubId'))]"
                       },
                       "publicIPAddress": {
-                        "id": "[resourceInfo('publicIp').id]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-fwl-ip', parameters('prefix')))]"
                       }
                     }
                   }
@@ -453,7 +453,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4989043547049501784"
+              "templateHash": "7861983186134794544"
             }
           },
           "parameters": {
@@ -488,7 +488,7 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('route').id]"
+              "value": "[resourceId('Microsoft.Network/routeTables', format('{0}-rot', parameters('prefix')))]"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/modules/fwl.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/modules/fwl.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11041164400216467917"
+      "templateHash": "17250409949006673883"
     }
   },
   "parameters": {
@@ -46,7 +46,7 @@
                 "id": "[format('{0}/subnets/AzureFirewallSubnet', parameters('hubId'))]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIp').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-fwl-ip', parameters('prefix')))]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/modules/rot.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/modules/rot.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4989043547049501784"
+      "templateHash": "7861983186134794544"
     }
   },
   "parameters": {
@@ -42,7 +42,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('route').id]"
+      "value": "[resourceId('Microsoft.Network/routeTables', format('{0}-rot', parameters('prefix')))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/modules/vnet.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/modules/vnet.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7238692845072077253"
+      "templateHash": "10785713100551846074"
     }
   },
   "parameters": {
@@ -38,11 +38,11 @@
   "outputs": {
     "name": {
       "type": "string",
-      "value": "[resourceInfo('vnet').name]"
+      "value": "[format('{0}-rg', parameters('prefix'))]"
     },
     "id": {
       "type": "string",
-      "value": "[resourceInfo('vnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-rg', parameters('prefix')))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/key-vault-create/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7552979031435785171"
+      "templateHash": "3761323621114699632"
     }
   },
   "parameters": {
@@ -139,7 +139,7 @@
     "key": {
       "type": "Microsoft.KeyVault/vaults/keys",
       "apiVersion": "2019-09-01",
-      "name": "[format('{0}/{1}', resourceInfo('keyvault').name, parameters('keyName'))]",
+      "name": "[format('{0}/{1}', parameters('vaultName'), parameters('keyName'))]",
       "properties": {
         "kty": "RSA",
         "keyOps": [
@@ -155,7 +155,7 @@
     "secret": {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2018-02-14",
-      "name": "[format('{0}/{1}', resourceInfo('keyvault').name, parameters('secretName'))]",
+      "name": "[format('{0}/{1}', parameters('vaultName'), parameters('secretName'))]",
       "properties": {
         "value": "[parameters('secretValue')]"
       },

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/media-services-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/media-services-create/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14578809807727621980"
+      "templateHash": "2157902211856230734"
     }
   },
   "parameters": {
@@ -38,7 +38,7 @@
       "properties": {
         "storageAccounts": [
           {
-            "id": "[resourceInfo('storageAccount').id]",
+            "id": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
             "type": "Primary"
           }
         ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/mg-policy/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/mg-policy/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18340490257762112422"
+      "templateHash": "7102212884286788604"
     }
   },
   "parameters": {
@@ -61,7 +61,7 @@
       "name": "location-lock",
       "properties": {
         "scope": "[variables('mgScope')]",
-        "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', resourceInfo('policyDefinition').name)]"
+        "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', variables('policyDefinitionName'))]"
       },
       "dependsOn": [
         "policyDefinition"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/monitor-action-groups/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/monitor-action-groups/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15281887781461750948"
+      "templateHash": "4965299966954906799"
     }
   },
   "parameters": {
@@ -83,7 +83,7 @@
   "outputs": {
     "actionGroupId": {
       "type": "string",
-      "value": "[resourceInfo('actionGroup').id]"
+      "value": "[resourceId('microsoft.insights/actionGroups', parameters('actionGroupName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/nat-gateway-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/nat-gateway-vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11641992750217039422"
+      "templateHash": "4315925004950247409"
     }
   },
   "parameters": {
@@ -65,7 +65,7 @@
     "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]",
     "publicIpAddresses": [
       {
-        "id": "[resourceInfo('publicIp').id]"
+        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
       }
     ]
   },
@@ -120,7 +120,7 @@
             "properties": {
               "addressPrefix": "[parameters('vnetSubnetPrefix')]",
               "natGateway": {
-                "id": "[resourceInfo('natGateway').id]"
+                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
               },
               "privateEndpointNetworkPolicies": "Enabled",
               "privateLinkServiceNetworkPolicies": "Enabled",
@@ -161,7 +161,7 @@
       "properties": {
         "addressPrefix": "[parameters('vnetSubnetPrefix')]",
         "natGateway": {
-          "id": "[resourceInfo('natGateway').id]"
+          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
         },
         "privateEndpointNetworkPolicies": "Enabled",
         "privateLinkServiceNetworkPolicies": "Enabled",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/nat-gateway-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/nat-gateway-vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14067072517108432500"
+      "templateHash": "11641992750217039422"
     }
   },
   "parameters": {
@@ -62,7 +62,12 @@
     }
   },
   "variables": {
-    "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]"
+    "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]",
+    "publicIpAddresses": [
+      {
+        "id": "[resourceInfo('publicIp').id]"
+      }
+    ]
   },
   "resources": {
     "publicIp": {
@@ -92,7 +97,7 @@
       },
       "properties": {
         "idleTimeoutInMinutes": 4,
-        "publicIpAddresses": "[if(not(empty(parameters('publicIpDns'))), createArray(createObject('id', resourceInfo('publicIp').id)), null())]"
+        "publicIpAddresses": "[if(not(empty(parameters('publicIpDns'))), variables('publicIpAddresses'), null())]"
       },
       "dependsOn": [
         "publicIp"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/private-dns-zone/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/private-dns-zone/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10248908306285267520"
+      "templateHash": "13363178195081323433"
     }
   },
   "parameters": {
@@ -57,7 +57,7 @@
     "subnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', resourceInfo('virtualNetwork').name, parameters('subnetName'))]",
+      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetName'))]",
       "properties": {
         "addressPrefix": "[parameters('subnetAddressPrefix')]",
         "networkSecurityGroup": {
@@ -94,12 +94,12 @@
     "virtualNetworkLink": {
       "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
       "apiVersion": "2018-09-01",
-      "name": "[format('{0}/{1}-link', resourceInfo('privateDnsZone').name, resourceInfo('privateDnsZone').name)]",
+      "name": "[format('{0}/{1}-link', parameters('privateDnsZoneName'), parameters('privateDnsZoneName'))]",
       "location": "global",
       "properties": {
         "registrationEnabled": "[parameters('autoVmRegistration')]",
         "virtualNetwork": {
-          "id": "[resourceInfo('virtualNetwork').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/private-endpoint-webapp/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/private-endpoint-webapp/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7467027924371091930"
+      "templateHash": "3692350230291686383"
     }
   },
   "parameters": {
@@ -89,7 +89,7 @@
     "subnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', resourceInfo('virtualNetwork').name, parameters('subnetName'))]",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
       "properties": {
         "addressPrefix": "[parameters('subnetCIDR')]",
         "privateEndpointNetworkPolicies": "Disabled",
@@ -152,7 +152,7 @@
             "hostType": "Repository"
           }
         ],
-        "serverFarmId": "[resourceInfo('serverFarm').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
       },
       "dependsOn": [
         "serverFarm"
@@ -161,9 +161,9 @@
     "hostnameBinding": {
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}{2}', resourceInfo('website').name, resourceInfo('website').name, parameters('websiteDNSName'))]",
+      "name": "[format('{0}/{1}{2}', parameters('websiteName'), parameters('websiteName'), parameters('websiteDNSName'))]",
       "properties": {
-        "siteName": "[resourceInfo('website').name]",
+        "siteName": "[parameters('websiteName')]",
         "hostNameType": "Verified"
       },
       "dependsOn": [
@@ -177,13 +177,13 @@
       "location": "[parameters('location')]",
       "properties": {
         "subnet": {
-          "id": "[resourceInfo('subnet').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName')), '/')[1])]"
         },
         "privateLinkServiceConnections": [
           {
             "name": "[parameters('privateLinkConnectionName')]",
             "properties": {
-              "privateLinkServiceId": "[resourceInfo('website').id]",
+              "privateLinkServiceId": "[resourceId('Microsoft.Web/sites', parameters('websiteName'))]",
               "groupIds": [
                 "sites"
               ]
@@ -205,12 +205,12 @@
     "virtualNetworkLink": {
       "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}-link', resourceInfo('privateDNSZone').name, resourceInfo('privateDNSZone').name)]",
+      "name": "[format('{0}/{1}-link', parameters('privateDNSZoneName'), parameters('privateDNSZoneName'))]",
       "location": "global",
       "properties": {
         "registrationEnabled": false,
         "virtualNetwork": {
-          "id": "[resourceInfo('virtualNetwork').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
         }
       },
       "dependsOn": [
@@ -221,13 +221,13 @@
     "privateDNSZoneGroup": {
       "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/dnsgroupname', resourceInfo('privateEndpoint').name)]",
+      "name": "[format('{0}/dnsgroupname', parameters('privateEndpointName'))]",
       "properties": {
         "privateDnsZoneConfigs": [
           {
             "name": "config1",
             "properties": {
-              "privateDnsZoneId": "[resourceInfo('privateDNSZone').id]"
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDNSZoneName'))]"
             }
           }
         ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/sql-database/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/sql-database/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14297944808178125170"
+      "templateHash": "4195185749894704979"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     "sqlDB": {
       "type": "Microsoft.Sql/servers/databases",
       "apiVersion": "2020-08-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('server').name, parameters('sqlDBName'))]",
+      "name": "[format('{0}/{1}', parameters('serverName'), parameters('sqlDBName'))]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Standard",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/sqlmi-new-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/sqlmi-new-vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17642945083979560327"
+      "templateHash": "4043131898792973762"
     }
   },
   "parameters": {
@@ -168,10 +168,10 @@
       "properties": {
         "addressPrefix": "[parameters('subnetPrefix')]",
         "routeTable": {
-          "id": "[resourceInfo('routeTable').id]"
+          "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
         },
         "networkSecurityGroup": {
-          "id": "[resourceInfo('networkSecurityGroup').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         },
         "delegations": [
           {
@@ -201,7 +201,7 @@
       "properties": {
         "administratorLogin": "[parameters('adminLogin')]",
         "administratorLoginPassword": "[parameters('adminPassword')]",
-        "subnetId": "[resourceInfo('subnet').id]",
+        "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]",
         "storageSizeInGB": "[parameters('storageSizeInGB')]",
         "vCores": "[parameters('vCores')]",
         "licenseType": "LicenseIncluded"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/storage-blob-container/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/storage-blob-container/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17953042731019452306"
+      "templateHash": "1356105973675912490"
     }
   },
   "parameters": {
@@ -40,7 +40,7 @@
     "container": {
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2019-06-01",
-      "name": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('containerName'))]",
+      "name": "[format('{0}/default/{1}', parameters('storageAccountName'), parameters('containerName'))]",
       "dependsOn": [
         "sa"
       ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/storage-static-website/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/storage-static-website/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14565200303840693811"
+      "templateHash": "7175852432426490142"
     }
   },
   "parameters": {
@@ -83,7 +83,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceInfo('managedIdentity').id)]": {}
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'DeploymentScript'))]": {}
         }
       },
       "properties": {
@@ -103,7 +103,7 @@
   "outputs": {
     "scriptLogs": {
       "type": "string",
-      "value": "[reference(format('{0}/logs/default', resourceInfo('deploymentScript').id), resourceInfo('deploymentScript').apiVersion, 'Full').properties.log]"
+      "value": "[reference(format('{0}/logs/default', resourceId('Microsoft.Resources/deploymentScripts', 'deploymentScript')), '2020-10-01', 'Full').properties.log]"
     },
     "staticWebsiteHostName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/template-spec-deploy/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/template-spec-deploy/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12606053677028048382"
+      "templateHash": "259262868087408171"
     }
   },
   "parameters": {
@@ -50,7 +50,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "id": "[resourceInfo('ts::tsVersion').id]"
+          "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('templateSpecSub'), parameters('templateSpecRg')), 'Microsoft.Resources/templateSpecs/versions', parameters('templateSpecName'), parameters('templateSpecVersion'))]"
         },
         "parameters": {}
       }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/templatespec-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/templatespec-create/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10209337705276047407"
+      "templateHash": "13116823524345776818"
     }
   },
   "parameters": {
@@ -38,7 +38,7 @@
     "templateSpecVersion": {
       "type": "Microsoft.Resources/templateSpecs/versions",
       "apiVersion": "2019-06-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('templateSpec').name, parameters('templateSpecVersionName'))]",
+      "name": "[format('{0}/{1}', parameters('templateSpecName'), parameters('templateSpecVersionName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-linux/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-linux/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14775352266700963980"
+      "templateHash": "8232443465087908715"
     }
   },
   "parameters": {
@@ -116,17 +116,17 @@
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[resourceInfo('subnet').id]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]"
               },
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIP').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
         ],
         "networkSecurityGroup": {
-          "id": "[resourceInfo('nsg').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]"
         }
       },
       "dependsOn": [
@@ -177,7 +177,7 @@
       "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
       "properties": {
         "networkSecurityGroup": {
-          "id": "[resourceInfo('nsg').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]"
         },
         "addressPrefix": "[variables('subnetAddressPrefix')]",
         "privateEndpointNetworkPolicies": "Enabled",
@@ -231,7 +231,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-windows/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/vm-simple-windows/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10788629100956578636"
+      "templateHash": "4598761589687764547"
     }
   },
   "parameters": {
@@ -183,7 +183,7 @@
       "properties": {
         "addressPrefix": "[variables('subnetPrefix')]",
         "networkSecurityGroup": {
-          "id": "[resourceInfo('securityGroup').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
       },
       "dependsOn": [
@@ -203,10 +203,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIpName'))]"
               },
               "subnet": {
-                "id": "[resourceInfo('subnet').id]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
               }
             }
           }
@@ -255,7 +255,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/web-app-linux/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/web-app-linux/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9780637292414257005"
+      "templateHash": "8471018651931053181"
     }
   },
   "parameters": {
@@ -53,7 +53,7 @@
       "location": "[parameters('location')]",
       "kind": "app",
       "properties": {
-        "serverFarmId": "[resourceInfo('appServicePlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "siteConfig": {
           "linuxFxVersion": "[parameters('linuxFxVersion')]"
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/web-app-windows/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/web-app-windows/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12500925147872046527"
+      "templateHash": "6644050753310472315"
     }
   },
   "parameters": {
@@ -60,7 +60,7 @@
         "ProjectName": "[parameters('appName')]"
       },
       "properties": {
-        "serverFarmId": "[resourceInfo('appServicePlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "httpsOnly": true,
         "siteConfig": {
           "minTlsVersion": "1.2"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-managed-mysql/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-managed-mysql/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5842743105593093626"
+      "templateHash": "17427596913802988305"
     }
   },
   "parameters": {
@@ -138,7 +138,7 @@
       "name": "[parameters('siteName')]",
       "location": "[parameters('location')]",
       "properties": {
-        "serverFarmId": "[resourceInfo('hostingPlan').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
       },
       "dependsOn": [
         "hostingPlan"

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-privateendpoint-vnet-injection/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/webapp-privateendpoint-vnet-injection/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4483596420185342105"
+      "templateHash": "6682219580154635511"
     }
   },
   "parameters": {
@@ -245,7 +245,7 @@
       "location": "[parameters('location')]",
       "kind": "app",
       "properties": {
-        "serverFarmId": "[resourceInfo('serverFarm').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
       },
       "dependsOn": [
         "serverFarm"
@@ -258,7 +258,7 @@
       "location": "[parameters('location')]",
       "kind": "app",
       "properties": {
-        "serverFarmId": "[resourceInfo('serverFarm').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
       },
       "dependsOn": [
         "serverFarm"
@@ -301,9 +301,9 @@
     "webApp1Binding": {
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2019-08-01",
-      "name": "[format('{0}/{1}', parameters('site1_Name'), format('{0}{1}', resourceInfo('webApp1').name, variables('webapp_dns_name')))]",
+      "name": "[format('{0}/{1}', parameters('site1_Name'), format('{0}{1}', parameters('site1_Name'), variables('webapp_dns_name')))]",
       "properties": {
-        "siteName": "[resourceInfo('webApp1').name]",
+        "siteName": "[parameters('site1_Name')]",
         "hostNameType": "Verified"
       },
       "dependsOn": [
@@ -313,9 +313,9 @@
     "webApp2Binding": {
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2019-08-01",
-      "name": "[format('{0}/{1}', parameters('site2_Name'), format('{0}{1}', resourceInfo('webApp2').name, variables('webapp_dns_name')))]",
+      "name": "[format('{0}/{1}', parameters('site2_Name'), format('{0}{1}', parameters('site2_Name'), variables('webapp_dns_name')))]",
       "properties": {
-        "siteName": "[resourceInfo('webApp2').name]",
+        "siteName": "[parameters('site2_Name')]",
         "hostNameType": "Verified"
       },
       "dependsOn": [
@@ -327,7 +327,7 @@
       "apiVersion": "2020-06-01",
       "name": "[format('{0}/{1}', parameters('site2_Name'), 'virtualNetwork')]",
       "properties": {
-        "subnetResourceId": "[resourceInfo('subnet2').id]"
+        "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet2Name'))]"
       },
       "dependsOn": [
         "subnet2",
@@ -341,13 +341,13 @@
       "location": "[parameters('location')]",
       "properties": {
         "subnet": {
-          "id": "[resourceInfo('subnet1').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet1Name'))]"
         },
         "privateLinkServiceConnections": [
           {
             "name": "[parameters('privateLinkConnectionName')]",
             "properties": {
-              "privateLinkServiceId": "[resourceInfo('webApp1').id]",
+              "privateLinkServiceId": "[resourceId('Microsoft.Web/sites', parameters('site1_Name'))]",
               "groupIds": [
                 "sites"
               ]
@@ -372,12 +372,12 @@
     "privateDnsZoneLink": {
       "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
       "apiVersion": "2018-09-01",
-      "name": "[format('{0}/{1}', variables('privateDNSZoneName'), format('{0}-link', resourceInfo('privateDnsZones').name))]",
+      "name": "[format('{0}/{1}', variables('privateDNSZoneName'), format('{0}-link', variables('privateDNSZoneName')))]",
       "location": "global",
       "properties": {
         "registrationEnabled": false,
         "virtualNetwork": {
-          "id": "[resourceInfo('virtualNetwork').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
         }
       },
       "dependsOn": [
@@ -394,7 +394,7 @@
           {
             "name": "config1",
             "properties": {
-              "privateDnsZoneId": "[resourceInfo('privateDnsZones').id]"
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZoneName'))]"
             }
           }
         ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/website-with-container/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/website-with-container/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "111743328040493950"
+      "templateHash": "582567939873973528"
     }
   },
   "parameters": {
@@ -71,7 +71,7 @@
             },
             {
               "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
-              "value": "[listCredentials(resourceInfo('containerRegistry').id, '2019-05-01').passwords[0].value]"
+              "value": "[listCredentials(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('acrSubscription'), parameters('acrResourceGroup')), 'Microsoft.ContainerRegistry/registries', parameters('acrName')), '2019-05-01').passwords[0].value]"
             },
             {
               "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
@@ -80,7 +80,7 @@
           ],
           "linuxFxVersion": "[format('DOCKER|{0}.azurecr.io/{1}', parameters('acrName'), parameters('dockerImageAndTag'))]"
         },
-        "serverFarmId": "[resourceInfo('farm').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('farmName'))]"
       },
       "dependsOn": [
         "farm"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12395987166783928139"
+      "templateHash": "16362644346585816771"
     }
   },
   "parameters": {
@@ -80,7 +80,7 @@
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg2').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
               }
             }
           }
@@ -101,17 +101,17 @@
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, variables('subnet1Name'))]"
+                "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnet1Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
         ],
         "networkSecurityGroup": {
-          "id": "[resourceInfo('nsg').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
       },
       "dependsOn": [
@@ -131,7 +131,7 @@
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, variables('subnet2Name'))]"
+                "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnet2Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic"
             }
@@ -197,10 +197,10 @@
             "value": "VM-MultiNic"
           },
           "nic1Id": {
-            "value": "[resourceInfo('nic1').id]"
+            "value": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]"
           },
           "nic2Id": {
-            "value": "[resourceInfo('nic2').id]"
+            "value": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
           },
           "diagsStorageUri": {
             "value": "[reference('diagsAccount').primaryEndpoints.blob]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6805805791593525594"
+      "templateHash": "10897613961526376951"
     }
   },
   "parameters": {
@@ -83,13 +83,13 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceInfo('managedIdentity').id)]": {}
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')))]": {}
         }
       },
       "properties": {
         "forceUpdateTag": "1",
         "azPowerShellVersion": "3.0",
-        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', resourceInfo('storageAccount').name, parameters('fileShareName'), resourceGroup().name)]",
+        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', variables('storageAccountName'), parameters('fileShareName'), resourceGroup().name)]",
         "scriptContent": "param([string] $storageAccountName, [string] $fileShareName, [string] $resourceGroupName) Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName",
         "timeout": "PT5M",
         "cleanupPreference": "OnSuccess",
@@ -155,8 +155,8 @@
             "azureFile": {
               "readOnly": false,
               "shareName": "[parameters('fileShareName')]",
-              "storageAccountName": "[resourceInfo('storageAccount').name]",
-              "storageAccountKey": "[listKeys(resourceInfo('storageAccount').id, '2020-08-01-preview').keys[0].value]"
+              "storageAccountName": "[variables('storageAccountName')]",
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2020-08-01-preview').keys[0].value]"
             }
           }
         ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3656280551063454010"
+      "templateHash": "17715552190949918086"
     }
   },
   "parameters": {
@@ -43,6 +43,8 @@
     "wpShareName": "wordpress-share",
     "sqlShareName": "mysql-share",
     "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+    "roleAssignmentName": "[guid(resourceInfo('mi').name, variables('roleDefinitionId'), resourceGroup().id)]",
+    "uamiId": "[resourceId(resourceInfo('mi').type, resourceInfo('mi').name)]",
     "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wpShareName'))]",
     "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('sqlShareName'))]"
   },
@@ -56,7 +58,7 @@
     "miRoleAssign": {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceInfo('mi').name, variables('roleDefinitionId'), resourceGroup().id)]",
+      "name": "[variables('roleAssignmentName')]",
       "properties": {
         "roleDefinitionId": "[variables('roleDefinitionId')]",
         "principalId": "[reference('mi').principalId]",
@@ -88,7 +90,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceId(resourceInfo('mi').type, resourceInfo('mi').name))]": {}
+          "[format('{0}', variables('uamiId'))]": {}
         }
       },
       "properties": {
@@ -116,7 +118,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceId(resourceInfo('mi').type, resourceInfo('mi').name))]": {}
+          "[format('{0}', variables('uamiId'))]": {}
         }
       },
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17715552190949918086"
+      "templateHash": "14863520600235918217"
     }
   },
   "parameters": {
@@ -43,8 +43,8 @@
     "wpShareName": "wordpress-share",
     "sqlShareName": "mysql-share",
     "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-    "roleAssignmentName": "[guid(resourceInfo('mi').name, variables('roleDefinitionId'), resourceGroup().id)]",
-    "uamiId": "[resourceId(resourceInfo('mi').type, resourceInfo('mi').name)]",
+    "roleAssignmentName": "[guid('scratch', variables('roleDefinitionId'), resourceGroup().id)]",
+    "uamiId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'scratch')]",
     "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wpShareName'))]",
     "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('sqlShareName'))]"
   },
@@ -96,8 +96,8 @@
       "properties": {
         "azPowerShellVersion": "3.0",
         "storageAccountSettings": {
-          "storageAccountName": "[resourceInfo('stg').name]",
-          "storageAccountKey": "[listKeys(resourceInfo('stg').id, '2019-06-01').keys[0].value]"
+          "storageAccountName": "[parameters('storageAccountName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
         },
         "scriptContent": "[variables('wpScriptToExecute')]",
         "cleanupPreference": "OnSuccess",
@@ -124,8 +124,8 @@
       "properties": {
         "azPowerShellVersion": "3.0",
         "storageAccountSettings": {
-          "storageAccountName": "[resourceInfo('stg').name]",
-          "storageAccountKey": "[listKeys(resourceInfo('stg').id, '2019-06-01').keys[0].value]"
+          "storageAccountName": "[parameters('storageAccountName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
         },
         "scriptContent": "[variables('sqlScriptToExecute')]",
         "cleanupPreference": "OnSuccess",
@@ -213,16 +213,16 @@
           {
             "azureFile": {
               "shareName": "[variables('wpShareName')]",
-              "storageAccountKey": "[listKeys(resourceInfo('stg').id, '2019-06-01').keys[0].value]",
-              "storageAccountName": "[resourceInfo('stg').name]"
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]",
+              "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "wordpressfile"
           },
           {
             "azureFile": {
               "shareName": "[variables('sqlShareName')]",
-              "storageAccountKey": "[listKeys(resourceInfo('stg').id, '2019-06-01').keys[0].value]",
-              "storageAccountName": "[resourceInfo('stg').name]"
+              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]",
+              "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "mysqlfile"
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/linux-vm-as.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/linux-vm-as.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5655803872329537180"
+      "templateHash": "13291865525414548816"
     }
   },
   "parameters": {
@@ -63,7 +63,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/linux-vm-az.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/linux-vm-az.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17704202260590793698"
+      "templateHash": "6402050329765381526"
     }
   },
   "parameters": {
@@ -67,7 +67,7 @@
                 "id": "[parameters('subnetId')]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-pip', parameters('vmName')))]"
               }
             }
           }
@@ -89,7 +89,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11302662662938524665"
+      "templateHash": "14451296711637906105"
     }
   },
   "parameters": {
@@ -43,7 +43,7 @@
         "platformFaultDomainCount": 2,
         "platformUpdateDomainCount": 5,
         "proximityPlacementGroup": {
-          "id": "[resourceInfo('ppg1').id]"
+          "id": "[resourceId('Microsoft.Compute/proximityPlacementGroups', 'Zone1')]"
         }
       },
       "sku": {
@@ -76,7 +76,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2380358959994836781"
+              "templateHash": "5389517954861270855"
             }
           },
           "parameters": {
@@ -156,7 +156,7 @@
                     "properties": {
                       "addressPrefix": "10.0.0.0/24",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('nsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'demo-nsg')]"
                       }
                     }
                   }
@@ -170,7 +170,7 @@
           "outputs": {
             "vnetId": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', 'demo-vnet')]"
             }
           }
         }
@@ -190,7 +190,7 @@
             "value": "[parameters('adminSshKey')]"
           },
           "proximityPlacementGroupId": {
-            "value": "[resourceInfo('ppg1').id]"
+            "value": "[resourceId('Microsoft.Compute/proximityPlacementGroups', 'Zone1')]"
           },
           "subnetId": {
             "value": "[format('{0}/subnets/Default', reference('network').outputs.vnetId.value)]"
@@ -211,7 +211,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17704202260590793698"
+              "templateHash": "6402050329765381526"
             }
           },
           "parameters": {
@@ -271,7 +271,7 @@
                         "id": "[parameters('subnetId')]"
                       },
                       "publicIPAddress": {
-                        "id": "[resourceInfo('pip').id]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-pip', parameters('vmName')))]"
                       }
                     }
                   }
@@ -293,7 +293,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
                     }
                   ]
                 },
@@ -360,7 +360,7 @@
             "value": "[parameters('adminSshKey')]"
           },
           "availabilitySetId": {
-            "value": "[resourceInfo('as1').id]"
+            "value": "[resourceId('Microsoft.Compute/availabilitySets', 'as1')]"
           },
           "subnetId": {
             "value": "[format('{0}/subnets/Default', reference('network').outputs.vnetId.value)]"
@@ -378,7 +378,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5655803872329537180"
+              "templateHash": "13291865525414548816"
             }
           },
           "parameters": {
@@ -434,7 +434,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
                     }
                   ]
                 },
@@ -495,7 +495,7 @@
             "value": "[parameters('adminSshKey')]"
           },
           "availabilitySetId": {
-            "value": "[resourceInfo('as1').id]"
+            "value": "[resourceId('Microsoft.Compute/availabilitySets', 'as1')]"
           },
           "subnetId": {
             "value": "[format('{0}/subnets/Default', reference('network').outputs.vnetId.value)]"
@@ -513,7 +513,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5655803872329537180"
+              "templateHash": "13291865525414548816"
             }
           },
           "parameters": {
@@ -569,7 +569,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
                     }
                   ]
                 },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/network.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/network.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2380358959994836781"
+      "templateHash": "5389517954861270855"
     }
   },
   "parameters": {
@@ -87,7 +87,7 @@
             "properties": {
               "addressPrefix": "10.0.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'demo-nsg')]"
               }
             }
           }
@@ -101,7 +101,7 @@
   "outputs": {
     "vnetId": {
       "type": "string",
-      "value": "[resourceInfo('vnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', 'demo-vnet')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/api-management-create-all-resources/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/api-management-create-all-resources/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15153717715607465919"
+      "templateHash": "2341400456794030263"
     }
   },
   "parameters": {
@@ -83,7 +83,7 @@
     "policy": {
       "type": "Microsoft.ApiManagement/service/policies",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/policy', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/policy', variables('apiManagementServiceName'))]",
       "properties": {
         "value": "[parameters('tenantPolicy')]"
       },
@@ -94,7 +94,7 @@
     "petStoreApiExample": {
       "type": "Microsoft.ApiManagement/service/apis",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/PetStoreSwaggerImportExample', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/PetStoreSwaggerImportExample', variables('apiManagementServiceName'))]",
       "properties": {
         "format": "swagger-link-json",
         "value": "http://petstore.swagger.io/v2/swagger.json",
@@ -107,7 +107,7 @@
     "exampleApi": {
       "type": "Microsoft.ApiManagement/service/apis",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleApi', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleApi', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "Example API Name",
         "description": "Description for example API",
@@ -124,7 +124,7 @@
     "exampleApiOperationDelete": {
       "type": "Microsoft.ApiManagement/service/apis/operations",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleOperationsDELETE', resourceInfo('exampleApi').name)]",
+      "name": "[format('{0}/exampleOperationsDELETE', format('{0}/exampleApi', variables('apiManagementServiceName')))]",
       "properties": {
         "displayName": "DELETE resource",
         "method": "DELETE",
@@ -138,7 +138,7 @@
     "exampleApiOperationGet": {
       "type": "Microsoft.ApiManagement/service/apis/operations",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleOperationsGET', resourceInfo('exampleApi').name)]",
+      "name": "[format('{0}/exampleOperationsGET', format('{0}/exampleApi', variables('apiManagementServiceName')))]",
       "properties": {
         "displayName": "GET resource",
         "method": "GET",
@@ -152,7 +152,7 @@
     "exampleApiOperationGetPolicy": {
       "type": "Microsoft.ApiManagement/service/apis/operations/policies",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/policy', resourceInfo('exampleApiOperationGet').name)]",
+      "name": "[format('{0}/policy', format('{0}/exampleOperationsGET', format('{0}/exampleApi', variables('apiManagementServiceName'))))]",
       "properties": {
         "value": "[parameters('operationPolicy')]"
       },
@@ -163,7 +163,7 @@
     "exampleApiWithPolicy": {
       "type": "Microsoft.ApiManagement/service/apis",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleApiWithPolicy', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleApiWithPolicy', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "Example API Name with policy",
         "description": "Description for example API with policy",
@@ -180,7 +180,7 @@
     "exampleApiWithPolicyPolicy": {
       "type": "Microsoft.ApiManagement/service/apis/operations/policies",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/policy', resourceInfo('exampleApiWithPolicy').name)]",
+      "name": "[format('{0}/policy', format('{0}/exampleApiWithPolicy', variables('apiManagementServiceName')))]",
       "properties": {
         "value": "[parameters('apiPolicy')]"
       },
@@ -191,7 +191,7 @@
     "exampleProduct": {
       "type": "Microsoft.ApiManagement/service/products",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleProduct', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleProduct', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "Example Product name",
         "description": "Description for example product",
@@ -208,7 +208,7 @@
     "exampleProductApi": {
       "type": "Microsoft.ApiManagement/service/apis",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleApi', resourceInfo('exampleProduct').name)]",
+      "name": "[format('{0}/exampleApi', format('{0}/exampleProduct', variables('apiManagementServiceName')))]",
       "dependsOn": [
         "exampleProduct"
       ]
@@ -216,7 +216,7 @@
     "exampleProductPolicy": {
       "type": "Microsoft.ApiManagement/service/products/policies",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/policy', resourceInfo('exampleProduct').name)]",
+      "name": "[format('{0}/policy', format('{0}/exampleProduct', variables('apiManagementServiceName')))]",
       "properties": {
         "value": "[parameters('productPolicy')]"
       },
@@ -227,7 +227,7 @@
     "exampleUser1": {
       "type": "Microsoft.ApiManagement/service/users",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleUser1', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleUser1', variables('apiManagementServiceName'))]",
       "properties": {
         "firstName": "ExampleFirstName1",
         "lastName": "ExampleLastName1",
@@ -242,7 +242,7 @@
     "exampleUser2": {
       "type": "Microsoft.ApiManagement/service/users",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleUser2', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleUser2', variables('apiManagementServiceName'))]",
       "properties": {
         "firstName": "ExampleFirstName2",
         "lastName": "ExampleLastName2",
@@ -257,7 +257,7 @@
     "exampleUser3": {
       "type": "Microsoft.ApiManagement/service/users",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleUser1', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleUser1', variables('apiManagementServiceName'))]",
       "properties": {
         "firstName": "ExampleFirstName3",
         "lastName": "ExampleLastName3",
@@ -272,7 +272,7 @@
     "exampleProperty": {
       "type": "Microsoft.ApiManagement/service/properties",
       "apiVersion": "2019-01-01",
-      "name": "[format('{0}/exampleproperties', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleproperties', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "propertyExampleName",
         "value": "propertyExampleValue",
@@ -287,11 +287,11 @@
     "subscription1": {
       "type": "Microsoft.ApiManagement/service/subscriptions",
       "apiVersion": "2017-03-01",
-      "name": "[format('{0}/examplesubscription1', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/examplesubscription1', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "examplesubscription1",
-        "productId": "[resourceInfo('exampleProduct').id]",
-        "userId": "[resourceInfo('exampleUser1').id]"
+        "productId": "[resourceId('Microsoft.ApiManagement/service/products', split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[1])]",
+        "userId": "[resourceId('Microsoft.ApiManagement/service/users', split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[1])]"
       },
       "dependsOn": [
         "apiManagementService",
@@ -302,11 +302,11 @@
     "subscription2": {
       "type": "Microsoft.ApiManagement/service/subscriptions",
       "apiVersion": "2017-03-01",
-      "name": "[format('{0}/examplesubscription2', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/examplesubscription2', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "examplesubscription2",
-        "productId": "[resourceInfo('exampleProduct').id]",
-        "userId": "[resourceInfo('exampleUser3').id]"
+        "productId": "[resourceId('Microsoft.ApiManagement/service/products', split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleProduct', variables('apiManagementServiceName')), '/')[1])]",
+        "userId": "[resourceId('Microsoft.ApiManagement/service/users', split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[0], split(format('{0}/exampleUser1', variables('apiManagementServiceName')), '/')[1])]"
       },
       "dependsOn": [
         "apiManagementService",
@@ -317,7 +317,7 @@
     "certificate": {
       "type": "Microsoft.ApiManagement/service/certificates",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleCertificate', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleCertificate', variables('apiManagementServiceName'))]",
       "properties": {
         "data": "[parameters('mutualAuthenticationCertificate')]",
         "password": "[parameters('certificatePassword')]"
@@ -329,7 +329,7 @@
     "exampleGroup": {
       "type": "Microsoft.ApiManagement/service/groups",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleGroup', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleGroup', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "Example Group Name",
         "description": "Example group description"
@@ -341,7 +341,7 @@
     "openIdConnectProvider": {
       "type": "Microsoft.ApiManagement/service/openidConnectProviders",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleOpenIdConnectProvider', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleOpenIdConnectProvider', variables('apiManagementServiceName'))]",
       "properties": {
         "displayName": "exampleOpenIdConnectProviderName",
         "description": "Description for example OpenId Connect provider",
@@ -356,7 +356,7 @@
     "exampleLogger": {
       "type": "Microsoft.ApiManagement/service/loggers",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/exampleLogger', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/exampleLogger', variables('apiManagementServiceName'))]",
       "properties": {
         "loggerType": "azureEventHub",
         "description": "Description for example logger",
@@ -372,7 +372,7 @@
     "identityProvider": {
       "type": "Microsoft.ApiManagement/service/identityProviders",
       "apiVersion": "2020-06-01-preview",
-      "name": "[format('{0}/google', resourceInfo('apiManagementService').name)]",
+      "name": "[format('{0}/google', variables('apiManagementServiceName'))]",
       "properties": {
         "clientId": "googleClientId",
         "clientSecret": "[parameters('googleClientSecret')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/asev2-ilb-with-web-app/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/asev2-ilb-with-web-app/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8732730911566083409"
+      "templateHash": "10271837689330496137"
     }
   },
   "parameters": {
@@ -68,7 +68,7 @@
     "subnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/subnet-01', resourceInfo('virtualNetwork').name)]",
+      "name": "[format('{0}/subnet-01', 'vnet-01')]",
       "properties": {
         "addressPrefix": "10.0.1.0/24",
         "networkSecurityGroup": {
@@ -109,8 +109,8 @@
         "internalLoadBalancingMode": "[parameters('internalLoadBalancingMode')]",
         "dnsSuffix": "[parameters('dnsSuffix')]",
         "virtualNetwork": {
-          "id": "[resourceInfo('virtualNetwork').id]",
-          "subnet": "[resourceInfo('subnet').name]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-01')]",
+          "subnet": "[format('{0}/subnet-01', 'vnet-01')]"
         },
         "workerPools": []
       },
@@ -126,7 +126,7 @@
       "location": "[parameters('location')]",
       "properties": {
         "hostingEnvironmentProfile": {
-          "id": "[resourceInfo('hostingEnvironment').id]"
+          "id": "[resourceId('Microsoft.Web/hostingEnvironments', parameters('aseName'))]"
         }
       },
       "sku": {
@@ -146,9 +146,9 @@
       "name": "[parameters('websiteName')]",
       "location": "[parameters('location')]",
       "properties": {
-        "serverFarmId": "[resourceInfo('serverFarm').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
         "hostingEnvironmentProfile": {
-          "id": "[resourceInfo('hostingEnvironment').id]"
+          "id": "[resourceId('Microsoft.Web/hostingEnvironments', parameters('aseName'))]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10998119369109628373"
+      "templateHash": "15422770400368608700"
     }
   },
   "parameters": {
@@ -56,7 +56,7 @@
         "mode": "Incremental",
         "parameters": {
           "logAnalyticsWorkspaceID": {
-            "value": "[resourceInfo('avdla').id]"
+            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
           },
           "hostpoolName": {
             "value": "[parameters('hostpoolName')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8384795648239187520"
+      "templateHash": "16124052747105188444"
     }
   },
   "parameters": {
@@ -87,7 +87,7 @@
       "properties": {
         "friendlyName": "[parameters('appgroupNameFriendlyName')]",
         "applicationGroupType": "[parameters('applicationgrouptype')]",
-        "hostPoolArmPath": "[resourceInfo('hp').id]"
+        "hostPoolArmPath": "[resourceId('Microsoft.DesktopVirtualization/hostPools', parameters('hostpoolName'))]"
       },
       "dependsOn": [
         "hp"
@@ -101,7 +101,7 @@
       "properties": {
         "friendlyName": "[parameters('workspaceNameFriendlyName')]",
         "applicationGroupReferences": [
-          "[resourceInfo('ag').id]"
+          "[resourceId('Microsoft.DesktopVirtualization/applicationGroups', parameters('appgroupName'))]"
         ]
       },
       "dependsOn": [
@@ -129,10 +129,10 @@
             "value": "[parameters('logAnalyticsWorkspaceSku')]"
           },
           "hostpoolName": {
-            "value": "[resourceInfo('hp').name]"
+            "value": "[parameters('hostpoolName')]"
           },
           "workspaceName": {
-            "value": "[resourceInfo('ws').name]"
+            "value": "[parameters('workspaceName')]"
           },
           "avdBackplaneResourceGroup": {
             "value": "[parameters('avdBackplaneResourceGroup')]"
@@ -147,7 +147,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10998119369109628373"
+              "templateHash": "15422770400368608700"
             }
           },
           "parameters": {
@@ -196,7 +196,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "logAnalyticsWorkspaceID": {
-                    "value": "[resourceInfo('avdla').id]"
+                    "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
                   },
                   "hostpoolName": {
                     "value": "[parameters('hostpoolName')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17528996743340300724"
+      "templateHash": "6107639765738611258"
     }
   },
   "parameters": {
@@ -30,7 +30,7 @@
     }
   },
   "variables": {
-    "filesharelocation": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]"
+    "filesharelocation": "[format('{0}/default/{1}', parameters('storageaccountName'), parameters('fileshareFolderName'))]"
   },
   "resources": {
     "sa": {
@@ -55,7 +55,7 @@
   "outputs": {
     "storageAccountId": {
       "type": "string",
-      "value": "[resourceInfo('sa').id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageaccountName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13272301670869903501"
+      "templateHash": "17528996743340300724"
     }
   },
   "parameters": {
@@ -29,6 +29,9 @@
       "defaultValue": "profilecontainers"
     }
   },
+  "variables": {
+    "filesharelocation": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]"
+  },
   "resources": {
     "sa": {
       "type": "Microsoft.Storage/storageAccounts",
@@ -43,7 +46,7 @@
     "fs": {
       "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
       "apiVersion": "2020-08-01-preview",
-      "name": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]",
+      "name": "[variables('filesharelocation')]",
       "dependsOn": [
         "sa"
       ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-privateendpoint-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-fileservices-privateendpoint-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9001760369221735716"
+      "templateHash": "1046509696741722446"
     }
   },
   "parameters": {
@@ -46,7 +46,7 @@
           {
             "name": "config1",
             "properties": {
-              "privateDnsZoneId": "[resourceInfo('privateDNSZone').id]"
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDNSZoneName'))]"
             }
           }
         ]
@@ -59,7 +59,7 @@
     "privateDNSZone::virtualNetworkLink": {
       "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', parameters('privateDNSZoneName'), format('{0}-link', resourceInfo('privateDNSZone').name))]",
+      "name": "[format('{0}/{1}', parameters('privateDNSZoneName'), format('{0}-link', parameters('privateDNSZoneName')))]",
       "location": "global",
       "properties": {
         "registrationEnabled": false,

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3591148648264486228"
+      "templateHash": "4602590212295487082"
     }
   },
   "parameters": {
@@ -72,7 +72,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceInfo('managedidentity').id)]": {}
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]": {}
         }
       },
       "properties": {
@@ -130,9 +130,9 @@
       "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceGroup().id, resourceInfo('aibdef').id, resourceInfo('managedidentity').id)]",
+      "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
       "properties": {
-        "roleDefinitionId": "[resourceInfo('aibdef').id]",
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom')))]",
         "principalId": "[reference('managedidentity').principalId]",
         "principalType": "ServicePrincipal"
       },
@@ -144,7 +144,7 @@
       "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', resourceInfo('managedidentity').id)]",
+      "name": "[guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
       "properties": {
         "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
         "principalId": "[reference('managedidentity').principalId]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-network-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-network-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18364266643358370653"
+      "templateHash": "8377334280691214017"
     }
   },
   "parameters": {
@@ -80,7 +80,7 @@
     },
     "vnetId": {
       "type": "string",
-      "value": "[resourceInfo('vnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-sig-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-sig-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3313400328646416300"
+      "templateHash": "1270528138025457372"
     }
   },
   "parameters": {
@@ -80,9 +80,9 @@
     "galleryassignment": {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceGroup().id, resourceInfo('gallerydef').id, resourceInfo('managedidentity').id)]",
+      "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
       "properties": {
-        "roleDefinitionId": "[resourceInfo('gallerydef').id]",
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
         "principalId": "[reference('managedidentity').principalId]",
         "principalType": "ServicePrincipal"
       },
@@ -94,7 +94,7 @@
     "avdid": {
       "type": "Microsoft.Compute/galleries/images",
       "apiVersion": "2019-07-01",
-      "name": "[format('{0}/{1}', resourceInfo('avdsig').name, parameters('imageDefinitionName'))]",
+      "name": "[format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName'))]",
       "location": "[parameters('sigLocation')]",
       "properties": {
         "osType": "Windows",
@@ -129,7 +129,7 @@
     },
     "avdidoutput": {
       "type": "string",
-      "value": "[resourceInfo('avdid').id]"
+      "value": "[resourceId('Microsoft.Compute/galleries/images', split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[0], split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[1])]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10210124824570567716"
+      "templateHash": "13839869369417737571"
     }
   },
   "parameters": {
@@ -698,7 +698,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13272301670869903501"
+              "templateHash": "17528996743340300724"
             }
           },
           "parameters": {
@@ -720,6 +720,9 @@
               "defaultValue": "profilecontainers"
             }
           },
+          "variables": {
+            "filesharelocation": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]"
+          },
           "resources": {
             "sa": {
               "type": "Microsoft.Storage/storageAccounts",
@@ -734,7 +737,7 @@
             "fs": {
               "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
               "apiVersion": "2020-08-01-preview",
-              "name": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]",
+              "name": "[variables('filesharelocation')]",
               "dependsOn": [
                 "sa"
               ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13839869369417737571"
+      "templateHash": "12119456684933518376"
     }
   },
   "parameters": {
@@ -214,10 +214,10 @@
             "value": "[parameters('logAnalyticslocation')]"
           },
           "logAnalyticsResourceGroup": {
-            "value": "[resourceInfo('rdmon').name]"
+            "value": "[format('{0}MONITOR', parameters('resourceGroupPrefrix'))]"
           },
           "avdBackplaneResourceGroup": {
-            "value": "[resourceInfo('rgavd').name]"
+            "value": "[format('{0}BACKPLANE', parameters('resourceGroupPrefrix'))]"
           }
         },
         "template": {
@@ -229,7 +229,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8384795648239187520"
+              "templateHash": "16124052747105188444"
             }
           },
           "parameters": {
@@ -309,7 +309,7 @@
               "properties": {
                 "friendlyName": "[parameters('appgroupNameFriendlyName')]",
                 "applicationGroupType": "[parameters('applicationgrouptype')]",
-                "hostPoolArmPath": "[resourceInfo('hp').id]"
+                "hostPoolArmPath": "[resourceId('Microsoft.DesktopVirtualization/hostPools', parameters('hostpoolName'))]"
               },
               "dependsOn": [
                 "hp"
@@ -323,7 +323,7 @@
               "properties": {
                 "friendlyName": "[parameters('workspaceNameFriendlyName')]",
                 "applicationGroupReferences": [
-                  "[resourceInfo('ag').id]"
+                  "[resourceId('Microsoft.DesktopVirtualization/applicationGroups', parameters('appgroupName'))]"
                 ]
               },
               "dependsOn": [
@@ -351,10 +351,10 @@
                     "value": "[parameters('logAnalyticsWorkspaceSku')]"
                   },
                   "hostpoolName": {
-                    "value": "[resourceInfo('hp').name]"
+                    "value": "[parameters('hostpoolName')]"
                   },
                   "workspaceName": {
-                    "value": "[resourceInfo('ws').name]"
+                    "value": "[parameters('workspaceName')]"
                   },
                   "avdBackplaneResourceGroup": {
                     "value": "[parameters('avdBackplaneResourceGroup')]"
@@ -369,7 +369,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10998119369109628373"
+                      "templateHash": "15422770400368608700"
                     }
                   },
                   "parameters": {
@@ -418,7 +418,7 @@
                         "mode": "Incremental",
                         "parameters": {
                           "logAnalyticsWorkspaceID": {
-                            "value": "[resourceInfo('avdla').id]"
+                            "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
                           },
                           "hostpoolName": {
                             "value": "[parameters('hostpoolName')]"
@@ -580,7 +580,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18364266643358370653"
+              "templateHash": "8377334280691214017"
             }
           },
           "parameters": {
@@ -653,7 +653,7 @@
             },
             "vnetId": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
             }
           }
         }
@@ -698,7 +698,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17528996743340300724"
+              "templateHash": "6107639765738611258"
             }
           },
           "parameters": {
@@ -721,7 +721,7 @@
             }
           },
           "variables": {
-            "filesharelocation": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('fileshareFolderName'))]"
+            "filesharelocation": "[format('{0}/default/{1}', parameters('storageaccountName'), parameters('fileshareFolderName'))]"
           },
           "resources": {
             "sa": {
@@ -746,7 +746,7 @@
           "outputs": {
             "storageAccountId": {
               "type": "string",
-              "value": "[resourceInfo('sa').id]"
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageaccountName'))]"
             }
           }
         }
@@ -791,7 +791,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9001760369221735716"
+              "templateHash": "1046509696741722446"
             }
           },
           "parameters": {
@@ -830,7 +830,7 @@
                   {
                     "name": "config1",
                     "properties": {
-                      "privateDnsZoneId": "[resourceInfo('privateDNSZone').id]"
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDNSZoneName'))]"
                     }
                   }
                 ]
@@ -843,7 +843,7 @@
             "privateDNSZone::virtualNetworkLink": {
               "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/{1}', parameters('privateDNSZoneName'), format('{0}-link', resourceInfo('privateDNSZone').name))]",
+              "name": "[format('{0}/{1}', parameters('privateDNSZoneName'), format('{0}-link', parameters('privateDNSZoneName')))]",
               "location": "global",
               "properties": {
                 "registrationEnabled": false,
@@ -937,7 +937,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3313400328646416300"
+              "templateHash": "1270528138025457372"
             }
           },
           "parameters": {
@@ -1010,9 +1010,9 @@
             "galleryassignment": {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
-              "name": "[guid(resourceGroup().id, resourceInfo('gallerydef').id, resourceInfo('managedidentity').id)]",
+              "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
               "properties": {
-                "roleDefinitionId": "[resourceInfo('gallerydef').id]",
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
                 "principalId": "[reference('managedidentity').principalId]",
                 "principalType": "ServicePrincipal"
               },
@@ -1024,7 +1024,7 @@
             "avdid": {
               "type": "Microsoft.Compute/galleries/images",
               "apiVersion": "2019-07-01",
-              "name": "[format('{0}/{1}', resourceInfo('avdsig').name, parameters('imageDefinitionName'))]",
+              "name": "[format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName'))]",
               "location": "[parameters('sigLocation')]",
               "properties": {
                 "osType": "Windows",
@@ -1059,7 +1059,7 @@
             },
             "avdidoutput": {
               "type": "string",
-              "value": "[resourceInfo('avdid').id]"
+              "value": "[resourceId('Microsoft.Compute/galleries/images', split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[0], split(format('{0}/{1}', parameters('sigName'), parameters('imageDefinitionName')), '/')[1])]"
             }
           }
         }
@@ -1110,7 +1110,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3591148648264486228"
+              "templateHash": "4602590212295487082"
             }
           },
           "parameters": {
@@ -1175,7 +1175,7 @@
               "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
-                  "[format('{0}', resourceInfo('managedidentity').id)]": {}
+                  "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]": {}
                 }
               },
               "properties": {
@@ -1233,9 +1233,9 @@
               "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
-              "name": "[guid(resourceGroup().id, resourceInfo('aibdef').id, resourceInfo('managedidentity').id)]",
+              "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom'))), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
               "properties": {
-                "roleDefinitionId": "[resourceInfo('aibdef').id]",
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameAIBCustom')))]",
                 "principalId": "[reference('managedidentity').principalId]",
                 "principalType": "ServicePrincipal"
               },
@@ -1247,7 +1247,7 @@
               "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
-              "name": "[guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', resourceInfo('managedidentity').id)]",
+              "name": "[guid(resourceGroup().id, '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('uamiName')))]",
               "properties": {
                 "roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
                 "principalId": "[reference('managedidentity').principalId]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cloud-shell-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cloud-shell-vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12525153509184672892"
+      "templateHash": "9976420533644316974"
     }
   },
   "parameters": {
@@ -156,7 +156,7 @@
                   "name": "[format('ipconfig-{0}', parameters('containerSubnetName'))]",
                   "properties": {
                     "subnet": {
-                      "id": "[resourceInfo('containerSubnet').id]"
+                      "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
                     }
                   }
                 }
@@ -173,7 +173,7 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
       "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
-      "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), resourceInfo('networkProfile').name)]",
+      "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
       "properties": {
         "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
         "principalId": "[parameters('azureContainerInstanceOID')]"
@@ -196,7 +196,7 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
       "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
-      "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), resourceInfo('relayNamespace').name)]",
+      "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
       "properties": {
         "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
         "principalId": "[parameters('azureContainerInstanceOID')]"
@@ -248,7 +248,7 @@
           {
             "name": "[parameters('privateEndpointName')]",
             "properties": {
-              "privateLinkServiceId": "[resourceInfo('relayNamespace').id]",
+              "privateLinkServiceId": "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
               "groupIds": [
                 "namespace"
               ]
@@ -256,7 +256,7 @@
           }
         ],
         "subnet": {
-          "id": "[resourceInfo('relaySubnet').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
         }
       },
       "dependsOn": [
@@ -349,11 +349,11 @@
     },
     "containerSubnetId": {
       "type": "string",
-      "value": "[resourceInfo('containerSubnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
     },
     "storageSubnetId": {
       "type": "string",
-      "value": "[resourceInfo('storageSubnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('storageSubnetName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/create-and-enable-ddos-protection-plans/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/create-and-enable-ddos-protection-plans/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13690952565402473036"
+      "templateHash": "8952424211803755990"
     }
   },
   "parameters": {
@@ -100,7 +100,7 @@
         ],
         "enableDdosProtection": "[parameters('ddosProtectionPlanEnabled')]",
         "ddosProtectionPlan": {
-          "id": "[resourceInfo('ddosProtectionPlan').id]"
+          "id": "[resourceId('Microsoft.Network/ddosProtectionPlans', parameters('ddosProtectionPlanName'))]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/cycleserver-vm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/cycleserver-vm.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17171045321904482363"
+      "templateHash": "4407761357378700867"
     }
   },
   "parameters": {
@@ -54,7 +54,7 @@
                 "id": "[parameters('subnetId')]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'cycleserver-pip')]"
               }
             }
           }
@@ -113,7 +113,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', 'cycleserver-nic')]"
             }
           ]
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7243411679537912996"
+      "templateHash": "12223948172566163865"
     }
   },
   "parameters": {
@@ -89,7 +89,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6407609062989221858"
+              "templateHash": "10459572222586925774"
             }
           },
           "parameters": {
@@ -169,7 +169,7 @@
                     "properties": {
                       "addressPrefix": "10.0.0.0/24",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('nsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'cc-nsg')]"
                       }
                     }
                   }
@@ -183,7 +183,7 @@
           "outputs": {
             "vnetId": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', 'cc-vnet')]"
             }
           }
         }
@@ -209,7 +209,7 @@
             "value": "[format('{0}/subnets/Default', reference('network').outputs.vnetId.value)]"
           },
           "userAssignedIdentity": {
-            "value": "[resourceInfo('mid').id]"
+            "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'CycleCloud-MI')]"
           }
         },
         "template": {
@@ -221,7 +221,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17171045321904482363"
+              "templateHash": "4407761357378700867"
             }
           },
           "parameters": {
@@ -268,7 +268,7 @@
                         "id": "[parameters('subnetId')]"
                       },
                       "publicIPAddress": {
-                        "id": "[resourceInfo('pip').id]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'cycleserver-pip')]"
                       }
                     }
                   }
@@ -327,7 +327,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', 'cycleserver-nic')]"
                     }
                   ]
                 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/network.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/network.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6407609062989221858"
+      "templateHash": "10459572222586925774"
     }
   },
   "parameters": {
@@ -87,7 +87,7 @@
             "properties": {
               "addressPrefix": "10.0.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'cc-nsg')]"
               }
             }
           }
@@ -101,7 +101,7 @@
   "outputs": {
     "vnetId": {
       "type": "string",
-      "value": "[resourceInfo('vnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', 'cc-vnet')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/event-hub-and-consumer-group/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/event-hub-and-consumer-group/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9051700267425549919"
+      "templateHash": "12588869209004628304"
     }
   },
   "parameters": {
@@ -58,7 +58,7 @@
     "eventHub": {
       "type": "Microsoft.EventHub/namespaces/eventhubs",
       "apiVersion": "2017-04-01",
-      "name": "[format('{0}/{1}', resourceInfo('namespace').name, parameters('eventHubName'))]",
+      "name": "[format('{0}/{1}', parameters('namespaceName'), parameters('eventHubName'))]",
       "properties": {},
       "dependsOn": [
         "namespace"
@@ -67,7 +67,7 @@
     "consumerGroup": {
       "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
       "apiVersion": "2017-04-01",
-      "name": "[format('{0}/{1}', resourceInfo('eventHub').name, parameters('consumerGroupName'))]",
+      "name": "[format('{0}/{1}', format('{0}/{1}', parameters('namespaceName'), parameters('eventHubName')), parameters('consumerGroupName'))]",
       "properties": {},
       "dependsOn": [
         "eventHub"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/firewall-with-ip-from-prefix/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/firewall-with-ip-from-prefix/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11690547563059134845"
+      "templateHash": "5151308088929181120"
     }
   },
   "parameters": {
@@ -105,7 +105,7 @@
       "properties": {
         "publicIPAllocationMethod": "Static",
         "publicIPPrefix": {
-          "id": "[resourceInfo('ipprefix').id]"
+          "id": "[resourceId('Microsoft.Network/publicIPPrefixes', variables('ipprefixname'))]"
         }
       },
       "dependsOn": [
@@ -124,10 +124,10 @@
             "name": "[format('{0}-vnetIpconf', variables('firewallname'))]",
             "properties": {
               "subnet": {
-                "id": "[format('{0}/subnets/AzureFirewallSubnet', resourceInfo('vnet').id)]"
+                "id": "[format('{0}/subnets/AzureFirewallSubnet', resourceId('Microsoft.Network/virtualNetworks', parameters('vnetname')))]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('publicip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/front-door-with-webapplication-firewall/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/front-door-with-webapplication-firewall/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1361546421070471110"
+      "templateHash": "18279504101555742258"
     }
   },
   "parameters": {
@@ -74,7 +74,7 @@
               "sessionAffinityEnabledState": "Disabled",
               "sessionAffinityTtlSeconds": 0,
               "webApplicationFirewallPolicyLink": {
-                "id": "[format('{0}', resourceInfo('resAzFdWaf').id)]"
+                "id": "[format('{0}', resourceId('Microsoft.Network/FrontDoorWebApplicationFirewallPolicies', variables('frontDoorWafName')))]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/iot-with-storage/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/iot-with-storage/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14338456154460389407"
+      "templateHash": "11805185149956814134"
     }
   },
   "parameters": {
@@ -55,7 +55,7 @@
     "blob": {
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2019-06-01",
-      "name": "[format('{0}/default/{1}', resourceInfo('stg').name, variables('storageContainerName'))]",
+      "name": "[format('{0}/default/{1}', variables('storageAccountName'), variables('storageContainerName'))]",
       "properties": {
         "publicAccess": "None"
       },
@@ -83,7 +83,7 @@
           "endpoints": {
             "storageContainers": [
               {
-                "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceInfo('stg').id, '2019-06-01').keys[0].value)]",
+                "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]",
                 "containerName": "[variables('storageContainerName')]",
                 "fileNameFormat": "{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}",
                 "batchFrequencyInSeconds": 100,

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/log-analytics-with-solutions-and-diagnostics/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/log-analytics-with-solutions-and-diagnostics/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3357074096310745217"
+      "templateHash": "18241112768914262406"
     }
   },
   "parameters": {
@@ -58,7 +58,7 @@
       "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('logAnalyticsWorkspaceName'))]",
       "name": "diagnosticSettings",
       "properties": {
-        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+        "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]",
         "logs": [
           {
             "category": "Audit",
@@ -90,7 +90,7 @@
       "name": "[variables('vmInsights').name]",
       "location": "[parameters('location')]",
       "properties": {
-        "workspaceResourceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
       },
       "plan": {
         "name": "[variables('vmInsights').name]",
@@ -108,7 +108,7 @@
       "name": "[variables('containerInsights').name]",
       "location": "[parameters('location')]",
       "properties": {
-        "workspaceResourceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
       },
       "plan": {
         "name": "[variables('containerInsights').name]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2493248739247190913"
+      "templateHash": "5989534997423292376"
     }
   },
   "parameters": {
@@ -47,7 +47,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11614669036025593162"
+              "templateHash": "10028704102689692286"
             }
           },
           "parameters": {
@@ -369,7 +369,7 @@
                 "parameters": {},
                 "policyDefinitions": [
                   {
-                    "policyDefinitionId": "[resourceInfo('deployAzureMonitorAgentWindowsDCR').id]",
+                    "policyDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/policyDefinitions', 'deployAzureMonitorAgentWindowsDCR')]",
                     "parameters": {}
                   }
                 ]
@@ -382,7 +382,7 @@
           "outputs": {
             "monitoringGovernanceId": {
               "type": "string",
-              "value": "[resourceInfo('monitoringGovernance').id]"
+              "value": "[subscriptionResourceId('Microsoft.Authorization/policySetDefinitions', 'monitoringGovernance')]"
             }
           }
         }
@@ -418,7 +418,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10115694628080181563"
+              "templateHash": "17856974315146222949"
             }
           },
           "parameters": {
@@ -460,7 +460,7 @@
             "roleAssignment": {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
-              "name": "[guid(resourceInfo('monitoringGovernanceAssignment').name, resourceInfo('monitoringGovernanceAssignment').type, subscription().subscriptionId)]",
+              "name": "[guid('monitoringGovernance', 'Microsoft.Authorization/policyAssignments', subscription().subscriptionId)]",
               "properties": {
                 "principalId": "[reference('monitoringGovernanceAssignment', '2020-09-01', 'full').identity.principalId]",
                 "roleDefinitionId": "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/policyAssignment.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/policyAssignment.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10115694628080181563"
+      "templateHash": "17856974315146222949"
     }
   },
   "parameters": {
@@ -49,7 +49,7 @@
     "roleAssignment": {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceInfo('monitoringGovernanceAssignment').name, resourceInfo('monitoringGovernanceAssignment').type, subscription().subscriptionId)]",
+      "name": "[guid('monitoringGovernance', 'Microsoft.Authorization/policyAssignments', subscription().subscriptionId)]",
       "properties": {
         "principalId": "[reference('monitoringGovernanceAssignment', '2020-09-01', 'full').identity.principalId]",
         "roleDefinitionId": "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/policyDefinition.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/policyDefinition.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11614669036025593162"
+      "templateHash": "10028704102689692286"
     }
   },
   "parameters": {
@@ -329,7 +329,7 @@
         "parameters": {},
         "policyDefinitions": [
           {
-            "policyDefinitionId": "[resourceInfo('deployAzureMonitorAgentWindowsDCR').id]",
+            "policyDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/policyDefinitions', 'deployAzureMonitorAgentWindowsDCR')]",
             "parameters": {}
           }
         ]
@@ -342,7 +342,7 @@
   "outputs": {
     "monitoringGovernanceId": {
       "type": "string",
-      "value": "[resourceInfo('monitoringGovernance').id]"
+      "value": "[subscriptionResourceId('Microsoft.Authorization/policySetDefinitions', 'monitoringGovernance')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-definition-with-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-definition-with-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9452753629208196690"
+      "templateHash": "9248020643429221846"
     }
   },
   "parameters": {
@@ -74,7 +74,7 @@
       "apiVersion": "2020-09-01",
       "name": "Resource-location-restriction",
       "properties": {
-        "policyDefinitionId": "[resourceInfo('locationPolicyDefinition').id]",
+        "policyDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/policyDefinitions', 'custom-allowed-location')]",
         "displayName": "Restrict location for Azure resources",
         "description": "Policy will either Audit or Deny resources being deployed in other locations",
         "parameters": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-with-initiative-definition-and-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-with-initiative-definition-and-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5423294562473628901"
+      "templateHash": "1412638833729620817"
     }
   },
   "parameters": {
@@ -107,7 +107,7 @@
       "properties": {
         "scope": "[subscription().id]",
         "enforcementMode": "Default",
-        "policyDefinitionId": "[resourceInfo('initiativeDefinition').id]",
+        "policyDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/policySetDefinitions', variables('initiativeDefinitionName'))]",
         "parameters": {
           "listOfAllowedLocations": {
             "value": "[parameters('listOfAllowedLocations')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/portal-dashboard-with-appinsights/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/portal-dashboard-with-appinsights/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "601069753694913082"
+      "templateHash": "8479115218615516519"
     }
   },
   "parameters": {
@@ -57,7 +57,7 @@
                       "name": "Scope",
                       "value": {
                         "resourceIds": [
-                          "[resourceInfo('appinsights').id]"
+                          "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
                         ]
                       }
                     },
@@ -132,7 +132,7 @@
                       "name": "Scope",
                       "value": {
                         "resourceIds": [
-                          "[resourceInfo('appinsights').id]"
+                          "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
                         ]
                       }
                     },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/aks.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/aks.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12908939607230391049"
+      "templateHash": "1042632168174174653"
     }
   },
   "parameters": {
@@ -360,7 +360,7 @@
             "count": "[parameters('nodePoolCount')]",
             "vmSize": "[parameters('nodePoolVmSize')]",
             "osDiskSizeGB": "[parameters('nodePoolOsDiskSizeGB')]",
-            "vnetSubnetID": "[resourceInfo('aksSubnet').id]",
+            "vnetSubnetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), parameters('aksSubnetName'))]",
             "maxPods": "[parameters('nodePoolMaxPods')]",
             "osType": "[parameters('nodePoolOsType')]",
             "maxCount": "[parameters('nodePoolMaxCount')]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/bastion.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/bastion.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8781863150970461215"
+      "templateHash": "15474133821211749567"
     }
   },
   "parameters": {
@@ -61,7 +61,7 @@
                 "id": "[parameters('bastionSubnetId')]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('bastionPublicIpAddress').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10482767500499069638"
+      "templateHash": "9527868671209848226"
     }
   },
   "parameters": {
@@ -143,7 +143,7 @@
   },
   "variables": {
     "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
-    "vmNicId": "[resourceInfo('vmNic').id]",
+    "vmNicId": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]",
     "blobPublicDNSZoneForwarder": "[format('.blob.{0}', environment().suffixes.storage)]",
     "blobPrivateDnsZoneName": "[format('privatelink{0}', variables('blobPublicDNSZoneForwarder'))]",
     "blobStorageAccountPrivateEndpointGroupName": "blob",
@@ -250,7 +250,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('vmNic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]"
             }
           ]
         },
@@ -280,7 +280,7 @@
           "stopOnMultipleConnections": false
         },
         "protectedSettings": {
-          "workspaceKey": "[listKeys(resourceInfo('logAnalyticsWorkspace').id, '2020-10-01').primarySharedKey]"
+          "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2020-10-01').primarySharedKey]"
         }
       },
       "dependsOn": [
@@ -333,7 +333,7 @@
           {
             "name": "[parameters('blobStorageAccountPrivateEndpointName')]",
             "properties": {
-              "privateLinkServiceId": "[resourceInfo('blobStorageAccount').id]",
+              "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))]",
               "groupIds": [
                 "[variables('blobStorageAccountPrivateEndpointGroupName')]"
               ]
@@ -362,7 +362,7 @@
           {
             "name": "dnsConfig",
             "properties": {
-              "privateDnsZoneId": "[resourceInfo('blobPrivateDnsZone').id]"
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('blobPrivateDnsZoneName'))]"
             }
           }
         ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11288953077036289210"
+      "templateHash": "10482767500499069638"
     }
   },
   "parameters": {
@@ -143,6 +143,7 @@
   },
   "variables": {
     "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
+    "vmNicId": "[resourceInfo('vmNic').id]",
     "blobPublicDNSZoneForwarder": "[format('.blob.{0}', environment().suffixes.storage)]",
     "blobPrivateDnsZoneName": "[format('privatelink{0}', variables('blobPublicDNSZoneForwarder'))]",
     "blobStorageAccountPrivateEndpointGroupName": "blob",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/log-analytics.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/log-analytics.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13505260839993690492"
+      "templateHash": "10909310188500531954"
     }
   },
   "parameters": {
@@ -62,7 +62,7 @@
   "outputs": {
     "logAnalyticsWorkspaceId": {
       "type": "string",
-      "value": "[resourceInfo('logAnalyticsWorkspace').id]"
+      "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12231022264051282998"
+      "templateHash": "16423430419775360557"
     }
   },
   "parameters": {
@@ -528,7 +528,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13883503950548406884"
+              "templateHash": "14960226424976816995"
             }
           },
           "parameters": {
@@ -591,7 +591,10 @@
           "variables": {
             "bastionSubnetName": "AzureBastionSubnet",
             "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
-            "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]"
+            "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, variables('bastionSubnetName'))]",
+            "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]",
+            "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('vmSubnetName'))]",
+            "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('aksSubnetName'))]"
           },
           "resources": {
             "vmSubnetNsg": {
@@ -1112,7 +1115,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11288953077036289210"
+              "templateHash": "10482767500499069638"
             }
           },
           "parameters": {
@@ -1248,6 +1251,7 @@
           },
           "variables": {
             "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
+            "vmNicId": "[resourceInfo('vmNic').id]",
             "blobPublicDNSZoneForwarder": "[format('.blob.{0}', environment().suffixes.storage)]",
             "blobPrivateDnsZoneName": "[format('privatelink{0}', variables('blobPublicDNSZoneForwarder'))]",
             "blobStorageAccountPrivateEndpointGroupName": "blob",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16423430419775360557"
+      "templateHash": "18356467795016096840"
     }
   },
   "parameters": {
@@ -528,7 +528,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14960226424976816995"
+              "templateHash": "13071021001108748467"
             }
           },
           "parameters": {
@@ -591,10 +591,10 @@
           "variables": {
             "bastionSubnetName": "AzureBastionSubnet",
             "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
-            "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, variables('bastionSubnetName'))]",
+            "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('bastionSubnetName'))]",
             "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]",
-            "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('vmSubnetName'))]",
-            "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('aksSubnetName'))]"
+            "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('vmSubnetName'))]",
+            "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('aksSubnetName'))]"
           },
           "resources": {
             "vmSubnetNsg": {
@@ -775,7 +775,7 @@
                     "properties": {
                       "addressPrefix": "[parameters('vmSubnetAddressPrefix')]",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('vmSubnetNsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmSubnetNsgName'))]"
                       },
                       "privateEndpointNetworkPolicies": "Disabled",
                       "privateLinkServiceNetworkPolicies": "Enabled"
@@ -786,7 +786,7 @@
                     "properties": {
                       "addressPrefix": "[parameters('bastionSubnetAddressPrefix')]",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('bastionSubnetNsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionSubnetNsgName'))]"
                       }
                     }
                   }
@@ -830,19 +830,19 @@
           "outputs": {
             "virtualNetworkResourceId": {
               "type": "string",
-              "value": "[resourceInfo('virtualNetwork').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
             },
             "bastionSubnetId": {
               "type": "string",
-              "value": "[resourceInfo('bastionSubnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('bastionSubnetName'))]"
             },
             "aksSubnetId": {
               "type": "string",
-              "value": "[resourceInfo('aksSubnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('aksSubnetName'))]"
             },
             "vmSubnetId": {
               "type": "string",
-              "value": "[resourceInfo('vmSubnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('vmSubnetName'))]"
             }
           }
         }
@@ -877,7 +877,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8781863150970461215"
+              "templateHash": "15474133821211749567"
             }
           },
           "parameters": {
@@ -931,7 +931,7 @@
                         "id": "[parameters('bastionSubnetId')]"
                       },
                       "publicIPAddress": {
-                        "id": "[resourceInfo('bastionPublicIpAddress').id]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]"
                       }
                     }
                   }
@@ -980,7 +980,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "13505260839993690492"
+              "templateHash": "10909310188500531954"
             }
           },
           "parameters": {
@@ -1035,7 +1035,7 @@
           "outputs": {
             "logAnalyticsWorkspaceId": {
               "type": "string",
-              "value": "[resourceInfo('logAnalyticsWorkspace').id]"
+              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
             }
           }
         }
@@ -1115,7 +1115,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10482767500499069638"
+              "templateHash": "9527868671209848226"
             }
           },
           "parameters": {
@@ -1251,7 +1251,7 @@
           },
           "variables": {
             "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
-            "vmNicId": "[resourceInfo('vmNic').id]",
+            "vmNicId": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]",
             "blobPublicDNSZoneForwarder": "[format('.blob.{0}', environment().suffixes.storage)]",
             "blobPrivateDnsZoneName": "[format('privatelink{0}', variables('blobPublicDNSZoneForwarder'))]",
             "blobStorageAccountPrivateEndpointGroupName": "blob",
@@ -1358,7 +1358,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('vmNic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]"
                     }
                   ]
                 },
@@ -1388,7 +1388,7 @@
                   "stopOnMultipleConnections": false
                 },
                 "protectedSettings": {
-                  "workspaceKey": "[listKeys(resourceInfo('logAnalyticsWorkspace').id, '2020-10-01').primarySharedKey]"
+                  "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2020-10-01').primarySharedKey]"
                 }
               },
               "dependsOn": [
@@ -1441,7 +1441,7 @@
                   {
                     "name": "[parameters('blobStorageAccountPrivateEndpointName')]",
                     "properties": {
-                      "privateLinkServiceId": "[resourceInfo('blobStorageAccount').id]",
+                      "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))]",
                       "groupIds": [
                         "[variables('blobStorageAccountPrivateEndpointGroupName')]"
                       ]
@@ -1470,7 +1470,7 @@
                   {
                     "name": "dnsConfig",
                     "properties": {
-                      "privateDnsZoneId": "[resourceInfo('blobPrivateDnsZone').id]"
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('blobPrivateDnsZoneName'))]"
                     }
                   }
                 ]
@@ -1625,7 +1625,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12908939607230391049"
+              "templateHash": "1042632168174174653"
             }
           },
           "parameters": {
@@ -1978,7 +1978,7 @@
                     "count": "[parameters('nodePoolCount')]",
                     "vmSize": "[parameters('nodePoolVmSize')]",
                     "osDiskSizeGB": "[parameters('nodePoolOsDiskSizeGB')]",
-                    "vnetSubnetID": "[resourceInfo('aksSubnet').id]",
+                    "vnetSubnetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), parameters('aksSubnetName'))]",
                     "maxPods": "[parameters('nodePoolMaxPods')]",
                     "osType": "[parameters('nodePoolOsType')]",
                     "maxCount": "[parameters('nodePoolMaxCount')]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/vnet.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/vnet.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14960226424976816995"
+      "templateHash": "13071021001108748467"
     }
   },
   "parameters": {
@@ -70,10 +70,10 @@
   "variables": {
     "bastionSubnetName": "AzureBastionSubnet",
     "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
-    "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, variables('bastionSubnetName'))]",
+    "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('bastionSubnetName'))]",
     "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]",
-    "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('vmSubnetName'))]",
-    "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('aksSubnetName'))]"
+    "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('vmSubnetName'))]",
+    "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('aksSubnetName'))]"
   },
   "resources": {
     "vmSubnetNsg": {
@@ -254,7 +254,7 @@
             "properties": {
               "addressPrefix": "[parameters('vmSubnetAddressPrefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('vmSubnetNsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmSubnetNsgName'))]"
               },
               "privateEndpointNetworkPolicies": "Disabled",
               "privateLinkServiceNetworkPolicies": "Enabled"
@@ -265,7 +265,7 @@
             "properties": {
               "addressPrefix": "[parameters('bastionSubnetAddressPrefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('bastionSubnetNsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionSubnetNsgName'))]"
               }
             }
           }
@@ -309,19 +309,19 @@
   "outputs": {
     "virtualNetworkResourceId": {
       "type": "string",
-      "value": "[resourceInfo('virtualNetwork').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
     },
     "bastionSubnetId": {
       "type": "string",
-      "value": "[resourceInfo('bastionSubnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('bastionSubnetName'))]"
     },
     "aksSubnetId": {
       "type": "string",
-      "value": "[resourceInfo('aksSubnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('aksSubnetName'))]"
     },
     "vmSubnetId": {
       "type": "string",
-      "value": "[resourceInfo('vmSubnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('vmSubnetName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/vnet.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/vnet.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13883503950548406884"
+      "templateHash": "14960226424976816995"
     }
   },
   "parameters": {
@@ -70,7 +70,10 @@
   "variables": {
     "bastionSubnetName": "AzureBastionSubnet",
     "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
-    "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]"
+    "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, variables('bastionSubnetName'))]",
+    "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]",
+    "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('vmSubnetName'))]",
+    "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('virtualNetwork').name, parameters('aksSubnetName'))]"
   },
   "resources": {
     "vmSubnetNsg": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/anchored-ppg.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/anchored-ppg.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16079889332281336314"
+      "templateHash": "11723375933265431589"
     }
   },
   "parameters": {
@@ -73,7 +73,7 @@
                 "id": "[parameters('subnetId')]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-pip', parameters('vmName')))]"
               }
             }
           }
@@ -95,7 +95,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
             }
           ]
         },
@@ -115,7 +115,7 @@
           }
         },
         "proximityPlacementGroup": {
-          "id": "[resourceInfo('ppg').id]"
+          "id": "[resourceId('Microsoft.Compute/proximityPlacementGroups', format('Zone-{0}', parameters('zone')))]"
         },
         "storageProfile": {
           "imageReference": {
@@ -145,7 +145,7 @@
   "outputs": {
     "ppgId": {
       "type": "string",
-      "value": "[resourceInfo('ppg').id]"
+      "value": "[resourceId('Microsoft.Compute/proximityPlacementGroups', format('Zone-{0}', parameters('zone')))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/linux-vm-as.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/linux-vm-as.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16602990965325228130"
+      "templateHash": "14746205280723861821"
     }
   },
   "parameters": {
@@ -71,7 +71,7 @@
       "location": "[parameters('location')]",
       "properties": {
         "availabilitySet": {
-          "id": "[resourceInfo('availabilitySets').id]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'as')]"
         },
         "hardwareProfile": {
           "vmSize": "Standard_B4ms"
@@ -79,7 +79,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17610915880492382089"
+      "templateHash": "12614717428855112446"
     }
   },
   "parameters": {
@@ -71,7 +71,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2380358959994836781"
+              "templateHash": "5389517954861270855"
             }
           },
           "parameters": {
@@ -151,7 +151,7 @@
                     "properties": {
                       "addressPrefix": "10.0.0.0/24",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('nsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'demo-nsg')]"
                       }
                     }
                   }
@@ -165,7 +165,7 @@
           "outputs": {
             "vnetId": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', 'demo-vnet')]"
             }
           }
         }
@@ -207,7 +207,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16079889332281336314"
+              "templateHash": "11723375933265431589"
             }
           },
           "parameters": {
@@ -273,7 +273,7 @@
                         "id": "[parameters('subnetId')]"
                       },
                       "publicIPAddress": {
-                        "id": "[resourceInfo('pip').id]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}-pip', parameters('vmName')))]"
                       }
                     }
                   }
@@ -295,7 +295,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
                     }
                   ]
                 },
@@ -315,7 +315,7 @@
                   }
                 },
                 "proximityPlacementGroup": {
-                  "id": "[resourceInfo('ppg').id]"
+                  "id": "[resourceId('Microsoft.Compute/proximityPlacementGroups', format('Zone-{0}', parameters('zone')))]"
                 },
                 "storageProfile": {
                   "imageReference": {
@@ -345,7 +345,7 @@
           "outputs": {
             "ppgId": {
               "type": "string",
-              "value": "[resourceInfo('ppg').id]"
+              "value": "[resourceId('Microsoft.Compute/proximityPlacementGroups', format('Zone-{0}', parameters('zone')))]"
             }
           }
         }
@@ -388,7 +388,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16602990965325228130"
+              "templateHash": "14746205280723861821"
             }
           },
           "parameters": {
@@ -452,7 +452,7 @@
               "location": "[parameters('location')]",
               "properties": {
                 "availabilitySet": {
-                  "id": "[resourceInfo('availabilitySets').id]"
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets', 'as')]"
                 },
                 "hardwareProfile": {
                   "vmSize": "Standard_B4ms"
@@ -460,7 +460,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
                     }
                   ]
                 },
@@ -542,7 +542,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16602990965325228130"
+              "templateHash": "14746205280723861821"
             }
           },
           "parameters": {
@@ -606,7 +606,7 @@
               "location": "[parameters('location')]",
               "properties": {
                 "availabilitySet": {
-                  "id": "[resourceInfo('availabilitySets').id]"
+                  "id": "[resourceId('Microsoft.Compute/availabilitySets', 'as')]"
                 },
                 "hardwareProfile": {
                   "vmSize": "Standard_B4ms"
@@ -614,7 +614,7 @@
                 "networkProfile": {
                   "networkInterfaces": [
                     {
-                      "id": "[resourceInfo('nic').id]"
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
                     }
                   ]
                 },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/network.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/network.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2380358959994836781"
+      "templateHash": "5389517954861270855"
     }
   },
   "parameters": {
@@ -87,7 +87,7 @@
             "properties": {
               "addressPrefix": "10.0.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'demo-nsg')]"
               }
             }
           }
@@ -101,7 +101,7 @@
   "outputs": {
     "vnetId": {
       "type": "string",
-      "value": "[resourceInfo('vnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', 'demo-vnet')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18307971782512789410"
+      "templateHash": "5765491140023463766"
     }
   },
   "parameters": {
@@ -114,7 +114,7 @@
           "rdb-backup-enabled": "true",
           "rdb-backup-frequency": "60",
           "rdb-backup-max-snapshot-count": "1",
-          "rdb-storage-connection-string": "[format('DefaultEndpointsProtocol=https;BlobEndpoint=https://{0}.blob.{1};AccountName={2};AccountKey={3}', resourceInfo('storageAccount').name, environment().suffixes.storage, resourceInfo('storageAccount').name, listKeys(resourceInfo('storageAccount').id, '2021-04-01').keys[0].value)]"
+          "rdb-storage-connection-string": "[format('DefaultEndpointsProtocol=https;BlobEndpoint=https://{0}.blob.{1};AccountName={2};AccountKey={3}', parameters('storageAccountName'), environment().suffixes.storage, parameters('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value)]"
         }
       }
     },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/prereqs.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/prereqs.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9709034695536265833"
+      "templateHash": "3379072964600254192"
     }
   },
   "parameters": {
@@ -61,15 +61,15 @@
   "outputs": {
     "diagAccountId": {
       "type": "string",
-      "value": "[resourceInfo('diagsAccount').id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', format('diags{0}', uniqueString(resourceGroup().id)))]"
     },
     "cacheAccountName": {
       "type": "string",
-      "value": "[resourceInfo('cacheAccount').name]"
+      "value": "[parameters('cacheAccountName')]"
     },
     "cacheAccountId": {
       "type": "string",
-      "value": "[resourceInfo('cacheAccount').id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('cacheAccountName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/servicebus-create-queue/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/servicebus-create-queue/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17550427312171209821"
+      "templateHash": "3102022256267994560"
     }
   },
   "parameters": {
@@ -36,7 +36,7 @@
     "serviceBusQueue": {
       "type": "Microsoft.ServiceBus/namespaces/queues",
       "apiVersion": "2017-04-01",
-      "name": "[format('{0}/{1}', resourceInfo('serviceBusNamespace').name, parameters('serviceBusQueueName'))]",
+      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName'))]",
       "properties": {
         "lockDuration": "PT5M",
         "maxSizeInMegabytes": 1024,

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/shared-image-gallery-with-image-defintition-and-role-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/shared-image-gallery-with-image-defintition-and-role-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10426512095450825065"
+      "templateHash": "15227432288030425616"
     }
   },
   "parameters": {
@@ -101,9 +101,9 @@
     "galleryass": {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceGroup().id, resourceInfo('gallerydef').id, parameters('principalId'))]",
+      "name": "[guid(resourceGroup().id, resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage'))), parameters('principalId'))]",
       "properties": {
-        "roleDefinitionId": "[resourceInfo('gallerydef').id]",
+        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', guid(parameters('roleNameGalleryImage')))]",
         "principalId": "[parameters('principalId')]"
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/traffic-manager-webapp/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/traffic-manager-webapp/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13754927006065788180"
+      "templateHash": "16807685243729840213"
     }
   },
   "parameters": {
@@ -57,7 +57,7 @@
       "name": "[parameters('uniqueDnsNameForWebApp')]",
       "location": "[parameters('location')]",
       "properties": {
-        "serverFarmId": "[resourceInfo('appServicePlan').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
       },
       "dependsOn": [
         "appServicePlan"
@@ -85,7 +85,7 @@
             "name": "[parameters('uniqueDnsNameForWebApp')]",
             "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
             "properties": {
-              "targetResourceId": "[resourceInfo('webSite').id]",
+              "targetResourceId": "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]",
               "endpointStatus": "Enabled"
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-copy-managed-disks/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-copy-managed-disks/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "328224610852803274"
+      "templateHash": "14833838210000853526"
     }
   },
   "parameters": {
@@ -123,7 +123,7 @@
       "properties": {
         "addressPrefix": "[variables('myVNETSubnet1Prefix')]",
         "networkSecurityGroup": {
-          "id": "[resourceInfo('networkSecurityGroup').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
       },
       "dependsOn": [
@@ -198,7 +198,7 @@
           ]
         },
         "availabilitySet": {
-          "id": "[resourceInfo('availabilitySet').id]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
@@ -231,7 +231,7 @@
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}{1}-PIP1', parameters('virtualMachineNamePrefix'), add(range(0, parameters('virtualMachineCount'))[copyIndex()], 1)))]"
               },
               "subnet": {
-                "id": "[resourceInfo('subNet').id]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', variables('myVNETName'), variables('myVNETSubnet1Name')), '/')[0], split(format('{0}/{1}', variables('myVNETName'), variables('myVNETSubnet1Name')), '/')[1])]"
               }
             }
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-domain-join/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-domain-join/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17982765110025310907"
+      "templateHash": "13957027872942036651"
     }
   },
   "parameters": {
@@ -100,7 +100,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIp').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetId')]"
@@ -152,7 +152,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
             }
           ]
         },
@@ -171,7 +171,7 @@
     "virtualMachineExtension": {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/joindomain', resourceInfo('virtualMachine').name)]",
+      "name": "[format('{0}/joindomain', parameters('dnsLabelPrefix'))]",
       "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Compute",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10846596578121457424"
+      "templateHash": "10650312790912797349"
     }
   },
   "parameters": {
@@ -156,6 +156,11 @@
       }
     }
   },
+  "variables": {
+    "storageAccountId": "[if(parameters('createNewStorageAccount'), resourceInfo('storageAccount').id, resourceId(parameters('storageAccountResourceGroupName'), 'Microsoft.Storage/storageAccounts/', parameters('storageAccountName')))]",
+    "subnetId": "[if(parameters('createNewVnet'), resourceInfo('subnet').id, resourceId(parameters('vnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName')))]",
+    "publicIPId": "[if(parameters('createNewPublicIP'), resourceInfo('publicIP').id, resourceId(parameters('publicIPResourceGroupName'), 'Microsoft.Network/publicIPAddresses', parameters('publicIPName')))]"
+  },
   "resources": {
     "storageAccount": {
       "condition": "[parameters('createNewStorageAccount')]",
@@ -245,10 +250,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[if(parameters('createNewVnet'), resourceInfo('subnet').id, resourceId(parameters('vnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName')))]"
+                "id": "[variables('subnetId')]"
               },
               "publicIPAddress": {
-                "id": "[if(parameters('createNewPublicIP'), resourceInfo('publicIP').id, resourceId(parameters('publicIPResourceGroupName'), 'Microsoft.Network/publicIPAddresses', parameters('publicIPName')))]"
+                "id": "[variables('publicIPId')]"
               }
             }
           }
@@ -296,7 +301,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(if(parameters('createNewStorageAccount'), resourceInfo('storageAccount').id, resourceId(parameters('storageAccountResourceGroupName'), 'Microsoft.Storage/storageAccounts/', parameters('storageAccountName')))).primaryEndpoints.blob]"
+            "storageUri": "[reference(variables('storageAccountId')).primaryEndpoints.blob]"
           }
         }
       },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-new-or-existing-conditions/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10650312790912797349"
+      "templateHash": "4161770653523253824"
     }
   },
   "parameters": {
@@ -157,9 +157,9 @@
     }
   },
   "variables": {
-    "storageAccountId": "[if(parameters('createNewStorageAccount'), resourceInfo('storageAccount').id, resourceId(parameters('storageAccountResourceGroupName'), 'Microsoft.Storage/storageAccounts/', parameters('storageAccountName')))]",
-    "subnetId": "[if(parameters('createNewVnet'), resourceInfo('subnet').id, resourceId(parameters('vnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName')))]",
-    "publicIPId": "[if(parameters('createNewPublicIP'), resourceInfo('publicIP').id, resourceId(parameters('publicIPResourceGroupName'), 'Microsoft.Network/publicIPAddresses', parameters('publicIPName')))]"
+    "storageAccountId": "[if(parameters('createNewStorageAccount'), resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), resourceId(parameters('storageAccountResourceGroupName'), 'Microsoft.Storage/storageAccounts/', parameters('storageAccountName')))]",
+    "subnetId": "[if(parameters('createNewVnet'), resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/{1}', parameters('vnetName'), parameters('subnetName')), '/')[0], split(format('{0}/{1}', parameters('vnetName'), parameters('subnetName')), '/')[1]), resourceId(parameters('vnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName')))]",
+    "publicIPId": "[if(parameters('createNewPublicIP'), resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPName')), resourceId(parameters('publicIPResourceGroupName'), 'Microsoft.Network/publicIPAddresses', parameters('publicIPName')))]"
   },
   "resources": {
     "storageAccount": {
@@ -226,11 +226,11 @@
       "condition": "[parameters('createNewVnet')]",
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2017-09-01",
-      "name": "[format('{0}/{1}', resourceInfo('vnet').name, parameters('subnetName'))]",
+      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnetName'))]",
       "properties": {
         "addressPrefix": "[parameters('subnetPrefix')]",
         "networkSecurityGroup": {
-          "id": "[resourceInfo('nsg').id]"
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'default-NSG')]"
         }
       },
       "dependsOn": [
@@ -294,7 +294,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-push-certificate-windows/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-push-certificate-windows/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14418460216769172143"
+      "templateHash": "9988305214679977467"
     }
   },
   "parameters": {
@@ -100,7 +100,7 @@
             "properties": {
               "addressPrefix": "10.0.0.0/24",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('nsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
               }
             }
           }
@@ -122,10 +122,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceInfo('pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'certPublicIp')]"
               },
               "subnet": {
-                "id": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, variables('subnet1Name'))]"
+                "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), variables('subnet1Name'))]"
               }
             }
           }
@@ -178,7 +178,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceInfo('nic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', 'certNic')]"
             }
           ]
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3972844562288684861"
+      "templateHash": "6418395677303165146"
     }
   },
   "parameters": {
@@ -122,7 +122,7 @@
           "properties": {
             "addressPrefix": "[parameters('virtualNetworkSubnetPrefix')]",
             "networkSecurityGroup": {
-              "id": "[resourceInfo('nsg').id]"
+              "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroup').name)]"
             }
           }
         }
@@ -137,10 +137,10 @@
           "properties": {
             "privateIPAllocationMethod": "Dynamic",
             "publicIPAddress": {
-              "id": "[resourceInfo('pip').id]"
+              "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIp').name)]"
             },
             "subnet": {
-              "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnetName'))]"
+              "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetwork').name, variables('subnetName'))]"
             }
           }
         }
@@ -160,12 +160,12 @@
       "vmDataDisks": [],
       "networkInterfaces": [
         {
-          "id": "[resourceInfo('nic').id]"
+          "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterface').name)]"
         }
       ]
     },
     "virtualMachineExtensionCustomScript": {
-      "name": "[format('{0}/config-app', resourceInfo('vm').name)]",
+      "name": "[format('{0}/config-app', variables('virtualMachine').name)]",
       "location": "[parameters('location')]",
       "fileUris": [
         "[parameters('virtualMachineExtensionCustomScriptUri')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows-with-custom-script-extension/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5537579470070255671"
+      "templateHash": "3972844562288684861"
     }
   },
   "parameters": {
@@ -109,7 +109,69 @@
         }
       ]
     },
-    "subnetName": "default"
+    "subnetName": "default",
+    "virtualNetwork": {
+      "name": "[replace(variables('metadata').longName, '{0}', 'vnet')]",
+      "location": "[parameters('location')]",
+      "addressPrefixes": [
+        "[parameters('virtualNetworkAddressPrefix')]"
+      ],
+      "subnets": [
+        {
+          "name": "[variables('subnetName')]",
+          "properties": {
+            "addressPrefix": "[parameters('virtualNetworkSubnetPrefix')]",
+            "networkSecurityGroup": {
+              "id": "[resourceInfo('nsg').id]"
+            }
+          }
+        }
+      ]
+    },
+    "networkInterface": {
+      "name": "[replace(variables('metadata').longName, '{0}', 'nic')]",
+      "location": "[parameters('location')]",
+      "ipConfigurations": [
+        {
+          "name": "ipconfig1",
+          "properties": {
+            "privateIPAllocationMethod": "Dynamic",
+            "publicIPAddress": {
+              "id": "[resourceInfo('pip').id]"
+            },
+            "subnet": {
+              "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnetName'))]"
+            }
+          }
+        }
+      ]
+    },
+    "virtualMachine": {
+      "name": "[replace(variables('metadata').shortName, '{0}', 'vm')]",
+      "location": "[parameters('location')]",
+      "vmSize": "[parameters('virtualMachineSize')]",
+      "vmComputerName": "[replace(variables('metadata').shortName, '{0}', 'vm')]",
+      "vmAdminUsername": "[parameters('virtualMachineAdminUsername')]",
+      "vmAdminPassword": "[parameters('virtualMachineAdminPassword')]",
+      "vmImagePublisher": "[parameters('virtualMachinePublisher')]",
+      "vmImageOffer": "[parameters('virtualMachineOffer')]",
+      "vmImageSku": "[parameters('virtualMachineSku')]",
+      "vmOSDiskName": "[replace(variables('metadata').longName, '{0}', 'osdisk')]",
+      "vmDataDisks": [],
+      "networkInterfaces": [
+        {
+          "id": "[resourceInfo('nic').id]"
+        }
+      ]
+    },
+    "virtualMachineExtensionCustomScript": {
+      "name": "[format('{0}/config-app', resourceInfo('vm').name)]",
+      "location": "[parameters('location')]",
+      "fileUris": [
+        "[parameters('virtualMachineExtensionCustomScriptUri')]"
+      ],
+      "commandToExecute": "[format('powershell -ExecutionPolicy Unrestricted -File ./{0}', last(split(parameters('virtualMachineExtensionCustomScriptUri'), '/')))]"
+    }
   },
   "resources": {
     "st": {
@@ -146,13 +208,13 @@
     "vnet": {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2020-06-01",
-      "name": "[createObject('name', replace(variables('metadata').longName, '{0}', 'vnet'), 'location', parameters('location'), 'addressPrefixes', createArray(parameters('virtualNetworkAddressPrefix')), 'subnets', createArray(createObject('name', variables('subnetName'), 'properties', createObject('addressPrefix', parameters('virtualNetworkSubnetPrefix'), 'networkSecurityGroup', createObject('id', resourceInfo('nsg').id))))).name]",
-      "location": "[createObject('name', replace(variables('metadata').longName, '{0}', 'vnet'), 'location', parameters('location'), 'addressPrefixes', createArray(parameters('virtualNetworkAddressPrefix')), 'subnets', createArray(createObject('name', variables('subnetName'), 'properties', createObject('addressPrefix', parameters('virtualNetworkSubnetPrefix'), 'networkSecurityGroup', createObject('id', resourceInfo('nsg').id))))).location]",
+      "name": "[variables('virtualNetwork').name]",
+      "location": "[variables('virtualNetwork').location]",
       "properties": {
         "addressSpace": {
-          "addressPrefixes": "[createObject('name', replace(variables('metadata').longName, '{0}', 'vnet'), 'location', parameters('location'), 'addressPrefixes', createArray(parameters('virtualNetworkAddressPrefix')), 'subnets', createArray(createObject('name', variables('subnetName'), 'properties', createObject('addressPrefix', parameters('virtualNetworkSubnetPrefix'), 'networkSecurityGroup', createObject('id', resourceInfo('nsg').id))))).addressPrefixes]"
+          "addressPrefixes": "[variables('virtualNetwork').addressPrefixes]"
         },
-        "subnets": "[createObject('name', replace(variables('metadata').longName, '{0}', 'vnet'), 'location', parameters('location'), 'addressPrefixes', createArray(parameters('virtualNetworkAddressPrefix')), 'subnets', createArray(createObject('name', variables('subnetName'), 'properties', createObject('addressPrefix', parameters('virtualNetworkSubnetPrefix'), 'networkSecurityGroup', createObject('id', resourceInfo('nsg').id))))).subnets]"
+        "subnets": "[variables('virtualNetwork').subnets]"
       },
       "dependsOn": [
         "nsg"
@@ -161,10 +223,10 @@
     "nic": {
       "type": "Microsoft.Network/networkInterfaces",
       "apiVersion": "2020-06-01",
-      "name": "[createObject('name', replace(variables('metadata').longName, '{0}', 'nic'), 'location', parameters('location'), 'ipConfigurations', createArray(createObject('name', 'ipconfig1', 'properties', createObject('privateIPAllocationMethod', 'Dynamic', 'publicIPAddress', createObject('id', resourceInfo('pip').id), 'subnet', createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnetName'))))))).name]",
-      "location": "[createObject('name', replace(variables('metadata').longName, '{0}', 'nic'), 'location', parameters('location'), 'ipConfigurations', createArray(createObject('name', 'ipconfig1', 'properties', createObject('privateIPAllocationMethod', 'Dynamic', 'publicIPAddress', createObject('id', resourceInfo('pip').id), 'subnet', createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnetName'))))))).location]",
+      "name": "[variables('networkInterface').name]",
+      "location": "[variables('networkInterface').location]",
       "properties": {
-        "ipConfigurations": "[createObject('name', replace(variables('metadata').longName, '{0}', 'nic'), 'location', parameters('location'), 'ipConfigurations', createArray(createObject('name', 'ipconfig1', 'properties', createObject('privateIPAllocationMethod', 'Dynamic', 'publicIPAddress', createObject('id', resourceInfo('pip').id), 'subnet', createObject('id', resourceId('Microsoft.Network/virtualNetworks/subnets', resourceInfo('vnet').name, variables('subnetName'))))))).ipConfigurations]"
+        "ipConfigurations": "[variables('networkInterface').ipConfigurations]"
       },
       "dependsOn": [
         "pip",
@@ -174,33 +236,33 @@
     "vm": {
       "type": "Microsoft.Compute/virtualMachines",
       "apiVersion": "2020-06-01",
-      "name": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).name]",
-      "location": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).location]",
+      "name": "[variables('virtualMachine').name]",
+      "location": "[variables('virtualMachine').location]",
       "properties": {
         "hardwareProfile": {
-          "vmSize": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmSize]"
+          "vmSize": "[variables('virtualMachine').vmSize]"
         },
         "osProfile": {
-          "computerName": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmComputerName]",
-          "adminUsername": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmAdminUsername]",
-          "adminPassword": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmAdminPassword]"
+          "computerName": "[variables('virtualMachine').vmComputerName]",
+          "adminUsername": "[variables('virtualMachine').vmAdminUsername]",
+          "adminPassword": "[variables('virtualMachine').vmAdminPassword]"
         },
         "storageProfile": {
           "imageReference": {
-            "publisher": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmImagePublisher]",
-            "offer": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmImageOffer]",
-            "sku": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmImageSku]",
+            "publisher": "[variables('virtualMachine').vmImagePublisher]",
+            "offer": "[variables('virtualMachine').vmImageOffer]",
+            "sku": "[variables('virtualMachine').vmImageSku]",
             "version": "latest"
           },
           "osDisk": {
-            "name": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmOSDiskName]",
+            "name": "[variables('virtualMachine').vmOSDiskName]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           },
-          "dataDisks": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).vmDataDisks]"
+          "dataDisks": "[variables('virtualMachine').vmDataDisks]"
         },
         "networkProfile": {
-          "networkInterfaces": "[createObject('name', replace(variables('metadata').shortName, '{0}', 'vm'), 'location', parameters('location'), 'vmSize', parameters('virtualMachineSize'), 'vmComputerName', replace(variables('metadata').shortName, '{0}', 'vm'), 'vmAdminUsername', parameters('virtualMachineAdminUsername'), 'vmAdminPassword', parameters('virtualMachineAdminPassword'), 'vmImagePublisher', parameters('virtualMachinePublisher'), 'vmImageOffer', parameters('virtualMachineOffer'), 'vmImageSku', parameters('virtualMachineSku'), 'vmOSDiskName', replace(variables('metadata').longName, '{0}', 'osdisk'), 'vmDataDisks', createArray(), 'networkInterfaces', createArray(createObject('id', resourceInfo('nic').id))).networkInterfaces]"
+          "networkInterfaces": "[variables('virtualMachine').networkInterfaces]"
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
@@ -217,16 +279,16 @@
     "vmext": {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2020-06-01",
-      "name": "[createObject('name', format('{0}/config-app', resourceInfo('vm').name), 'location', parameters('location'), 'fileUris', createArray(parameters('virtualMachineExtensionCustomScriptUri')), 'commandToExecute', format('powershell -ExecutionPolicy Unrestricted -File ./{0}', last(split(parameters('virtualMachineExtensionCustomScriptUri'), '/')))).name]",
-      "location": "[createObject('name', format('{0}/config-app', resourceInfo('vm').name), 'location', parameters('location'), 'fileUris', createArray(parameters('virtualMachineExtensionCustomScriptUri')), 'commandToExecute', format('powershell -ExecutionPolicy Unrestricted -File ./{0}', last(split(parameters('virtualMachineExtensionCustomScriptUri'), '/')))).location]",
+      "name": "[variables('virtualMachineExtensionCustomScript').name]",
+      "location": "[variables('virtualMachineExtensionCustomScript').location]",
       "properties": {
         "publisher": "Microsoft.Compute",
         "type": "CustomScriptExtension",
         "typeHandlerVersion": "1.10",
         "autoUpgradeMinorVersion": true,
         "settings": {
-          "fileUris": "[createObject('name', format('{0}/config-app', resourceInfo('vm').name), 'location', parameters('location'), 'fileUris', createArray(parameters('virtualMachineExtensionCustomScriptUri')), 'commandToExecute', format('powershell -ExecutionPolicy Unrestricted -File ./{0}', last(split(parameters('virtualMachineExtensionCustomScriptUri'), '/')))).fileUris]",
-          "commandToExecute": "[createObject('name', format('{0}/config-app', resourceInfo('vm').name), 'location', parameters('location'), 'fileUris', createArray(parameters('virtualMachineExtensionCustomScriptUri')), 'commandToExecute', format('powershell -ExecutionPolicy Unrestricted -File ./{0}', last(split(parameters('virtualMachineExtensionCustomScriptUri'), '/')))).commandToExecute]"
+          "fileUris": "[variables('virtualMachineExtensionCustomScript').fileUris]",
+          "commandToExecute": "[variables('virtualMachineExtensionCustomScript').commandToExecute]"
         },
         "protectedSettings": {}
       },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vm-windows10-with-nvidia-gpu-extension-and-condition/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6551787062035757687"
+      "templateHash": "5681268842659059862"
     }
   },
   "parameters": {
@@ -104,7 +104,7 @@
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, variables('vnetConfig').subnet.name)]"
+                "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName')), variables('vnetConfig').subnet.name)]"
               },
               "privateIPAllocationMethod": "[variables('privateIPAllocationMethod')]"
             }
@@ -147,7 +147,7 @@
               "properties": {
                 "primary": true
               },
-              "id": "[resourceInfo('vmNic').id]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('defaultVmNicName'))]"
             }
           ]
         }
@@ -160,7 +160,7 @@
       "condition": "[parameters('installNVidiaGPUDriver')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/NvidiaGpuDriverWindows', resourceInfo('vm').name)]",
+      "name": "[format('{0}/NvidiaGpuDriverWindows', parameters('vmName'))]",
       "location": "[variables('defaultLocation')]",
       "properties": {
         "publisher": "Microsoft.HpcCompute",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vmss-windows-autoscale/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vmss-windows-autoscale/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8890252983138625946"
+      "templateHash": "6589637686605775794"
     }
   },
   "parameters": {
@@ -134,7 +134,7 @@
             "name": "LoadBalancerFrontEnd",
             "properties": {
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIP').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
@@ -202,16 +202,16 @@
                       "name": "[variables('ipConfigName')]",
                       "properties": {
                         "subnet": {
-                          "id": "[format('{0}/subnets/{1}', resourceInfo('virtualNetwork').id, variables('subnetName'))]"
+                          "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnetName'))]"
                         },
                         "loadBalancerBackendAddressPools": [
                           {
-                            "id": "[format('{0}/backendAddressPools/{1}', resourceInfo('loadBalancer').id, variables('bePoolName'))]"
+                            "id": "[format('{0}/backendAddressPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('bePoolName'))]"
                           }
                         ],
                         "loadBalancerInboundNatPools": [
                           {
-                            "id": "[format('{0}/inboundNatPools/{1}', resourceInfo('loadBalancer').id, variables('natPoolName'))]"
+                            "id": "[format('{0}/inboundNatPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('natPoolName'))]"
                           }
                         ]
                       }
@@ -235,7 +235,7 @@
       "location": "[parameters('location')]",
       "properties": {
         "name": "cpuautoscale",
-        "targetResourceUri": "[resourceInfo('vmss').id]",
+        "targetResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
         "enabled": true,
         "profiles": [
           {
@@ -250,7 +250,7 @@
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
                   "metricNamespace": "",
-                  "metricResourceUri": "[resourceInfo('vmss').id]",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
@@ -269,7 +269,7 @@
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
                   "metricNamespace": "",
-                  "metricResourceUri": "[resourceInfo('vmss').id]",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-bgp/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-bgp/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4669046696212341522"
+      "templateHash": "12652950816214191109"
     }
   },
   "parameters": {
@@ -219,10 +219,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[format('{0}/subnets/GatewaySubnet', resourceInfo('vnet1').id)]"
+                "id": "[format('{0}/subnets/GatewaySubnet', resourceId('Microsoft.Network/virtualNetworks', variables('vnet1cfg').name))]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('gw1pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vnet1cfg').gatewayPublicIPName)]"
               }
             }
           }
@@ -255,10 +255,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[format('{0}/subnets/GatewaySubnet', resourceInfo('vnet2').id)]"
+                "id": "[format('{0}/subnets/GatewaySubnet', resourceId('Microsoft.Network/virtualNetworks', variables('vnet2cfg').name))]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('gw2pip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vnet2cfg').gatewayPublicIPName)]"
               }
             }
           }
@@ -286,11 +286,11 @@
       "location": "[parameters('location')]",
       "properties": {
         "virtualNetworkGateway1": {
-          "id": "[resourceInfo('vpngw1').id]",
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', variables('vnet1cfg').gatewayName)]",
           "properties": {}
         },
         "virtualNetworkGateway2": {
-          "id": "[resourceInfo('vpngw2').id]",
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', variables('vnet2cfg').gatewayName)]",
           "properties": {}
         },
         "connectionType": "Vnet2Vnet",
@@ -310,11 +310,11 @@
       "location": "[parameters('location')]",
       "properties": {
         "virtualNetworkGateway1": {
-          "id": "[resourceInfo('vpngw2').id]",
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', variables('vnet2cfg').gatewayName)]",
           "properties": {}
         },
         "virtualNetworkGateway2": {
-          "id": "[resourceInfo('vpngw1').id]",
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', variables('vnet1cfg').gatewayName)]",
           "properties": {}
         },
         "connectionType": "Vnet2Vnet",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-peering/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-to-vnet-peering/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15926167857864613760"
+      "templateHash": "14483851728444660869"
     }
   },
   "parameters": {
@@ -97,7 +97,7 @@
         "allowGatewayTransit": false,
         "useRemoteGateways": false,
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnet2').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
         }
       },
       "dependsOn": [
@@ -156,7 +156,7 @@
         "allowGatewayTransit": false,
         "useRemoteGateways": false,
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnet1').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-with-subnet-and-user-defined-route/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vnet-with-subnet-and-user-defined-route/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14128341149922873145"
+      "templateHash": "11855925300895256067"
     }
   },
   "parameters": {
@@ -102,7 +102,7 @@
             "properties": {
               "addressPrefix": "[parameters('subnetaddressPrefix')]",
               "routeTable": {
-                "id": "[resourceInfo('udr').id]"
+                "id": "[resourceId('Microsoft.Network/routeTables', parameters('udrName'))]"
               },
               "networkSecurityGroup": {
                 "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/vwan-shared-services/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/vwan-shared-services/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7047555310483283564"
+      "templateHash": "13283502071312628991"
     }
   },
   "parameters": {
@@ -64,7 +64,7 @@
       "properties": {
         "addressPrefix": "[variables('virtual_hub_cfg').addressSpacePrefix]",
         "virtualWan": {
-          "id": "[resourceInfo('vwan').id]"
+          "id": "[resourceId('Microsoft.Network/virtualWans', variables('vwan_cfg').name)]"
         }
       },
       "dependsOn": [
@@ -84,7 +84,7 @@
               "[variables('vnet_shared_services_cfg').addressSpacePrefix]"
             ],
             "nextHopType": "ResourceId",
-            "nextHop": "[format('{0}/hubVirtualNetworkConnections/{1}_connection', resourceInfo('virtual_hub').id, variables('vnet_shared_services_cfg').name)]"
+            "nextHop": "[format('{0}/hubVirtualNetworkConnections/{1}_connection', resourceId('Microsoft.Network/virtualHubs', variables('virtual_hub_cfg').name), variables('vnet_shared_services_cfg').name)]"
           }
         ]
       },
@@ -221,19 +221,19 @@
       "name": "[format('{0}/{1}_connection', variables('virtual_hub_cfg').name, variables('vnet_shared_services_cfg').name)]",
       "properties": {
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnet_shared_services').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet_shared_services_cfg').name)]"
         },
         "routingConfiguration": {
           "associatedRouteTable": {
-            "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceInfo('virtual_hub').id)]"
+            "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceId('Microsoft.Network/virtualHubs', variables('virtual_hub_cfg').name))]"
           },
           "propagatedRouteTables": {
             "ids": [
               {
-                "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceInfo('virtual_hub').id)]"
+                "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceId('Microsoft.Network/virtualHubs', variables('virtual_hub_cfg').name))]"
               },
               {
-                "id": "[resourceInfo('rt_shared').id]"
+                "id": "[resourceId('Microsoft.Network/virtualHubs/hubRouteTables', split(format('{0}/RT_SHARED', variables('virtual_hub_cfg').name), '/')[0], split(format('{0}/RT_SHARED', variables('virtual_hub_cfg').name), '/')[1])]"
               }
             ]
           }
@@ -254,16 +254,16 @@
       "name": "[format('{0}/{1}_connection', variables('virtual_hub_cfg').name, variables('vnet_isolated_1_cfg').name)]",
       "properties": {
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnet_isolated_1').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet_isolated_1_cfg').name)]"
         },
         "routingConfiguration": {
           "associatedRouteTable": {
-            "id": "[resourceInfo('rt_shared').id]"
+            "id": "[resourceId('Microsoft.Network/virtualHubs/hubRouteTables', split(format('{0}/RT_SHARED', variables('virtual_hub_cfg').name), '/')[0], split(format('{0}/RT_SHARED', variables('virtual_hub_cfg').name), '/')[1])]"
           },
           "propagatedRouteTables": {
             "ids": [
               {
-                "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceInfo('virtual_hub').id)]"
+                "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceId('Microsoft.Network/virtualHubs', variables('virtual_hub_cfg').name))]"
               }
             ]
           }
@@ -285,16 +285,16 @@
       "name": "[format('{0}/{1}_connection', variables('virtual_hub_cfg').name, variables('vnet_isolated_2_cfg').name)]",
       "properties": {
         "remoteVirtualNetwork": {
-          "id": "[resourceInfo('vnet_isolated_2').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet_isolated_2_cfg').name)]"
         },
         "routingConfiguration": {
           "associatedRouteTable": {
-            "id": "[resourceInfo('rt_shared').id]"
+            "id": "[resourceId('Microsoft.Network/virtualHubs/hubRouteTables', split(format('{0}/RT_SHARED', variables('virtual_hub_cfg').name), '/')[0], split(format('{0}/RT_SHARED', variables('virtual_hub_cfg').name), '/')[1])]"
           },
           "propagatedRouteTables": {
             "ids": [
               {
-                "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceInfo('virtual_hub').id)]"
+                "id": "[format('{0}/hubRouteTables/defaultRouteTable', resourceId('Microsoft.Network/virtualHubs', variables('virtual_hub_cfg').name))]"
               }
             ]
           }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-asev2-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-asev2-create/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "431768123943403411"
+      "templateHash": "12447608717883445454"
     }
   },
   "parameters": {
@@ -61,7 +61,7 @@
         "name": "[parameters('aseName')]",
         "workerPools": [],
         "virtualNetwork": {
-          "id": "[resourceInfo('subNet').id]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/logging.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/logging.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8074257545984320654"
+      "templateHash": "66038776502113173"
     }
   },
   "parameters": {
@@ -55,7 +55,7 @@
       },
       "properties": {
         "Application_Type": "web",
-        "WorkspaceResourceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
       },
       "dependsOn": [
         "logAnalyticsWorkspace"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14336700440067418908"
+      "templateHash": "15146304940505606442"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16045524616618900290"
+              "templateHash": "14461411383786153262"
             }
           },
           "parameters": {
@@ -96,7 +96,7 @@
                 "ProjectName": "[parameters('appName')]"
               },
               "properties": {
-                "serverFarmId": "[resourceInfo('appServicePlan').id]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
                 "httpsOnly": true,
                 "siteConfig": {
                   "minTlsVersion": "1.2"
@@ -109,7 +109,7 @@
             "appServiceLogging": {
               "type": "Microsoft.Web/sites/config",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/logs', resourceInfo('appService').name)]",
+              "name": "[format('{0}/logs', variables('webSiteName'))]",
               "properties": {
                 "applicationLogs": {
                   "fileSystem": {
@@ -137,7 +137,7 @@
           "outputs": {
             "appServiceName": {
               "type": "string",
-              "value": "[resourceInfo('appService').name]"
+              "value": "[variables('webSiteName')]"
             }
           }
         }
@@ -167,7 +167,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8074257545984320654"
+              "templateHash": "66038776502113173"
             }
           },
           "parameters": {
@@ -215,7 +215,7 @@
               },
               "properties": {
                 "Application_Type": "web",
-                "WorkspaceResourceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
               },
               "dependsOn": [
                 "logAnalyticsWorkspace"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/webapp.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/webapp.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16045524616618900290"
+      "templateHash": "14461411383786153262"
     }
   },
   "parameters": {
@@ -59,7 +59,7 @@
         "ProjectName": "[parameters('appName')]"
       },
       "properties": {
-        "serverFarmId": "[resourceInfo('appServicePlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "httpsOnly": true,
         "siteConfig": {
           "minTlsVersion": "1.2"
@@ -72,7 +72,7 @@
     "appServiceLogging": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/logs', resourceInfo('appService').name)]",
+      "name": "[format('{0}/logs', variables('webSiteName'))]",
       "properties": {
         "applicationLogs": {
           "fileSystem": {
@@ -100,7 +100,7 @@
   "outputs": {
     "appServiceName": {
       "type": "string",
-      "value": "[resourceInfo('appService').name]"
+      "value": "[variables('webSiteName')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/app-service-plan.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/app-service-plan.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4637137393056098823"
+      "templateHash": "9542820828638189911"
     }
   },
   "parameters": {
@@ -49,7 +49,7 @@
   "outputs": {
     "appServicePlanID": {
       "type": "string",
-      "value": "[resourceInfo('appServicePlan').id]"
+      "value": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/app-service.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/app-service.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "587423152998807340"
+      "templateHash": "3819470834506068566"
     }
   },
   "parameters": {
@@ -52,7 +52,7 @@
     "appServiceLogging": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/logs', resourceInfo('appService').name)]",
+      "name": "[format('{0}/logs', variables('webSiteName'))]",
       "properties": {
         "applicationLogs": {
           "fileSystem": {
@@ -79,7 +79,7 @@
     "appServiceAppSettings": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/appsettings', resourceInfo('appService').name)]",
+      "name": "[format('{0}/appsettings', variables('webSiteName'))]",
       "properties": {
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('APPINSIGHTS_INSTRUMENTATIONKEY')]"
       },
@@ -90,7 +90,7 @@
     "appServiceSiteExtension": {
       "type": "Microsoft.Web/sites/siteextensions",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/Microsoft.ApplicationInsights.AzureWebsites', resourceInfo('appService').name)]",
+      "name": "[format('{0}/Microsoft.ApplicationInsights.AzureWebsites', variables('webSiteName'))]",
       "dependsOn": [
         "appService"
       ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/log-analytics.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/log-analytics.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7239376925861206286"
+      "templateHash": "15502974547644745936"
     }
   },
   "parameters": {
@@ -43,7 +43,7 @@
   "outputs": {
     "logAnalaticsWorkspaceResourceID": {
       "type": "string",
-      "value": "[resourceInfo('logAnalyticsWorkspace').id]"
+      "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18242448488243876106"
+      "templateHash": "9667267869245389470"
     }
   },
   "parameters": {
@@ -40,7 +40,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4637137393056098823"
+              "templateHash": "9542820828638189911"
             }
           },
           "parameters": {
@@ -82,7 +82,7 @@
           "outputs": {
             "appServicePlanID": {
               "type": "string",
-              "value": "[resourceInfo('appServicePlan').id]"
+              "value": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
             }
           }
         }
@@ -117,7 +117,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "587423152998807340"
+              "templateHash": "3819470834506068566"
             }
           },
           "parameters": {
@@ -162,7 +162,7 @@
             "appServiceLogging": {
               "type": "Microsoft.Web/sites/config",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/logs', resourceInfo('appService').name)]",
+              "name": "[format('{0}/logs', variables('webSiteName'))]",
               "properties": {
                 "applicationLogs": {
                   "fileSystem": {
@@ -189,7 +189,7 @@
             "appServiceAppSettings": {
               "type": "Microsoft.Web/sites/config",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/appsettings', resourceInfo('appService').name)]",
+              "name": "[format('{0}/appsettings', variables('webSiteName'))]",
               "properties": {
                 "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('APPINSIGHTS_INSTRUMENTATIONKEY')]"
               },
@@ -200,7 +200,7 @@
             "appServiceSiteExtension": {
               "type": "Microsoft.Web/sites/siteextensions",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/Microsoft.ApplicationInsights.AzureWebsites', resourceInfo('appService').name)]",
+              "name": "[format('{0}/Microsoft.ApplicationInsights.AzureWebsites', variables('webSiteName'))]",
               "dependsOn": [
                 "appService"
               ]
@@ -309,7 +309,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7239376925861206286"
+              "templateHash": "15502974547644745936"
             }
           },
           "parameters": {
@@ -345,7 +345,7 @@
           "outputs": {
             "logAnalaticsWorkspaceResourceID": {
               "type": "string",
-              "value": "[resourceInfo('logAnalyticsWorkspace').id]"
+              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13729247149373144532"
+      "templateHash": "9959650247723691159"
     }
   },
   "parameters": {
@@ -62,7 +62,7 @@
         "ProjectName": "[parameters('appName')]"
       },
       "properties": {
-        "serverFarmId": "[resourceInfo('appServicePlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "httpsOnly": true,
         "siteConfig": {
           "minTlsVersion": "1.2"
@@ -75,7 +75,7 @@
     "appServiceLogging": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/logs', resourceInfo('appService').name)]",
+      "name": "[format('{0}/logs', variables('webSiteName'))]",
       "properties": {
         "applicationLogs": {
           "fileSystem": {
@@ -102,7 +102,7 @@
     "appServiceAppSettings": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/appsettings', resourceInfo('appService').name)]",
+      "name": "[format('{0}/appsettings', variables('webSiteName'))]",
       "properties": {
         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference('appInsights').InstrumentationKey]"
       },
@@ -115,7 +115,7 @@
     "appServiceSiteExtension": {
       "type": "Microsoft.Web/sites/siteextensions",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/Microsoft.ApplicationInsights.AzureWebsites', resourceInfo('appService').name)]",
+      "name": "[format('{0}/Microsoft.ApplicationInsights.AzureWebsites', variables('webSiteName'))]",
       "dependsOn": [
         "appInsights",
         "appService"
@@ -133,7 +133,7 @@
       },
       "properties": {
         "Application_Type": "web",
-        "WorkspaceResourceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsName'))]"
       },
       "dependsOn": [
         "logAnalyticsWorkspace"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-sql-database/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-sql-database/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13974815108336004156"
+      "templateHash": "6205222235656650782"
     }
   },
   "parameters": {
@@ -66,7 +66,7 @@
     "sqlserverName_databaseName": {
       "type": "Microsoft.Sql/servers/databases",
       "apiVersion": "2020-08-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('sqlserver').name, variables('databaseName'))]",
+      "name": "[format('{0}/{1}', variables('sqlserverName'), variables('databaseName'))]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Basic"
@@ -82,7 +82,7 @@
     "sqlserverName_AllowAllWindowsAzureIps": {
       "type": "Microsoft.Sql/servers/firewallRules",
       "apiVersion": "2014-04-01",
-      "name": "[format('{0}/AllowAllWindowsAzureIps', resourceInfo('sqlserver').name)]",
+      "name": "[format('{0}/AllowAllWindowsAzureIps', variables('sqlserverName'))]",
       "properties": {
         "endIpAddress": "0.0.0.0",
         "startIpAddress": "0.0.0.0"
@@ -107,11 +107,11 @@
       "name": "[variables('webSiteName')]",
       "location": "[parameters('location')]",
       "tags": {
-        "[format('hidden-related:{0}', resourceInfo('hostingPlan').id)]": "empty",
+        "[format('hidden-related:{0}', resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName')))]": "empty",
         "displayName": "Website"
       },
       "properties": {
-        "serverFarmId": "[resourceInfo('hostingPlan').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
       },
       "dependsOn": [
         "hostingPlan"
@@ -120,7 +120,7 @@
     "webSiteConnectionStrings": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/connectionstrings', resourceInfo('webSite').name)]",
+      "name": "[format('{0}/connectionstrings', variables('webSiteName'))]",
       "properties": {
         "DefaultConnection": {
           "value": "[format('Data Source=tcp:{0},1433;Initial Catalog={1};User Id={2}@{3};Password={4};', reference('sqlserver').fullyQualifiedDomainName, variables('databaseName'), parameters('sqlAdministratorLogin'), reference('sqlserver').fullyQualifiedDomainName, parameters('sqlAdministratorLoginPassword'))]",
@@ -135,10 +135,10 @@
     "AppInsights_webSiteName": {
       "type": "Microsoft.Insights/components",
       "apiVersion": "2018-05-01-preview",
-      "name": "[format('AppInsights{0}', resourceInfo('webSite').name)]",
+      "name": "[format('AppInsights{0}', variables('webSiteName'))]",
       "location": "[parameters('location')]",
       "tags": {
-        "[format('hidden-link:{0}', resourceInfo('webSite').id)]": "Resource",
+        "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('webSiteName')))]": "Resource",
         "displayName": "AppInsightsComponent"
       },
       "kind": "web",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14726841752421343453"
+      "templateHash": "4259362336117477743"
     }
   },
   "parameters": {
@@ -562,7 +562,7 @@
       "location": "[parameters('location')]",
       "tags": "[parameters('applicationGroupTags')]",
       "properties": {
-        "hostPoolArmPath": "[resourceInfo('hostpool').id]",
+        "hostPoolArmPath": "[resourceId('Microsoft.DesktopVirtualization/hostPools', parameters('hostpoolName'))]",
         "friendlyName": "Default Desktop",
         "description": "Desktop Application Group created through the Hostpool Wizard",
         "applicationGroupType": "Desktop"
@@ -845,7 +845,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15617346665699553121"
+              "templateHash": "8529385440411645806"
             }
           },
           "parameters": {
@@ -1203,7 +1203,7 @@
                     }
                   },
                   "imageReference": {
-                    "id": "[resourceInfo('imageName').id]"
+                    "id": "[resourceId('Microsoft.Compute/images', variables('imageName_var'))]"
                   }
                 },
                 "networkProfile": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15617346665699553121"
+      "templateHash": "8529385440411645806"
     }
   },
   "parameters": {
@@ -365,7 +365,7 @@
             }
           },
           "imageReference": {
-            "id": "[resourceInfo('imageName').id]"
+            "id": "[resourceId('Microsoft.Compute/images', variables('imageName_var'))]"
           }
         },
         "networkProfile": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/automation-account-import-runbooks-and-modules/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/automation-account-import-runbooks-and-modules/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1061362101760482398"
+      "templateHash": "12157837096239928675"
     }
   },
   "parameters": {
@@ -108,8 +108,8 @@
     }
   },
   "variables": {
-    "lockName": "[format('{0}-lck', resourceInfo('automationAccount').name)]",
-    "diagnosticsName": "[format('{0}-dgs', resourceInfo('automationAccount').name)]"
+    "lockName": "[format('{0}-lck', parameters('name'))]",
+    "diagnosticsName": "[format('{0}-dgs', parameters('name'))]"
   },
   "resources": {
     "automationAccount": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/automation-account-import-runbooks-and-modules/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/automation-account-import-runbooks-and-modules/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5530956441668106595"
+      "templateHash": "1061362101760482398"
     }
   },
   "parameters": {
@@ -107,6 +107,10 @@
       }
     }
   },
+  "variables": {
+    "lockName": "[format('{0}-lck', resourceInfo('automationAccount').name)]",
+    "diagnosticsName": "[format('{0}-dgs', resourceInfo('automationAccount').name)]"
+  },
   "resources": {
     "automationAccount": {
       "type": "Microsoft.Automation/automationAccounts",
@@ -166,7 +170,7 @@
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2016-09-01",
       "scope": "[format('Microsoft.Automation/automationAccounts/{0}', parameters('name'))]",
-      "name": "[format('{0}-lck', resourceInfo('automationAccount').name)]",
+      "name": "[variables('lockName')]",
       "properties": {
         "level": "CanNotDelete"
       },
@@ -179,7 +183,7 @@
       "type": "Microsoft.Insights/diagnosticSettings",
       "apiVersion": "2017-05-01-preview",
       "scope": "[format('Microsoft.Automation/automationAccounts/{0}', parameters('name'))]",
-      "name": "[format('{0}-dgs', resourceInfo('automationAccount').name)]",
+      "name": "[variables('diagnosticsName')]",
       "properties": {
         "workspaceId": "[resourceId(parameters('logAnalyticsSubscriptionId'), parameters('logAnalyticsResourceGroup'), 'Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]",
         "storageAccountId": "[resourceId(parameters('diagnosticStorageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName'))]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/actionGroup.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/actionGroup.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11085173111604338779"
+      "templateHash": "11116191754843948367"
     }
   },
   "parameters": {
@@ -52,11 +52,11 @@
   "outputs": {
     "actionGroupId": {
       "type": "string",
-      "value": "[resourceInfo('actionGroup').id]"
+      "value": "[resourceId('microsoft.insights/actionGroups', parameters('actionGroupName'))]"
     },
     "actionGroupName": {
       "type": "string",
-      "value": "[resourceInfo('actionGroup').name]"
+      "value": "[parameters('actionGroupName')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14244886241558578206"
+      "templateHash": "12757951902521494572"
     }
   },
   "parameters": {
@@ -154,7 +154,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11085173111604338779"
+              "templateHash": "11116191754843948367"
             }
           },
           "parameters": {
@@ -199,11 +199,11 @@
           "outputs": {
             "actionGroupId": {
               "type": "string",
-              "value": "[resourceInfo('actionGroup').id]"
+              "value": "[resourceId('microsoft.insights/actionGroups', parameters('actionGroupName'))]"
             },
             "actionGroupName": {
               "type": "string",
-              "value": "[resourceInfo('actionGroup').name]"
+              "value": "[parameters('actionGroupName')]"
             }
           }
         }
@@ -287,7 +287,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18081516609564038783"
+              "templateHash": "18148507846623358518"
             }
           },
           "parameters": {
@@ -565,7 +565,7 @@
                 "parameters": {},
                 "policyDefinitions": [
                   {
-                    "policyDefinitionId": "[resourceInfo('bicepExampleDINEpolicy').id]",
+                    "policyDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/policyDefinitions', 'bicepExampleDINEpolicy')]",
                     "parameters": {}
                   }
                 ]
@@ -578,7 +578,7 @@
           "outputs": {
             "bicepExampleInitiativeId": {
               "type": "string",
-              "value": "[resourceInfo('bicepExampleInitiative').id]"
+              "value": "[subscriptionResourceId('Microsoft.Authorization/policySetDefinitions', 'bicepExampleInitiative')]"
             }
           }
         }
@@ -617,7 +617,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "444332721634326843"
+              "templateHash": "15295644524409115888"
             }
           },
           "parameters": {
@@ -659,7 +659,7 @@
             "roleAssignment": {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2020-04-01-preview",
-              "name": "[guid(resourceInfo('bicepExampleAssignment').name, resourceInfo('bicepExampleAssignment').type, subscription().subscriptionId)]",
+              "name": "[guid('bicepExampleAssignment', 'Microsoft.Authorization/policyAssignments', subscription().subscriptionId)]",
               "properties": {
                 "principalId": "[reference('bicepExampleAssignment', '2020-09-01', 'full').identity.principalId]",
                 "roleDefinitionId": "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/policyAssignment.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/policyAssignment.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "444332721634326843"
+      "templateHash": "15295644524409115888"
     }
   },
   "parameters": {
@@ -49,7 +49,7 @@
     "roleAssignment": {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[guid(resourceInfo('bicepExampleAssignment').name, resourceInfo('bicepExampleAssignment').type, subscription().subscriptionId)]",
+      "name": "[guid('bicepExampleAssignment', 'Microsoft.Authorization/policyAssignments', subscription().subscriptionId)]",
       "properties": {
         "principalId": "[reference('bicepExampleAssignment', '2020-09-01', 'full').identity.principalId]",
         "roleDefinitionId": "/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/policyDefinition.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/policyDefinition.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18081516609564038783"
+      "templateHash": "18148507846623358518"
     }
   },
   "parameters": {
@@ -285,7 +285,7 @@
         "parameters": {},
         "policyDefinitions": [
           {
-            "policyDefinitionId": "[resourceInfo('bicepExampleDINEpolicy').id]",
+            "policyDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/policyDefinitions', 'bicepExampleDINEpolicy')]",
             "parameters": {}
           }
         ]
@@ -298,7 +298,7 @@
   "outputs": {
     "bicepExampleInitiativeId": {
       "type": "string",
-      "value": "[resourceInfo('bicepExampleInitiative').id]"
+      "value": "[subscriptionResourceId('Microsoft.Authorization/policySetDefinitions', 'bicepExampleInitiative')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13489564152371543783"
+      "templateHash": "30670493720742874"
     }
   },
   "parameters": {
@@ -69,7 +69,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1762281737923456729"
+              "templateHash": "12811667487854516689"
             }
           },
           "parameters": {
@@ -135,7 +135,7 @@
             "fileshare": {
               "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
               "apiVersion": "2019-06-01",
-              "name": "[format('{0}/default/{1}', resourceInfo('storage').name, parameters('fileShareName'))]",
+              "name": "[format('{0}/default/{1}', parameters('name'), parameters('fileShareName'))]",
               "dependsOn": [
                 "storage"
               ]
@@ -144,11 +144,11 @@
           "outputs": {
             "resourceId": {
               "type": "string",
-              "value": "[resourceInfo('storage').id]"
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
             },
             "storageName": {
               "type": "string",
-              "value": "[resourceInfo('storage').name]"
+              "value": "[parameters('name')]"
             },
             "fileShareName": {
               "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/storage.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/storage.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1762281737923456729"
+      "templateHash": "12811667487854516689"
     }
   },
   "parameters": {
@@ -73,7 +73,7 @@
     "fileshare": {
       "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
       "apiVersion": "2019-06-01",
-      "name": "[format('{0}/default/{1}', resourceInfo('storage').name, parameters('fileShareName'))]",
+      "name": "[format('{0}/default/{1}', parameters('name'), parameters('fileShareName'))]",
       "dependsOn": [
         "storage"
       ]
@@ -82,11 +82,11 @@
   "outputs": {
     "resourceId": {
       "type": "string",
-      "value": "[resourceInfo('storage').id]"
+      "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
     },
     "storageName": {
       "type": "string",
-      "value": "[resourceInfo('storage').name]"
+      "value": "[parameters('name')]"
     },
     "fileShareName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/expressroute-circuit-vnet-connection/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/expressroute-circuit-vnet-connection/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14373867120325425096"
+      "templateHash": "11533283558062621794"
     }
   },
   "parameters": {
@@ -61,7 +61,7 @@
     "subnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', resourceInfo('virtualNetwork').name, parameters('subnetName'))]",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
       "properties": {
         "addressPrefix": "[parameters('subnetPrefix')]",
         "networkSecurityGroup": {
@@ -92,7 +92,7 @@
     "gatewaySubnet": {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/GatewaySubnet', resourceInfo('virtualNetwork').name)]",
+      "name": "[format('{0}/GatewaySubnet', parameters('virtualNetworkName'))]",
       "properties": {
         "addressPrefix": "[parameters('gatewaySubnetPrefix')]",
         "networkSecurityGroup": {
@@ -141,10 +141,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[resourceInfo('gatewaySubnet').id]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(format('{0}/GatewaySubnet', parameters('virtualNetworkName')), '/')[0], split(format('{0}/GatewaySubnet', parameters('virtualNetworkName')), '/')[1])]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('publicIP').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
               }
             }
           }
@@ -163,7 +163,7 @@
       "location": "[parameters('location')]",
       "properties": {
         "virtualNetworkGateway1": {
-          "id": "[resourceInfo('virtualNetworkGateway').id]",
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]",
           "properties": {}
         },
         "peer": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6126180465178974401"
+      "templateHash": "7405110499342508569"
     }
   },
   "parameters": {
@@ -70,7 +70,7 @@
       },
       "properties": {
         "httpsOnly": true,
-        "serverFarmId": "[resourceInfo('hostingPlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', format('{0}-asp', variables('componentBase')))]",
         "clientAffinityEnabled": false,
         "siteConfig": {
           "http20Enabled": true,
@@ -100,11 +100,11 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('storage').name, environment().suffixes.storage, listKeys(resourceInfo('storage').id, '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', format('{0}st', replace(variables('componentBase'), '-', '')), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', format('{0}st', replace(variables('componentBase'), '-', ''))), '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', resourceInfo('storage').name, environment().suffixes.storage, listKeys(resourceInfo('storage').id, '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', format('{0}st', replace(variables('componentBase'), '-', '')), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', format('{0}st', replace(variables('componentBase'), '-', ''))), '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",
@@ -144,7 +144,7 @@
       "properties": {
         "TTL": 3600,
         "CNAMERecord": {
-          "cname": "[format('{0}.azurewebsites.net', resourceInfo('functionApp').name)]"
+          "cname": "[format('{0}.azurewebsites.net', format('{0}-functionapp', variables('componentBase')))]"
         }
       },
       "dependsOn": [
@@ -154,12 +154,12 @@
     "functionAppCustomHost": {
       "type": "Microsoft.Web/sites/hostNameBindings",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}.{2}', resourceInfo('functionApp').name, parameters('applicationName'), parameters('dnsZone'))]",
+      "name": "[format('{0}/{1}.{2}', format('{0}-functionapp', variables('componentBase')), parameters('applicationName'), parameters('dnsZone'))]",
       "properties": {
         "hostNameType": "Verified",
         "sslState": "Disabled",
         "customHostNameDnsRecordType": "CName",
-        "siteName": "[resourceInfo('functionApp').name]"
+        "siteName": "[format('{0}-functionapp', variables('componentBase'))]"
       },
       "dependsOn": [
         "dnsCname",
@@ -173,7 +173,7 @@
       "name": "[format('{0}.{1}', parameters('applicationName'), parameters('dnsZone'))]",
       "location": "[variables('location')]",
       "properties": {
-        "serverFarmId": "[resourceInfo('hostingPlan').id]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', format('{0}-asp', variables('componentBase')))]",
         "canonicalName": "[format('{0}.{1}', parameters('applicationName'), parameters('dnsZone'))]"
       },
       "dependsOn": [
@@ -192,10 +192,10 @@
         "mode": "Incremental",
         "parameters": {
           "functionAppName": {
-            "value": "[resourceInfo('functionApp').name]"
+            "value": "[format('{0}-functionapp', variables('componentBase'))]"
           },
           "functionAppHostname": {
-            "value": "[format('{0}', resourceInfo('functionAppCustomHostCertificate').name)]"
+            "value": "[format('{0}', format('{0}.{1}', parameters('applicationName'), parameters('dnsZone')))]"
           },
           "certificateThumbprint": {
             "value": "[reference('functionAppCustomHostCertificate').thumbprint]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/insights-alertrules-application-insights/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/insights-alertrules-application-insights/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "761625557707370289"
+      "templateHash": "9792754545948665500"
     }
   },
   "parameters": {
@@ -65,7 +65,7 @@
       "kind": "web",
       "properties": {
         "Application_Type": "web",
-        "WorkspaceResourceId": "[resourceInfo('workspace').id]"
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
       },
       "dependsOn": [
         "workspace"
@@ -81,7 +81,7 @@
         "severity": 0,
         "enabled": true,
         "scopes": [
-          "[resourceInfo('applicationInsights').id]"
+          "[resourceId('Microsoft.Insights/components', parameters('applicationInsightsName'))]"
         ],
         "evaluationFrequency": "PT1M",
         "windowSize": "PT5M",
@@ -100,7 +100,7 @@
         },
         "actions": [
           {
-            "actionGroupId": "[resourceInfo('emailActionGroup').id]"
+            "actionGroupId": "[resourceId('microsoft.insights/actionGroups', 'emailActionGroup')]"
           }
         ]
       },

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/log-analytics-with-datasources-solutions/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/log-analytics-with-datasources-solutions/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15982968023323408126"
+      "templateHash": "5211779161132325392"
     }
   },
   "parameters": {
@@ -97,8 +97,8 @@
     }
   },
   "variables": {
-    "lockName": "[format('{0}-lck', resourceInfo('logAnalyticsWorkspace').name)]",
-    "diagnosticsName": "[format('{0}-dgs', resourceInfo('logAnalyticsWorkspace').name)]"
+    "lockName": "[format('{0}-lck', parameters('name'))]",
+    "diagnosticsName": "[format('{0}-dgs', parameters('name'))]"
   },
   "resources": {
     "logAnalyticsWorkspace": {
@@ -120,13 +120,13 @@
       },
       "type": "Microsoft.OperationsManagement/solutions",
       "apiVersion": "2015-11-01-preview",
-      "name": "[format('{0}({1})', parameters('solutions')[copyIndex()].name, resourceInfo('logAnalyticsWorkspace').name)]",
+      "name": "[format('{0}({1})', parameters('solutions')[copyIndex()].name, parameters('name'))]",
       "location": "[parameters('location')]",
       "properties": {
-        "workspaceResourceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]"
       },
       "plan": {
-        "name": "[format('{0}({1})', parameters('solutions')[copyIndex()].name, resourceInfo('logAnalyticsWorkspace').name)]",
+        "name": "[format('{0}({1})', parameters('solutions')[copyIndex()].name, parameters('name'))]",
         "product": "[parameters('solutions')[copyIndex()].product]",
         "publisher": "[parameters('solutions')[copyIndex()].publisher]",
         "promotionCode": "[parameters('solutions')[copyIndex()].promotionCode]"
@@ -181,7 +181,7 @@
       "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
       "name": "[variables('diagnosticsName')]",
       "properties": {
-        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+        "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]",
         "storageAccountId": "[resourceId(parameters('diagnosticStorageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName'))]",
         "logs": [
           {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/log-analytics-with-datasources-solutions/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/log-analytics-with-datasources-solutions/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16086514202404926137"
+      "templateHash": "15982968023323408126"
     }
   },
   "parameters": {
@@ -96,6 +96,10 @@
       }
     }
   },
+  "variables": {
+    "lockName": "[format('{0}-lck', resourceInfo('logAnalyticsWorkspace').name)]",
+    "diagnosticsName": "[format('{0}-dgs', resourceInfo('logAnalyticsWorkspace').name)]"
+  },
   "resources": {
     "logAnalyticsWorkspace": {
       "type": "Microsoft.OperationalInsights/workspaces",
@@ -162,7 +166,7 @@
       "type": "Microsoft.Authorization/locks",
       "apiVersion": "2016-09-01",
       "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
-      "name": "[format('{0}-lck', resourceInfo('logAnalyticsWorkspace').name)]",
+      "name": "[variables('lockName')]",
       "properties": {
         "level": "CanNotDelete"
       },
@@ -175,7 +179,7 @@
       "type": "Microsoft.Insights/diagnosticSettings",
       "apiVersion": "2017-05-01-preview",
       "scope": "[format('Microsoft.OperationalInsights/workspaces/{0}', parameters('name'))]",
-      "name": "[format('{0}-dgs', resourceInfo('logAnalyticsWorkspace').name)]",
+      "name": "[variables('diagnosticsName')]",
       "properties": {
         "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
         "storageAccountId": "[resourceId(parameters('diagnosticStorageAccountResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('diagnosticStorageAccountName'))]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/management-groups-nested-with-subscriptions/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/management-groups-nested-with-subscriptions/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4131452229265908377"
+      "templateHash": "6188807284257928663"
     }
   },
   "parameters": {
@@ -67,7 +67,7 @@
   "outputs": {
     "managementGroupID": {
       "type": "string",
-      "value": "[resourceInfo('managementGroup').name]"
+      "value": "[parameters('managementGroupId')]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/azfwpip.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/azfwpip.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10058717210123412779"
+      "templateHash": "4580692119464669188"
     }
   },
   "parameters": {
@@ -63,7 +63,7 @@
       "properties": {
         "publicIPAllocationMethod": "Static",
         "publicIPPrefix": {
-          "id": "[resourceInfo('fwipprefix').id]"
+          "id": "[resourceId('Microsoft.Network/publicIPPrefixes', parameters('ipprefixname'))]"
         }
       },
       "dependsOn": [
@@ -74,7 +74,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('fwip').id]"
+      "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('pipname'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/azfwpolicy.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/azfwpolicy.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16382808908725383106"
+      "templateHash": "7632131684262106800"
     }
   },
   "parameters": {
@@ -45,7 +45,7 @@
     "platformrcgroup": {
       "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/Platform-Rules', resourceInfo('policy').name)]",
+      "name": "[format('{0}/Platform-Rules', parameters('policyname'))]",
       "properties": {
         "priority": 100,
         "ruleCollections": [
@@ -137,11 +137,11 @@
   "outputs": {
     "name": {
       "type": "string",
-      "value": "[resourceInfo('policy').name]"
+      "value": "[parameters('policyname')]"
     },
     "id": {
       "type": "string",
-      "value": "[resourceInfo('policy').id]"
+      "value": "[resourceId('Microsoft.Network/firewallPolicies', parameters('policyname'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14532956574002831602"
+      "templateHash": "2801759771265342509"
     }
   },
   "parameters": {
@@ -111,7 +111,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8783959305394975706"
+              "templateHash": "17353621509052261789"
             }
           },
           "parameters": {
@@ -280,7 +280,7 @@
                     "properties": {
                       "addressPrefix": "[parameters('serversubnetprefix')]",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('servernsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('servernsgname'))]"
                       }
                     }
                   },
@@ -289,7 +289,7 @@
                     "properties": {
                       "addressPrefix": "[parameters('bastionsubnetprefix')]",
                       "networkSecurityGroup": {
-                        "id": "[resourceInfo('bastionnsg').id]"
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionnsgname'))]"
                       }
                     }
                   },
@@ -316,7 +316,7 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('vnet').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetname'))]"
             },
             "subnets": {
               "type": "array",
@@ -369,7 +369,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "73375902871047960"
+              "templateHash": "2943086781191583770"
             }
           },
           "parameters": {
@@ -425,7 +425,7 @@
                         "id": "[parameters('subnetref')]"
                       },
                       "publicIPAddress": {
-                        "id": "[resourceInfo('vpngwpip').id]"
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('vpngwpipname'))]"
                       }
                     }
                   }
@@ -450,7 +450,7 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('vpngw').id]"
+              "value": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('vpngwname'))]"
             },
             "vpngwip": {
               "type": "string",
@@ -499,7 +499,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16382808908725383106"
+              "templateHash": "7632131684262106800"
             }
           },
           "parameters": {
@@ -537,7 +537,7 @@
             "platformrcgroup": {
               "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/Platform-Rules', resourceInfo('policy').name)]",
+              "name": "[format('{0}/Platform-Rules', parameters('policyname'))]",
               "properties": {
                 "priority": 100,
                 "ruleCollections": [
@@ -629,11 +629,11 @@
           "outputs": {
             "name": {
               "type": "string",
-              "value": "[resourceInfo('policy').name]"
+              "value": "[parameters('policyname')]"
             },
             "id": {
               "type": "string",
-              "value": "[resourceInfo('policy').id]"
+              "value": "[resourceId('Microsoft.Network/firewallPolicies', parameters('policyname'))]"
             }
           }
         }
@@ -675,7 +675,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10058717210123412779"
+              "templateHash": "4580692119464669188"
             }
           },
           "parameters": {
@@ -731,7 +731,7 @@
               "properties": {
                 "publicIPAllocationMethod": "Static",
                 "publicIPPrefix": {
-                  "id": "[resourceInfo('fwipprefix').id]"
+                  "id": "[resourceId('Microsoft.Network/publicIPPrefixes', parameters('ipprefixname'))]"
                 }
               },
               "dependsOn": [
@@ -742,7 +742,7 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('fwip').id]"
+              "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('pipname'))]"
             }
           }
         }
@@ -939,7 +939,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "410829462598088868"
+              "templateHash": "9878070999700807777"
             }
           },
           "parameters": {
@@ -979,7 +979,7 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('wan').id]"
+              "value": "[resourceId('Microsoft.Network/virtualWans', parameters('wanname'))]"
             }
           }
         }
@@ -1021,7 +1021,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "55639183118113648"
+              "templateHash": "10092071195997223235"
             }
           },
           "parameters": {
@@ -1063,11 +1063,11 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('hub').id]"
+              "value": "[resourceId('Microsoft.Network/virtualHubs', parameters('hubname'))]"
             },
             "name": {
               "type": "string",
-              "value": "[resourceInfo('hub').name]"
+              "value": "[parameters('hubname')]"
             },
             "vhubaddress": {
               "type": "string",
@@ -1108,7 +1108,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16382808908725383106"
+              "templateHash": "7632131684262106800"
             }
           },
           "parameters": {
@@ -1146,7 +1146,7 @@
             "platformrcgroup": {
               "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
               "apiVersion": "2020-06-01",
-              "name": "[format('{0}/Platform-Rules', resourceInfo('policy').name)]",
+              "name": "[format('{0}/Platform-Rules', parameters('policyname'))]",
               "properties": {
                 "priority": 100,
                 "ruleCollections": [
@@ -1238,11 +1238,11 @@
           "outputs": {
             "name": {
               "type": "string",
-              "value": "[resourceInfo('policy').name]"
+              "value": "[parameters('policyname')]"
             },
             "id": {
               "type": "string",
-              "value": "[resourceInfo('policy').id]"
+              "value": "[resourceId('Microsoft.Network/firewallPolicies', parameters('policyname'))]"
             }
           }
         }
@@ -1441,7 +1441,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8384053763727493672"
+              "templateHash": "11538658444195466639"
             }
           },
           "parameters": {
@@ -1484,11 +1484,11 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('hubvpngw').id]"
+              "value": "[resourceId('Microsoft.Network/vpnGateways', parameters('hubvpngwname'))]"
             },
             "name": {
               "type": "string",
-              "value": "[resourceInfo('hubvpngw').name]"
+              "value": "[parameters('hubvpngwname')]"
             },
             "gwpublicip": {
               "type": "string",
@@ -1552,7 +1552,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11144922396738746036"
+              "templateHash": "2570603069945209398"
             }
           },
           "parameters": {
@@ -1624,7 +1624,7 @@
           "outputs": {
             "id": {
               "type": "string",
-              "value": "[resourceInfo('vpnsite').id]"
+              "value": "[resourceId('Microsoft.Network/vpnSites', parameters('vpnsitename'))]"
             }
           }
         }
@@ -1759,7 +1759,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17024638405349992044"
+              "templateHash": "15928558416114035813"
             }
           },
           "parameters": {
@@ -1843,7 +1843,7 @@
                 "enableBgp": true,
                 "sharedKey": "[parameters('psk')]",
                 "localNetworkGateway2": {
-                  "id": "[resourceInfo('localnetworkgw').id]",
+                  "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localnetworkgwname'))]",
                   "properties": {}
                 }
               },

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhub.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhub.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "55639183118113648"
+      "templateHash": "10092071195997223235"
     }
   },
   "parameters": {
@@ -49,11 +49,11 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('hub').id]"
+      "value": "[resourceId('Microsoft.Network/virtualHubs', parameters('hubname'))]"
     },
     "name": {
       "type": "string",
-      "value": "[resourceInfo('hub').name]"
+      "value": "[parameters('hubname')]"
     },
     "vhubaddress": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngw.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vhubvpngw.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8384053763727493672"
+      "templateHash": "11538658444195466639"
     }
   },
   "parameters": {
@@ -50,11 +50,11 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('hubvpngw').id]"
+      "value": "[resourceId('Microsoft.Network/vpnGateways', parameters('hubvpngwname'))]"
     },
     "name": {
       "type": "string",
-      "value": "[resourceInfo('hubvpngw').name]"
+      "value": "[parameters('hubvpngwname')]"
     },
     "gwpublicip": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnet.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnet.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8783959305394975706"
+      "templateHash": "17353621509052261789"
     }
   },
   "parameters": {
@@ -176,7 +176,7 @@
             "properties": {
               "addressPrefix": "[parameters('serversubnetprefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('servernsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('servernsgname'))]"
               }
             }
           },
@@ -185,7 +185,7 @@
             "properties": {
               "addressPrefix": "[parameters('bastionsubnetprefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('bastionnsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionnsgname'))]"
               }
             }
           },
@@ -212,7 +212,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('vnet').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetname'))]"
     },
     "subnets": {
       "type": "array",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetsitetosite.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17024638405349992044"
+      "templateHash": "15928558416114035813"
     }
   },
   "parameters": {
@@ -91,7 +91,7 @@
         "enableBgp": true,
         "sharedKey": "[parameters('psk')]",
         "localNetworkGateway2": {
-          "id": "[resourceInfo('localnetworkgw').id]",
+          "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localnetworkgwname'))]",
           "properties": {}
         }
       },

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetvpngw.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vnetvpngw.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "73375902871047960"
+      "templateHash": "2943086781191583770"
     }
   },
   "parameters": {
@@ -63,7 +63,7 @@
                 "id": "[parameters('subnetref')]"
               },
               "publicIPAddress": {
-                "id": "[resourceInfo('vpngwpip').id]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('vpngwpipname'))]"
               }
             }
           }
@@ -88,7 +88,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('vpngw').id]"
+      "value": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('vpngwname'))]"
     },
     "vpngwip": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vwan.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vwan.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "410829462598088868"
+      "templateHash": "9878070999700807777"
     }
   },
   "parameters": {
@@ -47,7 +47,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('wan').id]"
+      "value": "[resourceId('Microsoft.Network/virtualWans', parameters('wanname'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vwanvpnsite.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/vwanvpnsite.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11144922396738746036"
+      "templateHash": "2570603069945209398"
     }
   },
   "parameters": {
@@ -79,7 +79,7 @@
   "outputs": {
     "id": {
       "type": "string",
-      "value": "[resourceInfo('vpnsite').id]"
+      "value": "[resourceId('Microsoft.Network/vpnSites', parameters('vpnsitename'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3222260244803295673"
+      "templateHash": "3453376788904590022"
     }
   },
   "parameters": {
@@ -187,7 +187,7 @@
             "properties": {
               "addressPrefix": "[parameters('NATSubnetPrefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('natNsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('NATSubnetNSGName'))]"
               }
             }
           },
@@ -196,7 +196,7 @@
             "properties": {
               "addressPrefix": "[parameters('hyperVSubnetPrefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('hyperVNsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('hyperVSubnetNSGName'))]"
               }
             }
           },
@@ -205,7 +205,7 @@
             "properties": {
               "addressPrefix": "[parameters('ghostedSubnetPrefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('ghostedNsg').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('ghostedSubnetNSGName'))]"
               }
             }
           },
@@ -214,7 +214,7 @@
             "properties": {
               "addressPrefix": "[parameters('azureVMsSubnetPrefix')]",
               "networkSecurityGroup": {
-                "id": "[resourceInfo('azureVmsSubnet').id]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('azureVMsSubnetNSGName'))]"
               },
               "routeTable": {
                 "id": "[reference('createAzureVmUdr').outputs.udrId.value]"
@@ -298,7 +298,7 @@
     "vmExtension": {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2019-03-01",
-      "name": "[format('{0}/InstallWindowsFeatures', resourceInfo('hostVm').name)]",
+      "name": "[format('{0}/InstallWindowsFeatures', parameters('HostVirtualMachineName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Powershell",
@@ -321,7 +321,7 @@
     "hostVmSetupExtension": {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2019-03-01",
-      "name": "[format('{0}/HVHOSTSetup', resourceInfo('hostVm').name)]",
+      "name": "[format('{0}/HVHOSTSetup', parameters('HostVirtualMachineName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Compute",
@@ -355,10 +355,10 @@
             "value": "[parameters('HostNetworkInterface1Name')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, parameters('NATSubnetName'))]"
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('NATSubnetName'))]"
           },
           "pipId": {
-            "value": "[resourceInfo('publicIp').id]"
+            "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]"
           }
         },
         "template": {
@@ -370,7 +370,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3322466845026343883"
+              "templateHash": "833684061951102879"
             }
           },
           "parameters": {
@@ -433,7 +433,7 @@
           "outputs": {
             "nicId": {
               "type": "string",
-              "value": "[resourceInfo('nic').id]"
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             },
             "assignedIp": {
               "type": "string",
@@ -464,7 +464,7 @@
             "value": true
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, parameters('hyperVSubnetName'))]"
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('hyperVSubnetName'))]"
           }
         },
         "template": {
@@ -476,7 +476,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3322466845026343883"
+              "templateHash": "833684061951102879"
             }
           },
           "parameters": {
@@ -539,7 +539,7 @@
           "outputs": {
             "nicId": {
               "type": "string",
-              "value": "[resourceInfo('nic').id]"
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             },
             "assignedIp": {
               "type": "string",
@@ -572,10 +572,10 @@
             "value": "[parameters('HostNetworkInterface1Name')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, parameters('NATSubnetName'))]"
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('NATSubnetName'))]"
           },
           "pipId": {
-            "value": "[resourceInfo('publicIp').id]"
+            "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]"
           }
         },
         "template": {
@@ -587,7 +587,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3322466845026343883"
+              "templateHash": "833684061951102879"
             }
           },
           "parameters": {
@@ -650,7 +650,7 @@
           "outputs": {
             "nicId": {
               "type": "string",
-              "value": "[resourceInfo('nic').id]"
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             },
             "assignedIp": {
               "type": "string",
@@ -688,7 +688,7 @@
             "value": true
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/{1}', resourceInfo('vnet').id, parameters('hyperVSubnetName'))]"
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('hyperVSubnetName'))]"
           }
         },
         "template": {
@@ -700,7 +700,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "3322466845026343883"
+              "templateHash": "833684061951102879"
             }
           },
           "parameters": {
@@ -763,7 +763,7 @@
           "outputs": {
             "nicId": {
               "type": "string",
-              "value": "[resourceInfo('nic').id]"
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
             },
             "assignedIp": {
               "type": "string",
@@ -800,7 +800,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7458258094091755263"
+              "templateHash": "16856940868851518995"
             }
           },
           "parameters": {
@@ -834,7 +834,7 @@
           "outputs": {
             "udrId": {
               "type": "string",
-              "value": "[resourceInfo('udr').id]"
+              "value": "[resourceId('Microsoft.Network/routeTables', parameters('udrName'))]"
             }
           }
         }
@@ -869,7 +869,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7458258094091755263"
+              "templateHash": "16856940868851518995"
             }
           },
           "parameters": {
@@ -903,7 +903,7 @@
           "outputs": {
             "udrId": {
               "type": "string",
-              "value": "[resourceInfo('udr').id]"
+              "value": "[resourceId('Microsoft.Network/routeTables', parameters('udrName'))]"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/nic.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/nic.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3322466845026343883"
+      "templateHash": "833684061951102879"
     }
   },
   "parameters": {
@@ -70,7 +70,7 @@
   "outputs": {
     "nicId": {
       "type": "string",
-      "value": "[resourceInfo('nic').id]"
+      "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
     },
     "assignedIp": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/udr.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/udr.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7458258094091755263"
+      "templateHash": "16856940868851518995"
     }
   },
   "parameters": {
@@ -41,7 +41,7 @@
   "outputs": {
     "udrId": {
       "type": "string",
-      "value": "[resourceInfo('udr').id]"
+      "value": "[resourceId('Microsoft.Network/routeTables', parameters('udrName'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/publish-api-to-apim-opendocs/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/publish-api-to-apim-opendocs/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1704111063431546570"
+      "templateHash": "17875009690651459352"
     }
   },
   "parameters": {
@@ -125,8 +125,8 @@
       "copy": {
         "count": "[length(variables('productsSet'))]",
         "input": {
-          "productId": "[resourceInfo(format('ProductRecords[{0}]', copyIndex())).id]",
-          "productName": "[resourceInfo(format('ProductRecords[{0}]', copyIndex())).name]"
+          "productId": "[resourceId('Microsoft.ApiManagement/service/products', parameters('apimInstanceName'), variables('productsSet')[copyIndex()].productName)]",
+          "productName": "[variables('productsSet')[copyIndex()].productName]"
         }
       }
     }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/servicebus-namespace-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/servicebus-namespace-vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12967971239076179496"
+      "templateHash": "8254788634696027979"
     }
   },
   "parameters": {
@@ -86,9 +86,9 @@
     "namespaceVirtualNetworkRule": {
       "type": "Microsoft.ServiceBus/namespaces/virtualnetworkrules",
       "apiVersion": "2018-01-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('serviceBusNamespace').name, resourceInfo('virtualNetwork').name)]",
+      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('virtualNetworkName'))]",
       "properties": {
-        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', resourceInfo('virtualNetwork').name, parameters('subnetName'))]"
+        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'), parameters('subnetName'))]"
       },
       "dependsOn": [
         "serviceBusNamespace",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4310145193762195129"
+      "templateHash": "14854225228870243196"
     }
   },
   "parameters": {
@@ -61,7 +61,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5135248745203700679"
+              "templateHash": "6078679929449391574"
             }
           },
           "parameters": {
@@ -175,7 +175,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "5645417119312437986"
+                      "templateHash": "15779774648617518046"
                     }
                   },
                   "parameters": {
@@ -317,7 +317,7 @@
                           "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
                         },
                         "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
                       },
                       "dependsOn": [
                         "azureDefender",
@@ -391,7 +391,7 @@
                       "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('sqlLogicalServer').name, 'master')]",
                       "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
                       "properties": {
-                        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)]",
                         "logs": [
                           {
                             "category": "SQLSecurityAuditEvents",
@@ -435,7 +435,7 @@
                             }
                           }
                         ],
-                        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)]"
                       },
                       "dependsOn": [
                         "dummyDeployments",
@@ -540,7 +540,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "10681318813883397556"
+                              "templateHash": "4919674308990176848"
                             }
                           },
                           "parameters": {
@@ -630,7 +630,7 @@
                                   "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                                 },
                                 "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
                               },
                               "dependsOn": [
                                 "azureDefender",
@@ -654,7 +654,7 @@
                               "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1])]",
                               "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
                               "properties": {
-                                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                                "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]",
                                 "logs": [
                                   {
                                     "category": "SQLSecurityAuditEvents",
@@ -693,7 +693,7 @@
                                     }
                                   }
                                 ],
-                                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                                "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
                               },
                               "dependsOn": [
                                 "sqlDb",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10681318813883397556"
+      "templateHash": "4919674308990176848"
     }
   },
   "parameters": {
@@ -97,7 +97,7 @@
           "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
         },
         "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
       },
       "dependsOn": [
         "azureDefender",
@@ -121,7 +121,7 @@
       "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1])]",
       "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
       "properties": {
-        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]",
         "logs": [
           {
             "category": "SQLSecurityAuditEvents",
@@ -160,7 +160,7 @@
             }
           }
         ],
-        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
       },
       "dependsOn": [
         "sqlDb",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5645417119312437986"
+      "templateHash": "15779774648617518046"
     }
   },
   "parameters": {
@@ -149,7 +149,7 @@
           "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
         },
         "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
       },
       "dependsOn": [
         "azureDefender",
@@ -223,7 +223,7 @@
       "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('sqlLogicalServer').name, 'master')]",
       "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
       "properties": {
-        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)]",
         "logs": [
           {
             "category": "SQLSecurityAuditEvents",
@@ -267,7 +267,7 @@
             }
           }
         ],
-        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)]"
       },
       "dependsOn": [
         "dummyDeployments",
@@ -372,7 +372,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10681318813883397556"
+              "templateHash": "4919674308990176848"
             }
           },
           "parameters": {
@@ -462,7 +462,7 @@
                   "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                 },
                 "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
               },
               "dependsOn": [
                 "azureDefender",
@@ -486,7 +486,7 @@
               "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1])]",
               "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
               "properties": {
-                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]",
                 "logs": [
                   {
                     "category": "SQLSecurityAuditEvents",
@@ -525,7 +525,7 @@
                     }
                   }
                 ],
-                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
               },
               "dependsOn": [
                 "sqlDb",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5135248745203700679"
+      "templateHash": "6078679929449391574"
     }
   },
   "parameters": {
@@ -121,7 +121,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5645417119312437986"
+              "templateHash": "15779774648617518046"
             }
           },
           "parameters": {
@@ -263,7 +263,7 @@
                   "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
                 },
                 "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
               },
               "dependsOn": [
                 "azureDefender",
@@ -337,7 +337,7 @@
               "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('sqlLogicalServer').name, 'master')]",
               "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
               "properties": {
-                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)]",
                 "logs": [
                   {
                     "category": "SQLSecurityAuditEvents",
@@ -381,7 +381,7 @@
                     }
                   }
                 ],
-                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)]"
               },
               "dependsOn": [
                 "dummyDeployments",
@@ -486,7 +486,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "10681318813883397556"
+                      "templateHash": "4919674308990176848"
                     }
                   },
                   "parameters": {
@@ -576,7 +576,7 @@
                           "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                         },
                         "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
                       },
                       "dependsOn": [
                         "azureDefender",
@@ -600,7 +600,7 @@
                       "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1])]",
                       "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
                       "properties": {
-                        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]",
                         "logs": [
                           {
                             "category": "SQLSecurityAuditEvents",
@@ -639,7 +639,7 @@
                             }
                           }
                         ],
-                        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                        "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
                       },
                       "dependsOn": [
                         "sqlDb",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/web-app-managed-identity-sql-db/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/web-app-managed-identity-sql-db/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2734358218178251737"
+      "templateHash": "17037999912607815487"
     }
   },
   "parameters": {
@@ -73,7 +73,7 @@
     "sqlserverName_databaseName": {
       "type": "Microsoft.Sql/servers/databases",
       "apiVersion": "2020-08-01-preview",
-      "name": "[format('{0}/{1}', resourceInfo('sqlserver').name, variables('databaseName'))]",
+      "name": "[format('{0}/{1}', variables('sqlserverName'), variables('databaseName'))]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Basic"
@@ -89,7 +89,7 @@
     "sqlserverName_AllowAllWindowsAzureIps": {
       "type": "Microsoft.Sql/servers/firewallRules",
       "apiVersion": "2014-04-01",
-      "name": "[format('{0}/AllowAllWindowsAzureIps', resourceInfo('sqlserver').name)]",
+      "name": "[format('{0}/AllowAllWindowsAzureIps', variables('sqlserverName'))]",
       "properties": {
         "endIpAddress": "0.0.0.0",
         "startIpAddress": "0.0.0.0"
@@ -114,16 +114,16 @@
       "name": "[variables('webSiteName')]",
       "location": "[parameters('location')]",
       "tags": {
-        "[format('hidden-related:{0}', resourceInfo('hostingPlan').id)]": "empty",
+        "[format('hidden-related:{0}', resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName')))]": "empty",
         "displayName": "Website"
       },
       "properties": {
-        "serverFarmId": "[resourceInfo('hostingPlan').id]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
       },
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceInfo('msi').id)]": {}
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')))]": {}
         }
       },
       "dependsOn": [
@@ -134,7 +134,7 @@
     "webSiteConnectionStrings": {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/connectionstrings', resourceInfo('webSite').name)]",
+      "name": "[format('{0}/connectionstrings', variables('webSiteName'))]",
       "properties": {
         "DefaultConnection": {
           "value": "[format('Data Source=tcp:{0},1433;Initial Catalog={1};User Id={2}@{3};Password={4};', reference('sqlserver').fullyQualifiedDomainName, variables('databaseName'), parameters('sqlAdministratorLogin'), reference('sqlserver').fullyQualifiedDomainName, parameters('sqlAdministratorLoginPassword'))]",
@@ -168,10 +168,10 @@
     "AppInsights_webSiteName": {
       "type": "Microsoft.Insights/components",
       "apiVersion": "2018-05-01-preview",
-      "name": "[format('AppInsights{0}', resourceInfo('webSite').name)]",
+      "name": "[format('AppInsights{0}', variables('webSiteName'))]",
       "location": "[parameters('location')]",
       "tags": {
-        "[format('hidden-link:{0}', resourceInfo('webSite').id)]": "Resource",
+        "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('webSiteName')))]": "Resource",
         "displayName": "AppInsightsComponent"
       },
       "kind": "web",

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15123951157452680396"
+      "templateHash": "18070324715020214399"
     }
   },
   "parameters": {
@@ -64,7 +64,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4813262003843921725"
+              "templateHash": "14213653433535193735"
             }
           },
           "parameters": {
@@ -131,7 +131,7 @@
             },
             "kubeConfig": {
               "type": "string",
-              "value": "[listClusterAdminCredential(resourceInfo('aks').id, '2020-09-01').kubeconfigs[0].value]"
+              "value": "[listClusterAdminCredential(resourceId('Microsoft.ContainerService/managedClusters', parameters('baseName')), '2020-09-01').kubeconfigs[0].value]"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/aks.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/aks.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4813262003843921725"
+      "templateHash": "14213653433535193735"
     }
   },
   "parameters": {
@@ -74,7 +74,7 @@
     },
     "kubeConfig": {
       "type": "string",
-      "value": "[listClusterAdminCredential(resourceInfo('aks').id, '2020-09-01').kubeconfigs[0].value]"
+      "value": "[listClusterAdminCredential(resourceId('Microsoft.ContainerService/managedClusters', parameters('baseName')), '2020-09-01').kubeconfigs[0].value]"
     }
   }
 }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -10,7 +10,7 @@ namespace Bicep.Core.Emit
         {
             AssemblyFileVersion = features.AssemblyVersion;
             EnableSourceMapping = features.SourceMappingEnabled;
-            EnableSymbolicNames = features.ShouldEmitSymbolicNames();
+            EnableSymbolicNames = features.SymbolicNameCodegenEnabled || features.ExtensibilityEnabled || features.UserDefinedTypesEnabled;
         }
 
         /// <summary>

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -38,7 +38,7 @@ namespace Bicep.Core.Emit
 
             if (targetVariable is not null)
             {
-                // the functionality
+                // the functionality 
                 this.currentStack = ImmutableStack.Create<string>();
                 this.capturedSequence = null;
             }
@@ -204,7 +204,7 @@ namespace Bicep.Core.Emit
                 return;
             }
 
-            bool ShouldSkipInlining(ObjectType objectType, string propertyName, ResourceSymbol? resourceSymbol = null)
+            static bool ShouldSkipInlining(ObjectType objectType, string propertyName, ResourceSymbol? resourceSymbol = null)
             {
                 if (!objectType.Properties.TryGetValue(propertyName, out var propertyType))
                 {
@@ -215,16 +215,9 @@ namespace Bicep.Core.Emit
                 if (propertyType.Flags.HasFlag(TypePropertyFlags.DeployTimeConstant))
                 {
                     // TODO: Do we need to special case resource properties here?
-                    if (resourceSymbol is not null)
+                    if (resourceSymbol is not null &&
+                        !AzResourceTypeProvider.ReadWriteDeployTimeConstantPropertyNames.Contains(propertyName, LanguageConstants.IdentifierComparer))
                     {
-                        if (AzResourceTypeProvider.ReadWriteDeployTimeConstantPropertyNames.Contains(propertyName, LanguageConstants.IdentifierComparer) &&
-                            !model.Features.ShouldEmitSymbolicNames())
-                        {
-                            // For non-symbolic name scenarios, we are able to emit name, type, apiVersion & id properties directly, without introducing non-DTCs
-                            // For symbolic name scenarios, we instead use `resourceInfo('symbol').id`, which cannot be used when evaluating variables
-                            return true;
-                        }
-
                         // The property is not declared in the resource - we should inline event it is a deploy-time constant.
                         // We skip standardized properties (id, name, type, and apiVersion) since their values are always known
                         // and emitted if there are not syntactic and semantic errors (see ConvertResourcePropertyAccess in ExpressionConverter).

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -22,8 +22,5 @@ namespace Bicep.Core.Features
         bool ParamsFilesEnabled { get; }
 
         bool UserDefinedTypesEnabled { get; }
-
-        bool ShouldEmitSymbolicNames()
-            => SymbolicNameCodegenEnabled || ExtensibilityEnabled || UserDefinedTypesEnabled;
     }
 }


### PR DESCRIPTION
For symbolic-named resources we have the option of simplifying codegen by emitting expressions like `resourceInfo('symbolicName').id` using the `resourceInfo()` function. However, there are numerous cases where resourceInfo can & can't be used, and it's too difficult to try and address them all here. See https://github.com/Azure/bicep/issues/9450 & https://github.com/Azure/bicep/issues/9246 for examples.

This PR changes codegen to emit the more verbose expressions that we know work. It consists of a revert of #9298, followed by one small actual code change to `src/Bicep.Core/Emit/ExpressionConverter.cs` (and many baseline updates).

Closes #9450

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9458)