### PR TITLE
Published Bicep modules now include `artifactType` in the OCI manifest

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
@@ -22,6 +22,11 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Bicep.Core.Modules;
+using Bicep.Core.Registry.Oci;
+using Microsoft.WindowsAzure.ResourceStack.Common.Memory;
+using System.Text;
+using Bicep.Core.Emit;
 
 namespace Bicep.Cli.IntegrationTests
 {
@@ -72,6 +77,77 @@ namespace Bicep.Cli.IntegrationTests
             {
                 // ensure something got restored
                 settings.FeatureOverrides.Should().HaveValidModules();
+            }
+        }
+
+        /// <summary>
+        /// Validates that we can restore a module published by an older version of Bicep that did not set artifactType in the OCI manifest.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Restore_ArtifactWithoutArtifactType_ShouldSucceed()
+        {
+            var registry = "example.com";
+            var registryUri = new Uri("https://" + registry);
+            var repository = "hello/there";
+            var dataSet = DataSets.Empty;
+
+            var client = new MockRegistryBlobClient();
+
+            var clientFactory = StrictMock.Of<IContainerRegistryClientFactory>();
+            clientFactory.Setup(m => m.CreateAuthenticatedBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
+
+            var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
+
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
+
+            var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
+            Directory.CreateDirectory(tempDirectory);
+
+            var containerRegistryManager = new AzureContainerRegistryManager(clientFactory.Object);
+            var configuration = BicepTestConstants.BuiltInConfiguration;
+
+            using (var compiledStream = new BufferedMemoryStream())
+            {
+                OciArtifactModuleReference.TryParse(null, $"{registry}/{repository}:v1", configuration, new Uri("file:///main.bicep"), out var moduleReference, out _).Should().BeTrue();
+
+                compiledStream.Write(TemplateEmitter.UTF8EncodingWithoutBom.GetBytes(dataSet.Compiled!));
+                compiledStream.Position = 0;
+
+                await containerRegistryManager.PushArtifactAsync(
+                    configuration: configuration,
+                    moduleReference: moduleReference!,
+                    // intentionally setting artifactType to null to simulate a publish done by an older version of Bicep
+                    artifactType: null,
+                    config: new StreamDescriptor(Stream.Null, BicepMediaTypes.BicepModuleConfigV1),
+                    layers: new StreamDescriptor(compiledStream, BicepMediaTypes.BicepModuleLayerV1Json));
+            }
+
+            /*
+             * TODO: Publish via code
+             */
+
+            client.Blobs.Should().HaveCount(2);
+            client.Manifests.Should().HaveCount(1);
+            client.ManifestTags.Should().HaveCount(1);
+
+            string digest = client.Manifests.Single().Key;
+
+            var bicep = $@"
+module empty 'br:{registry}/{repository}@{digest}' = {{
+  name: 'empty'
+}}
+";
+
+            var restoreBicepFilePath = Path.Combine(tempDirectory, "restored.bicep");
+            File.WriteAllText(restoreBicepFilePath, bicep);
+
+            var (output, error, result) = await Bicep(settings, "restore", restoreBicepFilePath);
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
             }
         }
 

--- a/src/Bicep.Core.UnitTests/Assertions/MockRegistryAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/MockRegistryAssertions.cs
@@ -41,6 +41,8 @@ namespace Bicep.Core.UnitTests.Assertions
                 using var manifestStream = MockRegistryBlobClient.WriteStream(manifestBytes);
                 var manifest = OciSerialization.Deserialize<OciManifest>(manifestStream);
 
+                manifest.ArtifactType.Should().Be("application/vnd.ms.bicep.module.artifact", "artifact type should be correct");
+
                 var config = manifest.Config;
                 config.MediaType.Should().Be("application/vnd.ms.bicep.module.config.v1+json", "config media type should be correct");
                 config.Size.Should().Be(0, "config should be empty");

--- a/src/Bicep.Core/Registry/Oci/BicepMediaTypes.cs
+++ b/src/Bicep.Core/Registry/Oci/BicepMediaTypes.cs
@@ -9,6 +9,6 @@ namespace Bicep.Core.Registry.Oci
 
         public const string BicepModuleLayerV1Json = "application/vnd.ms.bicep.module.layer.v1+json";
 
-        public const string BicepModuleLayerV1Zip = "application/vnd.ms.bicep.module.layer.v1+zip";
+        public const string BicepModuleArtifactType = "application/vnd.ms.bicep.module.artifact";
     }
 }

--- a/src/Bicep.Core/Registry/Oci/OciManifest.cs
+++ b/src/Bicep.Core/Registry/Oci/OciManifest.cs
@@ -9,14 +9,17 @@ namespace Bicep.Core.Registry.Oci
     public class OciManifest
     {
         // TODO: Add top-level annotations
-        public OciManifest(int schemaVersion, OciDescriptor config, IEnumerable<OciDescriptor> layers)
+        public OciManifest(int schemaVersion, string? artifactType, OciDescriptor config, IEnumerable<OciDescriptor> layers)
         {
             this.SchemaVersion = schemaVersion;
+            this.ArtifactType = artifactType;
             this.Config = config;
             this.Layers = layers.ToImmutableArray();
         }
 
         public int SchemaVersion { get; }
+
+        public string? ArtifactType { get; }
 
         public OciDescriptor Config { get; }
 

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -120,7 +120,7 @@ namespace Bicep.Core.Registry
 
             try
             {
-                await this.client.PushArtifactAsync(configuration, moduleReference, config, layer);
+                await this.client.PushArtifactAsync(configuration, moduleReference, BicepMediaTypes.BicepModuleArtifactType, config, layer);
             }
             catch (AggregateException exception) when (CheckAllInnerExceptionsAreRequestFailures(exception))
             {


### PR DESCRIPTION
There is a new field in the OCI manifest called `artifactType` that will help us support completions for modules published to container registries. From now on, Bicep will include that field in the OCI manifests we generate. I've also added tests to ensure that modules published by versions of Bicep that don't set `artifactType` will restore as before.

Reference to OCI spec: https://github.com/opencontainers/image-spec/blob/main/artifact.md


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9520)