### PR TITLE
Emit a warning rather than an error when nullability alone will prevent an assignment

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4230,7 +4230,7 @@ resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
             result.Template.Should().NotBeNull();
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
             {
-                ("BCP033", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
+                ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
             });
 
             result.ExcludingLinterDiagnostics().Diagnostics.Single().Should().BeAssignableTo<IFixable>();

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4230,7 +4230,7 @@ resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
             result.Template.Should().NotBeNull();
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
             {
-                ("BCP321", DiagnosticLevel.Warning, @"The value of type ""null | string"" may be null at the start of the deployment, which would cause this assignment (and the overall deployment with it) to fail."),
+                ("BCP033", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
             });
 
             result.ExcludingLinterDiagnostics().Diagnostics.Single().Should().BeAssignableTo<IFixable>();

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1816,12 +1816,14 @@ namespace Bicep.Core.Diagnostics
                 "BCP320",
                 "The properties of module output resources cannot be accessed directly. To use the properties of this resource, pass it as a resource-typed parameter to another module and access the parameter's properties therein.");
 
-            public FixableDiagnostic PossibleNullReferenceAssignment(TypeSymbol expectedType, TypeSymbol actualType, SyntaxBase expression)
-            {
-                var typeMismatchDiagnostic = ExpectedValueTypeMismatch(true, expectedType, actualType);
-
-                return new(TextSpan, typeMismatchDiagnostic.Level, typeMismatchDiagnostic.Code, typeMismatchDiagnostic.Message, typeMismatchDiagnostic.Uri, typeMismatchDiagnostic.Styling, AsNonNullable(expression));
-            }
+            public FixableDiagnostic PossibleNullReferenceAssignment(TypeSymbol expectedType, TypeSymbol actualType, SyntaxBase expression) => new(
+                TextSpan,
+                DiagnosticLevel.Warning,
+                "BCP321",
+                $"Expected a value of type \"{expectedType}\" but the provided value is of type \"{actualType}\".",
+                documentationUri: null,
+                styling: DiagnosticStyling.Default,
+                fix: AsNonNullable(expression));
 
             private static CodeFix AsNonNullable(SyntaxBase expression) => new(
                 "If you know the value will not be null, use a non-null assertion operator to inform the compiler that the value will not be null",

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1824,7 +1824,7 @@ namespace Bicep.Core.Diagnostics
             }
 
             private static CodeFix AsNonNullable(SyntaxBase expression) => new(
-                "If you know the value will not be null, use a non-null assertion operator to override the ",
+                "If you know the value will not be null, use a non-null assertion operator to inform the compiler that the value will not be null",
                 false,
                 CodeFixKind.QuickFix,
                 new(expression.Span, SyntaxFactory.AsNonNullable(expression).ToTextPreserveFormatting()));

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1819,6 +1819,19 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP320",
                 "The properties of module output resources cannot be accessed directly. To use the properties of this resource, pass it as a resource-typed parameter to another module and access the parameter's properties therein.");
+
+            public FixableDiagnostic PossibleNullReferenceAssignment(string possiblyNullType, SyntaxBase baseExpression) => new(
+                TextSpan,
+                DiagnosticLevel.Warning,
+                "BCP321",
+                $@"The value of type ""{possiblyNullType}"" may be null at the start of the deployment, which would cause this assignment (and the overall deployment with it) to fail.",
+                documentationUri: null,
+                styling: DiagnosticStyling.Default,
+                fix: new(
+                    "If you know the value will not be null at the start of the deployment, use a non-null assertion operator to inform the compiler that the value will not be null",
+                    false,
+                    CodeFixKind.QuickFix,
+                    new(baseExpression.Span, SyntaxFactory.AsNonNullable(baseExpression).ToTextPreserveFormatting())));
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -272,7 +272,7 @@ namespace Bicep.Core.TypeSystem
             {
                 if (TypeHelper.TryRemoveNullability(expressionType) is TypeSymbol nonNullableExpressionType && AreTypesAssignable(nonNullableExpressionType, targetType))
                 {
-                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).PossibleNullReferenceAssignment(expressionType.Type.Name, expression));
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).PossibleNullReferenceAssignment(targetType, expressionType.Type, expression));
                     return NarrowType(config, expression, nonNullableExpressionType, targetType);
                 }
 

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -270,6 +270,12 @@ namespace Bicep.Core.TypeSystem
             // basic assignability check
             if (AreTypesAssignable(expressionType, targetType) == false)
             {
+                if (TypeHelper.TryRemoveNullability(expressionType) is TypeSymbol nonNullableExpressionType && AreTypesAssignable(nonNullableExpressionType, targetType))
+                {
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).PossibleNullReferenceAssignment(expressionType.Type.Name, expression));
+                    return NarrowType(config, expression, nonNullableExpressionType, targetType);
+                }
+
                 // fundamentally different types - cannot assign
                 if (config.OnTypeMismatch is not null)
                 {


### PR DESCRIPTION
Resolves #9653 

This PR updates the type narrowing flow to emit a warning with a quickfix when the expression provided for a property expecting `<type>` instead received `<type> | null`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9654)