### PR TITLE
fix: nested functions not detected in strings

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -552,7 +552,7 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
                 updatedParam =>
                 {
                     updatedParam.name.Should().Be("deploymentLocation");
-                    updatedParam.value.Should().Be("concat('deploy-',resourceGroup().location)");
+                    updatedParam.value.Should().Be("concat('deploy-', resourceGroup().location)");
                     updatedParam.isMissingParam.Should().BeFalse();
                     updatedParam.isExpression.Should().BeTrue();
                     updatedParam.isSecure.Should().BeFalse();

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -484,6 +484,7 @@ param testProperties object";
         {
             var bicepFileContents = @"param location string = resourceGroup().location
 param deploymentLocation string = 'deploy-${resourceGroup().location}'
+param dataFactoryName string = 'datafactory${uniqueString(resourceGroup().id)}'
 param policyDefinitionId string = resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetworkName_var', 'subnet1Name')
 resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@2018-11-01-preview' = {
   name: 'name/policyArtifact'
@@ -511,6 +512,10 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
     ""deploymentLocation"": {
       ""type"": ""string"",
       ""defaultValue"": ""[concat('deploy-',resourceGroup().location)]""
+    },
+    ""dataFactoryName"": {
+        ""type"": ""string"",
+        ""defaultValue"": ""[format('datafactory{0}', uniqueString(resourceGroup().id))]""
     },
     ""policyDefinitionId"": {
       ""type"": ""string"",
@@ -548,6 +553,13 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
                 {
                     updatedParam.name.Should().Be("deploymentLocation");
                     updatedParam.value.Should().Be("concat('deploy-',resourceGroup().location)");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeTrue();
+                    updatedParam.isSecure.Should().BeFalse();
+                },
+                updatedParam => {
+                    updatedParam.name.Should().Be("dataFactoryName");
+                    updatedParam.value.Should().Be("format('datafactory{0}', uniqueString(resourceGroup().id))");
                     updatedParam.isMissingParam.Should().BeFalse();
                     updatedParam.isExpression.Should().BeTrue();
                     updatedParam.isSecure.Should().BeFalse();

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -483,6 +483,7 @@ param testProperties object";
         public async Task Handle_ParameterWithDefaultValuesOfTypeExpression_ShouldReturnUpdatedDeploymentParametersWithIsExpressionSetToTrue()
         {
             var bicepFileContents = @"param location string = resourceGroup().location
+param deploymentLocation string = 'deploy-${resourceGroup().location}'
 param policyDefinitionId string = resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetworkName_var', 'subnet1Name')
 resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@2018-11-01-preview' = {
   name: 'name/policyArtifact'
@@ -506,6 +507,10 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
     ""location"": {
       ""type"": ""string"",
       ""defaultValue"": ""[resourceGroup().location]""
+    },
+    ""deploymentLocation"": {
+      ""type"": ""string"",
+      ""defaultValue"": ""[concat('deploy-',resourceGroup().location)]""
     },
     ""policyDefinitionId"": {
       ""type"": ""string"",
@@ -535,6 +540,14 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
                 {
                     updatedParam.name.Should().Be("location");
                     updatedParam.value.Should().Be("resourceGroup().location");
+                    updatedParam.isMissingParam.Should().BeFalse();
+                    updatedParam.isExpression.Should().BeTrue();
+                    updatedParam.isSecure.Should().BeFalse();
+                },
+                updatedParam =>
+                {
+                    updatedParam.name.Should().Be("deploymentLocation");
+                    updatedParam.value.Should().Be("concat('deploy-',resourceGroup().location)");
                     updatedParam.isMissingParam.Should().BeFalse();
                     updatedParam.isExpression.Should().BeTrue();
                     updatedParam.isSecure.Should().BeFalse();

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentParametersHandlerTests.cs
@@ -552,7 +552,7 @@ resource blueprintName_policyArtifact 'Microsoft.Blueprint/blueprints/artifacts@
                 updatedParam =>
                 {
                     updatedParam.name.Should().Be("deploymentLocation");
-                    updatedParam.value.Should().Be("concat('deploy-', resourceGroup().location)");
+                    updatedParam.value.Should().Be("concat('deploy-',resourceGroup().location)");
                     updatedParam.isMissingParam.Should().BeFalse();
                     updatedParam.isExpression.Should().BeTrue();
                     updatedParam.isSecure.Should().BeFalse();

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -148,7 +148,10 @@ namespace Bicep.LanguageServer.Handlers
             return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
                 parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
                 expressionSyntax is not null &&
-                (expressionSyntax is not StringSyntax || expressionSyntax.IsInterpolated()) &&
+                (
+                    expressionSyntax is not StringSyntax ||
+                    expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated()
+                ) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (expressionSyntax is not StringSyntax specificationString || specificationString.IsInterpolated()) &&
+                (expressionSyntax is not StringSyntax specificationString || not specificationString.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,10 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (
-                    expressionSyntax is not StringSyntax ||
-                    expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated()
-                ) &&
+                (expressionSyntax is not StringSyntax || expressionSyntax.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated())
+                (expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (expressionSyntax is not StringSyntax specificationString || !specificationString.IsInterpolated()) &&
+                (expressionSyntax is not StringSyntax specificationString || specificationString.IsInterpolated()) && // (not a non-interpolated string literal)
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -148,7 +148,7 @@ namespace Bicep.LanguageServer.Handlers
             return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
                 parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
                 expressionSyntax is not null &&
-                (expressionSyntax is not StringSyntax || expressionSyntax is StringSyntax specificationString && not specificationString.IsInterpolated()) &&
+                (expressionSyntax is not StringSyntax || expressionSyntax.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -148,7 +148,7 @@ namespace Bicep.LanguageServer.Handlers
             return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
                 parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
                 expressionSyntax is not null &&
-                expressionSyntax is not StringSyntax &&  // This line is what is really causing the issue. Strings that contain ${} should be treated as expressions.
+                (expressionSyntax is not StringSyntax || specificationString.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (expressionSyntax is not StringSyntax || expressionSyntax.IsInterpolated()) &&
+                (expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated())
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -148,7 +148,7 @@ namespace Bicep.LanguageServer.Handlers
             return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
                 parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
                 expressionSyntax is not null &&
-                (expressionSyntax is not StringSyntax || specificationString.IsInterpolated()) &&
+                (expressionSyntax is not StringSyntax || expressionSyntax is StringSyntax specificationString && not specificationString.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -148,7 +148,7 @@ namespace Bicep.LanguageServer.Handlers
             return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
                 parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
                 expressionSyntax is not null &&
-                expressionSyntax is not StringSyntax &&
+                expressionSyntax is not StringSyntax &&  // This line is what is really causing the issue. Strings that contain ${} should be treated as expressions.
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated()) &&
+                (expressionSyntax is not StringSyntax specificationString || specificationString.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -148,6 +148,8 @@ namespace Bicep.LanguageServer.Handlers
             return modifier is ParameterDefaultValueSyntax parameterDefaultValueSyntax &&
                 parameterDefaultValueSyntax.DefaultValue is ExpressionSyntax expressionSyntax &&
                 expressionSyntax is not null &&
+                // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
+                // Fixes: https://github.com/Azure/bicep/issues/8154
                 (
                     expressionSyntax is not StringSyntax ||
                     expressionSyntax is StringSyntax specificationString && specificationString.IsInterpolated()

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentParametersHandler.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
                 expressionSyntax is not null &&
                 // Complex Evaluation of StringSyntax is required for nested functions like 'resource${uniqueString(resourceGroup().id)}'
                 // Fixes: https://github.com/Azure/bicep/issues/8154
-                (expressionSyntax is not StringSyntax specificationString || not specificationString.IsInterpolated()) &&
+                (expressionSyntax is not StringSyntax specificationString || !specificationString.IsInterpolated()) &&
                 expressionSyntax is not IntegerLiteralSyntax &&
                 expressionSyntax is not BooleanLiteralSyntax;
         }

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -27,7 +27,6 @@ import {
   BicepDeploymentWaitForCompletionParams,
   BicepUpdatedDeploymentParameter,
   ParametersFileUpdateOption,
-  ParameterType,
 } from "../language";
 import { AzLoginTreeItem } from "../tree/AzLoginTreeItem";
 import { AzManagementGroupTreeItem } from "../tree/AzManagementGroupTreeItem";
@@ -585,11 +584,7 @@ export class DeployCommand implements Command {
           placeHolder: `Please enter value for parameter "${paramName}"`,
         });
       } else {
-        if (
-          deploymentParameter.isExpression || 
-          (deploymentParameter.parameterType === ParameterType.String &&
-            deploymentParameter.value?.includes("${")))
-        {
+        if (deploymentParameter.isExpression ) {
           paramValue = await this.selectValueForParameterOfTypeExpression(
             _context,
             paramName,

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -584,7 +584,7 @@ export class DeployCommand implements Command {
           placeHolder: `Please enter value for parameter "${paramName}"`,
         });
       } else {
-        if (deploymentParameter.isExpression) {
+        if (deploymentParameter.isExpression || (deploymentParameter.parameterType.isString && contains(deploymentParameter.value, "${") {
           paramValue = await this.selectValueForParameterOfTypeExpression(
             _context,
             paramName,

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -585,7 +585,11 @@ export class DeployCommand implements Command {
           placeHolder: `Please enter value for parameter "${paramName}"`,
         });
       } else {
-        if (deploymentParameter.isExpression || (deploymentParameter.parameterType == ParameterType.String && deploymentParameter.value?.includes("${"))) {
+        if (
+          deploymentParameter.isExpression || 
+          (deploymentParameter.parameterType === ParameterType.String &&
+            deploymentParameter.value?.includes("${")))
+        {
           paramValue = await this.selectValueForParameterOfTypeExpression(
             _context,
             paramName,

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -584,7 +584,7 @@ export class DeployCommand implements Command {
           placeHolder: `Please enter value for parameter "${paramName}"`,
         });
       } else {
-        if (deploymentParameter.isExpression ) {
+        if (deploymentParameter.isExpression) {
           paramValue = await this.selectValueForParameterOfTypeExpression(
             _context,
             paramName,

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -27,6 +27,7 @@ import {
   BicepDeploymentWaitForCompletionParams,
   BicepUpdatedDeploymentParameter,
   ParametersFileUpdateOption,
+  ParameterType,
 } from "../language";
 import { AzLoginTreeItem } from "../tree/AzLoginTreeItem";
 import { AzManagementGroupTreeItem } from "../tree/AzManagementGroupTreeItem";
@@ -584,7 +585,7 @@ export class DeployCommand implements Command {
           placeHolder: `Please enter value for parameter "${paramName}"`,
         });
       } else {
-        if (deploymentParameter.isExpression || (deploymentParameter.parameterType.isString && contains(deploymentParameter.value, "${") {
+        if (deploymentParameter.isExpression || (deploymentParameter.parameterType == ParameterType.String && deploymentParameter.value?.includes("${"))) {
           paramValue = await this.selectValueForParameterOfTypeExpression(
             _context,
             paramName,


### PR DESCRIPTION
Fixes #8154 

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [x] This is a bug fix for an existing example
* [x] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [x] I have checked that all tests are passing by running `dotnet test`
* [x] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9587)