### PR TITLE
Block expressions that generate nested references

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -616,7 +616,6 @@ output id string = mod[0].outputs.storage.id
 output name string = mod[0].outputs.storage.name
 output type string = mod[0].outputs.storage.type
 output apiVersion string = mod[0].outputs.storage.apiVersion
-output accessTier string = mod[0].outputs.storage.properties.accessTier
 
 "),
 ("module.bicep", @"
@@ -647,11 +646,6 @@ output storage resource = storage
             {
                 ["type"] = new JValue("string"),
                 ["value"] = new JValue("2019-06-01"),
-            });
-            result.Template.Should().HaveValueAtPath("$.outputs.accessTier", new JObject()
-            {
-                ["type"] = new JValue("string"),
-                ["value"] = new JValue("[reference(reference(resourceId('Microsoft.Resources/deployments', format('test-{0}', 0)), '2020-10-01').outputs.storage.value, '2019-06-01').accessTier]"),
             });
         }
 

--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -569,7 +569,6 @@ output id string = mod.outputs.storage.id
 output name string = mod.outputs.storage.name
 output type string = mod.outputs.storage.type
 output apiVersion string = mod.outputs.storage.apiVersion
-output accessTier string = mod.outputs.storage.properties.accessTier
 
 "),
 ("module.bicep", @"
@@ -600,11 +599,6 @@ output storage resource = storage
             {
                 ["type"] = new JValue("string"),
                 ["value"] = new JValue("2019-06-01"),
-            });
-            result.Template.Should().HaveValueAtPath("$.outputs.accessTier", new JObject()
-            {
-                ["type"] = new JValue("string"),
-                ["value"] = new JValue("[reference(reference(resourceId('Microsoft.Resources/deployments', 'test'), '2020-10-01').outputs.storage.value, '2019-06-01').accessTier]"),
             });
         }
 

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4173,5 +4173,37 @@ output fooAccess object = {
   ""apiVersion"": ""2022-09-01""
 }"));
         }
+
+        // https://github.com/Azure/bicep/issues/6065
+        [TestMethod]
+        public void Test_Issue6065()
+        {
+            var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(ResourceTypedParamsAndOutputsEnabled: true)),
+("main.bicep", @"
+module mymodule 'test.bicep' = {
+  name: 'mymodule'
+}
+
+resource myresource 'Microsoft.Sql/servers@2021-08-01-preview' = {
+  name: 'myothersql'
+  location: resourceGroup().location
+  properties: {
+    administratorLogin: mymodule.outputs.sql.properties.administratorLogin
+  }
+}
+"),
+("test.bicep", @"
+resource sql 'Microsoft.Sql/servers@2021-08-01-preview' existing = {
+  name: 'mysql'
+}
+
+output sql resource = sql
+"));
+
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+            {
+                ("BCP320", DiagnosticLevel.Error, "The properties of module output resources cannot be accessed directly. To use the properties of this resource, pass it as a resource-typed parameter to another module and access the parameter's properties therein."),
+            });
+        }
     }
 }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1814,6 +1814,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP319",
                 $@"The type at ""{errorSource}"" could not be resolved by the ARM JSON template engine. Original error message: ""{message}""");
+
+            public ErrorDiagnostic ModuleOutputResourcePropertyAccessDetected() => new(
+                TextSpan,
+                "BCP320",
+                "The properties of module output resources cannot be accessed directly. To use the properties of this resource, pass it as a resource-typed parameter to another module and access the parameter's properties therein.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -33,13 +33,12 @@ namespace Bicep.Core.TypeSystem.Az
          * The following top-level properties must be set deploy-time constant values,
          * and it is safe to read them at deploy-time because their values cannot be changed.
          */
-        public static readonly string[] ReadWriteDeployTimeConstantPropertyNames = new[]
-        {
-            ResourceIdPropertyName,
-            ResourceNamePropertyName,
-            ResourceTypePropertyName,
-            ResourceApiVersionPropertyName,
-        };
+        public static readonly ImmutableSortedSet<string> ReadWriteDeployTimeConstantPropertyNames
+            = ImmutableSortedSet.Create(LanguageConstants.IdentifierComparer,
+                ResourceIdPropertyName,
+                ResourceNamePropertyName,
+                ResourceTypePropertyName,
+                ResourceApiVersionPropertyName);
 
         /*
          * The following top-level properties must be set deploy-time constant values


### PR DESCRIPTION
Resolves #6065

This PR raises an error diagnostic when module output resource property access would generate a reference expression within a reference expression (e.g., the `[reference(reference(resourceId('Microsoft.Resources/deployments', 'mymodule'), '2020-10-01').outputs.sql.value, '2021-08-01-preview').administratorLogin]` ARM expression compiled from `mymodule.outputs.sql.properties.administratorLogin` in the example in #6065).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9646)