### PR TITLE
Emit a warning rather than an error when dereferencing a possibly null reference

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -416,7 +416,7 @@ output quux string = foos[0]!.bar.baz.quux
         var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, templateWithPossiblyNullDeref);
         result.Should().HaveDiagnostics(new []
         {
-          ("BCP318", DiagnosticLevel.Warning, @"The value of type ""null | { bar: { baz: { quux: 'quux' } } }"" may be null at deploy time, which would cause the deployment to fail."),
+          ("BCP318", DiagnosticLevel.Warning, @"The value of type ""null | { bar: { baz: { quux: 'quux' } } }"" may be null at the start of the deployment, which would cause this access expression (and the overall deployment with it) to fail."),
         });
         result.Diagnostics.Single().Should().BeAssignableTo<IFixable>();
         result.Diagnostics.Single().As<IFixable>().Fixes.Single().Should().HaveResult(templateWithPossiblyNullDeref, templateWithNonNullAssertion);

--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
@@ -400,23 +402,26 @@ param aDict {
     [TestMethod]
     public void Nullably_typed_values_can_be_used_as_nonnullable_outputs_with_postfix_assertion()
     {
-        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, @"
+        var templateWithPossiblyNullDeref = @"
 param foos (null | { bar: { baz: { quux: 'quux' } } })[]
 
 output quux string = foos[0].bar.baz.quux
-");
-
-        result.Should().HaveDiagnostics(new []
-        {
-          ("BCP055", DiagnosticLevel.Error, @"Cannot access properties of type ""null | { bar: { baz: { quux: 'quux' } } }"". An ""object"" type is required."),
-        });
-
-        result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, @"
+";
+        var templateWithNonNullAssertion = @"
 param foos (null | { bar: { baz: { quux: 'quux' } } })[]
 
 output quux string = foos[0]!.bar.baz.quux
-");
+";
 
+        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, templateWithPossiblyNullDeref);
+        result.Should().HaveDiagnostics(new []
+        {
+          ("BCP318", DiagnosticLevel.Warning, @"The value of type ""null | { bar: { baz: { quux: 'quux' } } }"" may be null at deploy time, which would cause the deployment to fail."),
+        });
+        result.Diagnostics.Single().Should().BeAssignableTo<IFixable>();
+        result.Diagnostics.Single().As<IFixable>().Fixes.Single().Should().HaveResult(templateWithPossiblyNullDeref, templateWithNonNullAssertion);
+
+        result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, templateWithNonNullAssertion);
         result.Should().NotHaveAnyDiagnostics();
         result.Should().HaveTemplateWithOutput("quux", "[parameters('foos')[0].bar.baz.quux]");
     }

--- a/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
@@ -160,6 +160,11 @@ namespace Bicep.Core.UnitTests.Diagnostics
                 return TestSyntaxFactory.CreateObject(Array.Empty<ObjectPropertySyntax>());
             }
 
+            if (parameter.ParameterType == typeof(SyntaxBase))
+            {
+                return TestSyntaxFactory.CreateVariableAccess("identifier");
+            }
+
             throw new AssertFailedException($"Unable to generate mock parameter value of type '{parameter.ParameterType}' for the diagnostic builder method.");
         }
 

--- a/src/Bicep.Core.UnitTests/Utils/TestSyntaxFactory.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestSyntaxFactory.cs
@@ -28,6 +28,8 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static IdentifierSyntax CreateIdentifier(string identifier) => new(CreateToken(TokenType.Identifier, identifier));
 
+        public static VariableAccessSyntax CreateVariableAccess(string identifier) => new(CreateIdentifier(identifier));
+
         public static ObjectPropertySyntax CreateProperty(string name, SyntaxBase value) => CreateProperty(CreateIdentifier(name), value);
 
         public static ObjectPropertySyntax CreateProperty(IdentifierSyntax name, SyntaxBase value) => new(name, CreateToken(TokenType.Colon), value);

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1816,11 +1816,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 DiagnosticLevel.Warning,
                 "BCP318",
-                $@"The value of type ""{possiblyNullType}"" may be null at deploy time, which would cause the deployment to fail.",
+                $@"The value of type ""{possiblyNullType}"" may be null at the start of the deployment, which would cause this access expression (and the overall deployment with it) to fail.",
                 documentationUri: null,
                 styling: DiagnosticStyling.Default,
                 fix: new(
-                    "If you know the value will not be null at deploy time, use a non-null assertion operator to inform the compiler that the value will not be null",
+                    "If you know the value will not be null at the start of the deployment, use a non-null assertion operator to inform the compiler that the value will not be null",
                     false,
                     CodeFixKind.QuickFix,
                     new(baseExpression.Span, SyntaxFactory.AsNonNullable(baseExpression).ToTextPreserveFormatting())));

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1811,6 +1811,19 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP317",
                 "Expected an identifier, a string, or an asterisk at this location.");
+
+            public FixableDiagnostic DereferenceOfPossiblyNullReference(string possiblyNullType, SyntaxBase baseExpression) => new(
+                TextSpan,
+                DiagnosticLevel.Warning,
+                "BCP318",
+                $@"The value of type ""{possiblyNullType}"" may be null at deploy time, which would cause the deployment to fail.",
+                documentationUri: null,
+                styling: DiagnosticStyling.Default,
+                fix: new(
+                    "If you know the value will not be null at deploy time, use a non-null assertion operator to inform the compiler that the value will not be null",
+                    false,
+                    CodeFixKind.QuickFix,
+                    new(baseExpression.Span, SyntaxFactory.AsNonNullable(baseExpression).ToTextPreserveFormatting())));
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -389,5 +389,11 @@ namespace Bicep.Core.Syntax
 
         public static Token CreateNewLineWithIndent(string indent) => GetNewlineToken(
             trailingTrivia: new SyntaxTrivia(SyntaxTriviaType.Whitespace, TextSpan.Nil, indent).AsEnumerable());
+
+        public static NonNullAssertionSyntax AsNonNullable(SyntaxBase @base) => @base switch
+        {
+            NonNullAssertionSyntax alreadyNonNull => alreadyNonNull,
+            _ => new NonNullAssertionSyntax(@base, ExclamationToken),
+        };
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -841,8 +841,14 @@ namespace Bicep.Core.TypeSystem
 
             return baseExpressionAssignment?.Reference switch
             {
-                DeferredTypeReference deferredType => new(new DeferredTypeReference(() => TypeHelper.RemoveNullability(deferredType.Type)), syntax, baseExpressionAssignment.Flags),
-                ITypeReference otherwise => new(TypeHelper.RemoveNullability(otherwise.Type), syntax, baseExpressionAssignment.Flags),
+                DeferredTypeReference deferredType => new(
+                    new DeferredTypeReference(() => TypeHelper.TryRemoveNullability(deferredType.Type) ?? deferredType.Type),
+                    syntax,
+                    baseExpressionAssignment.Flags),
+                ITypeReference otherwise => new(
+                    TypeHelper.TryRemoveNullability(otherwise.Type) ?? otherwise.Type,
+                    syntax,
+                    baseExpressionAssignment.Flags),
                 null => null,
             };
         }

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -337,13 +337,13 @@ namespace Bicep.Core.TypeSystem
         /// If the provided type is a union of <code>null</code> and one or more other types, this function will return a union with the <code>null</code>
         /// branch removed. For example, <code>null | string</code> would be transformed to <code>string</code>, and <code>null | string | int</code> would be
         /// transformed to <code>string | int</code>.
-        /// Otherwise, this method will return the input. Use <see cref="object.ReferenceEquals(object?, object?)" /> to determine whether this method created a new type.
+        /// Otherwise, this method will return null.
         /// </remarks>
-        public static TypeSymbol RemoveNullability(TypeSymbol type) => type switch
+        public static TypeSymbol? TryRemoveNullability(TypeSymbol type) => type switch
         {
             UnionType union when union.Members.Where(m => !ReferenceEquals(m.Type, LanguageConstants.Null)).ToImmutableArray() is {} sansNull &&
                 sansNull.Length < union.Members.Length => CreateTypeUnion(sansNull),
-            _ => type,
+            _ => null,
         };
 
         private static ImmutableArray<ITypeReference> NormalizeTypeList(IEnumerable<ITypeReference> unionMembers)


### PR DESCRIPTION
Resolves #9595 

This PR updates the `ArrayAccessSyntax` and `PropertyAccessSyntax` visitation methods in `TypeAssignmentVisitor` to handle nullably-typed base expressions as a special case. Where previously we would have emitted an error saying, "Cannot access properties of `null | <base type>`", the visitor will now detect when the base expression's type is nullable, emit a warning with a suggestion to use the `!` postfix operator, then retry the type assignment with the `null` variant stripped from the base expression's type.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9596)