### PR TITLE
Updating Azure.Bicep.Types.Az version for Bicep Release 0.14.0

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1976,7 +1976,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1802,7 +1802,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -52,10 +52,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1739,7 +1739,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1976,7 +1976,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Core.Samples/Files/Completions/resourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/Completions/resourceTypes.json
@@ -92,7 +92,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cd",
+    "sortText": "000000cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -113,7 +113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ce",
+    "sortText": "000000d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -134,7 +134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cf",
+    "sortText": "000000d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -155,7 +155,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d0",
+    "sortText": "000000d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -176,7 +176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d1",
+    "sortText": "000000d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -197,7 +197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d2",
+    "sortText": "000000d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -218,7 +218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d3",
+    "sortText": "000000d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -239,7 +239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d4",
+    "sortText": "000000d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -260,7 +260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d5",
+    "sortText": "000000d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -281,7 +281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d6",
+    "sortText": "000000d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -302,7 +302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d7",
+    "sortText": "000000d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -323,7 +323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d8",
+    "sortText": "000000da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -344,7 +344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d9",
+    "sortText": "000000db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -365,7 +365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000da",
+    "sortText": "000000dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -386,7 +386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000db",
+    "sortText": "000000dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -407,7 +407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000dc",
+    "sortText": "000000de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -428,7 +428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000dd",
+    "sortText": "000000df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -449,7 +449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000de",
+    "sortText": "000000e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -470,7 +470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000df",
+    "sortText": "000000e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -491,7 +491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e0",
+    "sortText": "000000e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -512,7 +512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e1",
+    "sortText": "000000e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -533,7 +533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e2",
+    "sortText": "000000e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -554,7 +554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e3",
+    "sortText": "000000e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -756,11 +756,11 @@
     }
   },
   {
-    "label": "'Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions'",
+    "label": "'Microsoft.AgFoodPlatform/farmBeats/solutions'",
     "kind": "class",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions`  \n`"
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeats/solutions`  \n`"
     },
     "deprecated": false,
     "preselect": false,
@@ -769,7 +769,49 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
+      "newText": "'Microsoft.AgFoodPlatform/farmBeats/solutions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000013",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
       "newText": "'Microsoft.AgFoodPlatform/farmBeatsExtensionDefinitions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AgFoodPlatform/farmBeatsSolutionDefinitions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AgFoodPlatform/farmBeatsSolutionDefinitions`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000014",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AgFoodPlatform/farmBeatsSolutionDefinitions@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -785,7 +827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000013",
+    "sortText": "00000015",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -806,7 +848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000014",
+    "sortText": "00000016",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -827,7 +869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000015",
+    "sortText": "00000017",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -848,7 +890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000017",
+    "sortText": "00000019",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -869,7 +911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000018",
+    "sortText": "0000001a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -890,7 +932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000019",
+    "sortText": "0000001b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -911,7 +953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001a",
+    "sortText": "0000001c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -932,7 +974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001b",
+    "sortText": "0000001d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -953,7 +995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002a",
+    "sortText": "0000002c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -974,7 +1016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001c",
+    "sortText": "0000001e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -995,7 +1037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001d",
+    "sortText": "0000001f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1016,7 +1058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001e",
+    "sortText": "00000020",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1037,7 +1079,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001f",
+    "sortText": "00000021",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1058,7 +1100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000020",
+    "sortText": "00000022",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1079,7 +1121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000021",
+    "sortText": "00000023",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1100,7 +1142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000022",
+    "sortText": "00000024",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1121,7 +1163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000023",
+    "sortText": "00000025",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1142,7 +1184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000024",
+    "sortText": "00000026",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1163,7 +1205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000025",
+    "sortText": "00000027",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1184,7 +1226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000026",
+    "sortText": "00000028",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1205,7 +1247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000027",
+    "sortText": "00000029",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1226,7 +1268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000028",
+    "sortText": "0000002a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1247,7 +1289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000029",
+    "sortText": "0000002b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1268,7 +1310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002b",
+    "sortText": "0000002d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1289,7 +1331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002c",
+    "sortText": "0000002e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1310,7 +1352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002d",
+    "sortText": "0000002f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1331,7 +1373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002e",
+    "sortText": "00000030",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1352,7 +1394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002f",
+    "sortText": "00000031",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1373,7 +1415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000030",
+    "sortText": "00000032",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1394,7 +1436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000031",
+    "sortText": "00000033",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1415,7 +1457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000032",
+    "sortText": "00000034",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1436,7 +1478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000033",
+    "sortText": "00000035",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1457,7 +1499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000034",
+    "sortText": "00000036",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1478,7 +1520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000035",
+    "sortText": "00000037",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1499,7 +1541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000036",
+    "sortText": "00000038",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1520,7 +1562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000037",
+    "sortText": "00000039",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1541,7 +1583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000038",
+    "sortText": "0000003a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1562,7 +1604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000039",
+    "sortText": "0000003b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1583,7 +1625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003a",
+    "sortText": "0000003c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1604,7 +1646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003b",
+    "sortText": "0000003d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1625,7 +1667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003c",
+    "sortText": "0000003e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1646,7 +1688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003d",
+    "sortText": "0000003f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1667,7 +1709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003e",
+    "sortText": "00000040",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1688,7 +1730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003f",
+    "sortText": "00000041",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1709,7 +1751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000040",
+    "sortText": "00000042",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1730,7 +1772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000041",
+    "sortText": "00000043",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1751,7 +1793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000042",
+    "sortText": "00000044",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1772,7 +1814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000043",
+    "sortText": "00000045",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1793,7 +1835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000044",
+    "sortText": "00000046",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1814,7 +1856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000045",
+    "sortText": "00000047",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1835,7 +1877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000047",
+    "sortText": "00000049",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1856,7 +1898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000046",
+    "sortText": "00000048",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1877,7 +1919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000048",
+    "sortText": "0000004a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1898,7 +1940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000049",
+    "sortText": "0000004b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1919,7 +1961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004a",
+    "sortText": "0000004c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1940,7 +1982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004b",
+    "sortText": "0000004d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1961,7 +2003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004c",
+    "sortText": "0000004e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1982,7 +2024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004d",
+    "sortText": "0000004f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2003,7 +2045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004e",
+    "sortText": "00000050",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2024,7 +2066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004f",
+    "sortText": "00000051",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2045,7 +2087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000050",
+    "sortText": "00000052",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2066,7 +2108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000051",
+    "sortText": "00000053",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2087,7 +2129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000052",
+    "sortText": "00000054",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2108,7 +2150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000053",
+    "sortText": "00000055",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2129,7 +2171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000054",
+    "sortText": "00000056",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2150,7 +2192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000055",
+    "sortText": "00000057",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2171,7 +2213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000056",
+    "sortText": "00000058",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2192,7 +2234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000057",
+    "sortText": "00000059",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2213,7 +2255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000058",
+    "sortText": "0000005a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2234,7 +2276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000059",
+    "sortText": "0000005b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2255,7 +2297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005a",
+    "sortText": "0000005c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2276,7 +2318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005b",
+    "sortText": "0000005d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2297,7 +2339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005c",
+    "sortText": "0000005e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2318,7 +2360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005d",
+    "sortText": "0000005f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2339,7 +2381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005e",
+    "sortText": "00000060",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2360,7 +2402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005f",
+    "sortText": "00000061",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2381,7 +2423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000060",
+    "sortText": "00000062",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2402,7 +2444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000061",
+    "sortText": "00000063",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2423,7 +2465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000062",
+    "sortText": "00000064",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2444,7 +2486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000063",
+    "sortText": "00000065",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2465,7 +2507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000064",
+    "sortText": "00000066",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2486,7 +2528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000065",
+    "sortText": "00000067",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2507,7 +2549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000066",
+    "sortText": "00000068",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2528,7 +2570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000067",
+    "sortText": "00000069",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2549,7 +2591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000068",
+    "sortText": "0000006a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2570,7 +2612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000069",
+    "sortText": "0000006b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2591,7 +2633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006a",
+    "sortText": "0000006c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2612,7 +2654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006b",
+    "sortText": "0000006d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2633,7 +2675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006c",
+    "sortText": "0000006e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2654,7 +2696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006d",
+    "sortText": "0000006f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2675,7 +2717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006e",
+    "sortText": "00000070",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2696,7 +2738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006f",
+    "sortText": "00000071",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2717,7 +2759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000070",
+    "sortText": "00000072",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2738,7 +2780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000071",
+    "sortText": "00000073",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2759,7 +2801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000087",
+    "sortText": "00000089",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2780,7 +2822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000072",
+    "sortText": "00000074",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2801,7 +2843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000073",
+    "sortText": "00000075",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2822,7 +2864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000074",
+    "sortText": "00000076",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2843,7 +2885,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000075",
+    "sortText": "00000077",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2864,7 +2906,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000076",
+    "sortText": "00000078",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2885,7 +2927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000077",
+    "sortText": "00000079",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2906,7 +2948,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000078",
+    "sortText": "0000007a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2927,7 +2969,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000079",
+    "sortText": "0000007b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2948,7 +2990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007a",
+    "sortText": "0000007c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2969,7 +3011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007b",
+    "sortText": "0000007d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2990,7 +3032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007c",
+    "sortText": "0000007e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3011,7 +3053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007d",
+    "sortText": "0000007f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3032,7 +3074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007e",
+    "sortText": "00000080",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3053,7 +3095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007f",
+    "sortText": "00000081",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3074,7 +3116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000080",
+    "sortText": "00000082",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3095,7 +3137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000081",
+    "sortText": "00000083",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3116,7 +3158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000082",
+    "sortText": "00000084",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3137,7 +3179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000083",
+    "sortText": "00000085",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3158,7 +3200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000084",
+    "sortText": "00000086",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3179,7 +3221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000085",
+    "sortText": "00000087",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3200,7 +3242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000086",
+    "sortText": "00000088",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3221,7 +3263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000088",
+    "sortText": "0000008a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3242,7 +3284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000089",
+    "sortText": "0000008b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3263,7 +3305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008a",
+    "sortText": "0000008c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3284,7 +3326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008b",
+    "sortText": "0000008d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3305,7 +3347,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008c",
+    "sortText": "0000008e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3326,7 +3368,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008d",
+    "sortText": "0000008f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3347,7 +3389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008e",
+    "sortText": "00000090",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3368,7 +3410,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008f",
+    "sortText": "00000091",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3389,7 +3431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000090",
+    "sortText": "00000092",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3410,7 +3452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000091",
+    "sortText": "00000093",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3431,7 +3473,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000092",
+    "sortText": "00000094",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3452,7 +3494,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000093",
+    "sortText": "00000095",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3473,7 +3515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000094",
+    "sortText": "00000096",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3494,7 +3536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000095",
+    "sortText": "00000097",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3515,7 +3557,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000096",
+    "sortText": "00000098",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3536,7 +3578,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000097",
+    "sortText": "00000099",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3557,7 +3599,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000099",
+    "sortText": "0000009b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3578,7 +3620,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009b",
+    "sortText": "0000009d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3599,7 +3641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009c",
+    "sortText": "0000009e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3620,7 +3662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000098",
+    "sortText": "0000009a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3641,7 +3683,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009a",
+    "sortText": "0000009c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3662,7 +3704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009d",
+    "sortText": "0000009f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3683,7 +3725,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009e",
+    "sortText": "000000a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3704,7 +3746,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009f",
+    "sortText": "000000a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3725,7 +3767,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a0",
+    "sortText": "000000a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3746,7 +3788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a2",
+    "sortText": "000000a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3767,7 +3809,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a1",
+    "sortText": "000000a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3788,7 +3830,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a3",
+    "sortText": "000000a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3809,7 +3851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a4",
+    "sortText": "000000a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3830,7 +3872,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a5",
+    "sortText": "000000a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3851,7 +3893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a6",
+    "sortText": "000000a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3872,7 +3914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a7",
+    "sortText": "000000a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3893,7 +3935,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a8",
+    "sortText": "000000aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3914,7 +3956,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a9",
+    "sortText": "000000ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3935,7 +3977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000aa",
+    "sortText": "000000ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3956,7 +3998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ab",
+    "sortText": "000000ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3977,7 +4019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ac",
+    "sortText": "000000ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3998,7 +4040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ad",
+    "sortText": "000000af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4019,7 +4061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ae",
+    "sortText": "000000b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4040,7 +4082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000af",
+    "sortText": "000000b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4061,7 +4103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b0",
+    "sortText": "000000b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4082,7 +4124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b1",
+    "sortText": "000000b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4103,7 +4145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b2",
+    "sortText": "000000b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4124,7 +4166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b3",
+    "sortText": "000000b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4145,7 +4187,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b4",
+    "sortText": "000000b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4166,7 +4208,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b6",
+    "sortText": "000000b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4187,7 +4229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b5",
+    "sortText": "000000b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4208,7 +4250,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b7",
+    "sortText": "000000b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4229,7 +4271,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b8",
+    "sortText": "000000ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4250,7 +4292,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b9",
+    "sortText": "000000bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4271,7 +4313,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bb",
+    "sortText": "000000bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4292,7 +4334,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ba",
+    "sortText": "000000bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4313,7 +4355,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bc",
+    "sortText": "000000be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4334,7 +4376,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bd",
+    "sortText": "000000bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4355,7 +4397,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000be",
+    "sortText": "000000c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4376,7 +4418,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bf",
+    "sortText": "000000c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4397,7 +4439,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c0",
+    "sortText": "000000c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4418,7 +4460,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c1",
+    "sortText": "000000c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4439,7 +4481,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c2",
+    "sortText": "000000c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4460,7 +4502,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c3",
+    "sortText": "000000c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4481,7 +4523,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c4",
+    "sortText": "000000c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4502,7 +4544,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c5",
+    "sortText": "000000c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4523,7 +4565,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c6",
+    "sortText": "000000c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4544,7 +4586,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c7",
+    "sortText": "000000c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4565,7 +4607,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c8",
+    "sortText": "000000ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4586,7 +4628,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c9",
+    "sortText": "000000cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4607,7 +4649,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ca",
+    "sortText": "000000cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4628,7 +4670,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cb",
+    "sortText": "000000cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4649,7 +4691,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cc",
+    "sortText": "000000ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4670,7 +4712,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e4",
+    "sortText": "000000e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4691,7 +4733,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e5",
+    "sortText": "000000e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4712,7 +4754,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e6",
+    "sortText": "000000e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4733,7 +4775,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e7",
+    "sortText": "000000e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4754,7 +4796,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e8",
+    "sortText": "000000ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4775,7 +4817,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e9",
+    "sortText": "000000eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4796,12 +4838,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ea",
+    "sortText": "000000ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.AzureArcData/sqlServerInstances@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureArcData/sqlServerInstances/databases'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureArcData/sqlServerInstances/databases`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000000ed",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureArcData/sqlServerInstances/databases@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -4817,7 +4880,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000eb",
+    "sortText": "000000ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4838,7 +4901,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ec",
+    "sortText": "000000ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4859,7 +4922,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ed",
+    "sortText": "000000f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4880,7 +4943,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ee",
+    "sortText": "000000f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4901,7 +4964,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ef",
+    "sortText": "000000f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4922,7 +4985,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f0",
+    "sortText": "000000f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4943,7 +5006,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f1",
+    "sortText": "000000f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4964,7 +5027,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f2",
+    "sortText": "000000f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4985,7 +5048,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f3",
+    "sortText": "000000f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5006,7 +5069,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f4",
+    "sortText": "000000f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5027,7 +5090,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f5",
+    "sortText": "000000f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5048,7 +5111,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f6",
+    "sortText": "000000f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5069,7 +5132,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f7",
+    "sortText": "000000fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5090,7 +5153,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fa",
+    "sortText": "000000fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5111,7 +5174,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f8",
+    "sortText": "000000fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5132,7 +5195,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f9",
+    "sortText": "000000fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5153,7 +5216,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fb",
+    "sortText": "000000fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5174,7 +5237,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fc",
+    "sortText": "000000ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5195,7 +5258,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fd",
+    "sortText": "00000100",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5216,7 +5279,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fe",
+    "sortText": "00000101",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5237,7 +5300,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000101",
+    "sortText": "00000104",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5258,7 +5321,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000102",
+    "sortText": "00000105",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5279,7 +5342,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000103",
+    "sortText": "00000106",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5300,7 +5363,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ff",
+    "sortText": "00000102",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5321,7 +5384,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000100",
+    "sortText": "00000103",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5342,7 +5405,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000104",
+    "sortText": "00000107",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5363,7 +5426,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000105",
+    "sortText": "00000108",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5384,7 +5447,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000106",
+    "sortText": "00000109",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5405,7 +5468,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000107",
+    "sortText": "0000010a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5426,7 +5489,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000108",
+    "sortText": "0000010b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5447,7 +5510,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000109",
+    "sortText": "0000010c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5468,7 +5531,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010a",
+    "sortText": "0000010d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5489,7 +5552,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010b",
+    "sortText": "0000010e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5510,7 +5573,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010c",
+    "sortText": "0000010f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5531,7 +5594,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010d",
+    "sortText": "00000110",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5552,7 +5615,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010e",
+    "sortText": "00000111",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5573,7 +5636,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010f",
+    "sortText": "00000112",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5594,7 +5657,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000110",
+    "sortText": "00000113",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5615,7 +5678,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000111",
+    "sortText": "00000114",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5636,7 +5699,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000112",
+    "sortText": "00000115",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5657,7 +5720,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000113",
+    "sortText": "00000116",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5678,7 +5741,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000114",
+    "sortText": "00000117",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5699,7 +5762,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000115",
+    "sortText": "00000118",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5720,7 +5783,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000116",
+    "sortText": "00000119",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5741,7 +5804,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000117",
+    "sortText": "0000011a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5762,7 +5825,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000118",
+    "sortText": "0000011b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5783,7 +5846,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000119",
+    "sortText": "0000011c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5804,7 +5867,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011a",
+    "sortText": "0000011d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5825,7 +5888,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011b",
+    "sortText": "0000011e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5846,7 +5909,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011c",
+    "sortText": "0000011f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5867,7 +5930,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011e",
+    "sortText": "00000121",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5888,7 +5951,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011f",
+    "sortText": "00000122",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5909,7 +5972,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000120",
+    "sortText": "00000123",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5930,7 +5993,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000121",
+    "sortText": "00000124",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5951,7 +6014,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000122",
+    "sortText": "00000125",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5972,7 +6035,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011d",
+    "sortText": "00000120",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5993,7 +6056,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000123",
+    "sortText": "00000126",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6014,7 +6077,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000124",
+    "sortText": "00000127",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6035,7 +6098,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000125",
+    "sortText": "00000128",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6056,7 +6119,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000126",
+    "sortText": "00000129",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6077,7 +6140,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000127",
+    "sortText": "0000012a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6098,7 +6161,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000128",
+    "sortText": "0000012b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6119,7 +6182,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000129",
+    "sortText": "0000012c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6140,7 +6203,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012a",
+    "sortText": "0000012d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6161,7 +6224,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012b",
+    "sortText": "0000012e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6182,7 +6245,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012c",
+    "sortText": "0000012f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6203,7 +6266,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012d",
+    "sortText": "00000130",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6224,7 +6287,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012e",
+    "sortText": "00000131",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6245,7 +6308,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012f",
+    "sortText": "00000132",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6266,7 +6329,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000130",
+    "sortText": "00000133",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6287,7 +6350,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000131",
+    "sortText": "00000134",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6308,7 +6371,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000132",
+    "sortText": "00000135",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6329,7 +6392,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000133",
+    "sortText": "00000136",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6350,7 +6413,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000135",
+    "sortText": "00000138",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6371,7 +6434,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000136",
+    "sortText": "00000139",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6392,7 +6455,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000137",
+    "sortText": "0000013a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6413,7 +6476,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000134",
+    "sortText": "00000137",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6434,7 +6497,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000138",
+    "sortText": "0000013b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6455,7 +6518,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000139",
+    "sortText": "0000013c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6476,7 +6539,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013a",
+    "sortText": "0000013d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6497,7 +6560,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013b",
+    "sortText": "0000013e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6518,7 +6581,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013c",
+    "sortText": "0000013f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6539,7 +6602,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013d",
+    "sortText": "00000140",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6560,7 +6623,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013e",
+    "sortText": "00000141",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6581,7 +6644,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013f",
+    "sortText": "00000142",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6602,7 +6665,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000140",
+    "sortText": "00000143",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6623,7 +6686,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000141",
+    "sortText": "00000144",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6644,7 +6707,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000142",
+    "sortText": "00000145",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6665,7 +6728,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000143",
+    "sortText": "00000146",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6686,7 +6749,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000144",
+    "sortText": "00000147",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6707,7 +6770,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000145",
+    "sortText": "00000148",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6728,7 +6791,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000146",
+    "sortText": "00000149",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6749,7 +6812,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000147",
+    "sortText": "0000014a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6770,7 +6833,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000148",
+    "sortText": "0000014b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6791,7 +6854,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000149",
+    "sortText": "0000014c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6812,7 +6875,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014a",
+    "sortText": "0000014d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6833,7 +6896,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014b",
+    "sortText": "0000014e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6854,7 +6917,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014c",
+    "sortText": "0000014f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6875,7 +6938,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014d",
+    "sortText": "00000150",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6896,7 +6959,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014e",
+    "sortText": "00000151",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6917,7 +6980,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014f",
+    "sortText": "00000152",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6938,7 +7001,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000150",
+    "sortText": "00000153",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6959,7 +7022,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000153",
+    "sortText": "00000156",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6980,7 +7043,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000151",
+    "sortText": "00000154",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7001,7 +7064,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000152",
+    "sortText": "00000155",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7022,7 +7085,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000154",
+    "sortText": "00000157",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7043,7 +7106,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000155",
+    "sortText": "00000158",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7064,7 +7127,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000157",
+    "sortText": "0000015a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7085,7 +7148,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000159",
+    "sortText": "0000015c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7106,7 +7169,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015b",
+    "sortText": "0000015e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7127,7 +7190,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015d",
+    "sortText": "00000160",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7148,7 +7211,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000156",
+    "sortText": "00000159",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7169,7 +7232,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000158",
+    "sortText": "0000015b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7190,7 +7253,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015a",
+    "sortText": "0000015d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7211,7 +7274,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015c",
+    "sortText": "0000015f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7232,7 +7295,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015e",
+    "sortText": "00000161",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7253,7 +7316,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015f",
+    "sortText": "00000162",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7274,7 +7337,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000160",
+    "sortText": "00000163",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7295,7 +7358,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000161",
+    "sortText": "00000164",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7316,7 +7379,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000162",
+    "sortText": "00000165",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7337,7 +7400,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000163",
+    "sortText": "00000166",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7358,7 +7421,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000164",
+    "sortText": "00000167",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7379,7 +7442,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000165",
+    "sortText": "00000168",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7400,7 +7463,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000167",
+    "sortText": "0000016a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7421,7 +7484,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000166",
+    "sortText": "00000169",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7442,7 +7505,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000168",
+    "sortText": "0000016b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7463,7 +7526,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000169",
+    "sortText": "0000016c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7484,7 +7547,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016a",
+    "sortText": "0000016d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7505,7 +7568,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016b",
+    "sortText": "0000016e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7526,7 +7589,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016c",
+    "sortText": "0000016f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7547,7 +7610,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016d",
+    "sortText": "00000170",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7568,7 +7631,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016e",
+    "sortText": "00000171",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7589,7 +7652,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016f",
+    "sortText": "00000172",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7610,7 +7673,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000170",
+    "sortText": "00000173",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7631,7 +7694,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000171",
+    "sortText": "00000174",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7652,7 +7715,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000172",
+    "sortText": "00000175",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7673,7 +7736,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000173",
+    "sortText": "00000176",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7694,7 +7757,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000174",
+    "sortText": "00000177",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7715,7 +7778,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000175",
+    "sortText": "00000178",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7736,7 +7799,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000176",
+    "sortText": "00000179",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7757,7 +7820,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000177",
+    "sortText": "0000017a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7778,7 +7841,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000178",
+    "sortText": "0000017b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7799,7 +7862,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000179",
+    "sortText": "0000017c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7820,7 +7883,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017a",
+    "sortText": "0000017d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7841,7 +7904,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017b",
+    "sortText": "0000017e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7862,7 +7925,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017c",
+    "sortText": "0000017f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7883,7 +7946,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017d",
+    "sortText": "00000180",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7904,7 +7967,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017e",
+    "sortText": "00000181",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7925,7 +7988,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017f",
+    "sortText": "00000182",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7946,7 +8009,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000180",
+    "sortText": "00000183",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7967,7 +8030,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000181",
+    "sortText": "00000184",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7988,12 +8051,54 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000182",
+    "sortText": "00000185",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.CognitiveServices/accounts/privateEndpointConnections@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.CognitiveServices/commitmentPlans'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.CognitiveServices/commitmentPlans`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000186",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.CognitiveServices/commitmentPlans@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.CognitiveServices/commitmentPlans/accountAssociations'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.CognitiveServices/commitmentPlans/accountAssociations`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000187",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.CognitiveServices/commitmentPlans/accountAssociations@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -8009,7 +8114,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000183",
+    "sortText": "00000188",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8030,7 +8135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000184",
+    "sortText": "00000189",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8051,7 +8156,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000185",
+    "sortText": "0000018a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8072,7 +8177,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000186",
+    "sortText": "0000018b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8093,7 +8198,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000187",
+    "sortText": "0000018c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8114,7 +8219,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000188",
+    "sortText": "0000018d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8135,7 +8240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000189",
+    "sortText": "0000018e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8156,7 +8261,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018a",
+    "sortText": "0000018f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8177,7 +8282,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018b",
+    "sortText": "00000190",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8198,7 +8303,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018c",
+    "sortText": "00000191",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8219,7 +8324,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018d",
+    "sortText": "00000192",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8240,7 +8345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018e",
+    "sortText": "00000193",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8261,7 +8366,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018f",
+    "sortText": "00000194",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8282,7 +8387,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000190",
+    "sortText": "00000195",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8303,7 +8408,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000191",
+    "sortText": "00000196",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8324,7 +8429,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000192",
+    "sortText": "00000197",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8345,7 +8450,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000193",
+    "sortText": "00000198",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8366,7 +8471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000194",
+    "sortText": "00000199",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8387,7 +8492,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000195",
+    "sortText": "0000019a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8408,7 +8513,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000196",
+    "sortText": "0000019b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8429,7 +8534,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000197",
+    "sortText": "0000019c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8450,7 +8555,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000198",
+    "sortText": "0000019d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8471,7 +8576,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000199",
+    "sortText": "0000019e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8492,7 +8597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019a",
+    "sortText": "0000019f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8513,7 +8618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019b",
+    "sortText": "000001a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8534,7 +8639,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019c",
+    "sortText": "000001a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8555,7 +8660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019d",
+    "sortText": "000001a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8576,7 +8681,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019e",
+    "sortText": "000001a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8597,7 +8702,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019f",
+    "sortText": "000001a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8618,7 +8723,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a0",
+    "sortText": "000001a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8639,7 +8744,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a1",
+    "sortText": "000001a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8660,7 +8765,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a5",
+    "sortText": "000001aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8681,7 +8786,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a6",
+    "sortText": "000001ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8702,7 +8807,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a7",
+    "sortText": "000001ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8723,7 +8828,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a8",
+    "sortText": "000001ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8744,7 +8849,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001aa",
+    "sortText": "000001af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8765,7 +8870,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ae",
+    "sortText": "000001b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8786,7 +8891,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001af",
+    "sortText": "000001b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8807,7 +8912,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a9",
+    "sortText": "000001ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8828,7 +8933,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a2",
+    "sortText": "000001a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8849,7 +8954,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a3",
+    "sortText": "000001a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8870,7 +8975,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a4",
+    "sortText": "000001a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8891,7 +8996,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b0",
+    "sortText": "000001b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8912,7 +9017,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b1",
+    "sortText": "000001b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8933,7 +9038,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b2",
+    "sortText": "000001b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8954,7 +9059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b3",
+    "sortText": "000001b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8975,7 +9080,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b4",
+    "sortText": "000001b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8996,7 +9101,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b5",
+    "sortText": "000001ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9017,7 +9122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b6",
+    "sortText": "000001bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9038,7 +9143,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b7",
+    "sortText": "000001bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9059,7 +9164,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b8",
+    "sortText": "000001bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9080,7 +9185,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b9",
+    "sortText": "000001be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9101,7 +9206,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001be",
+    "sortText": "000001c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9122,7 +9227,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ba",
+    "sortText": "000001bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9143,7 +9248,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bb",
+    "sortText": "000001c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9164,7 +9269,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bc",
+    "sortText": "000001c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9185,7 +9290,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bd",
+    "sortText": "000001c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9206,7 +9311,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bf",
+    "sortText": "000001c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9227,7 +9332,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c0",
+    "sortText": "000001c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9248,7 +9353,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c1",
+    "sortText": "000001c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9269,7 +9374,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c2",
+    "sortText": "000001c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9290,7 +9395,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c3",
+    "sortText": "000001c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9311,7 +9416,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c4",
+    "sortText": "000001c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9332,7 +9437,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c5",
+    "sortText": "000001ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9353,7 +9458,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c7",
+    "sortText": "000001cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9374,7 +9479,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c8",
+    "sortText": "000001cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9395,12 +9500,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c6",
+    "sortText": "000001cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.ContainerRegistry/registries/builds@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.ContainerRegistry/registries/cacheRules'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.ContainerRegistry/registries/cacheRules`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000001ce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.ContainerRegistry/registries/cacheRules@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -9416,12 +9542,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c9",
+    "sortText": "000001cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.ContainerRegistry/registries/connectedRegistries@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.ContainerRegistry/registries/credentialSets'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.ContainerRegistry/registries/credentialSets`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000001d0",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.ContainerRegistry/registries/credentialSets@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -9437,7 +9584,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ca",
+    "sortText": "000001d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9458,7 +9605,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cb",
+    "sortText": "000001d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9479,7 +9626,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cc",
+    "sortText": "000001d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9500,7 +9647,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cd",
+    "sortText": "000001d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9521,7 +9668,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ce",
+    "sortText": "000001d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9542,7 +9689,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cf",
+    "sortText": "000001d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9563,7 +9710,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d0",
+    "sortText": "000001d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9584,7 +9731,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d1",
+    "sortText": "000001d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9605,7 +9752,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d2",
+    "sortText": "000001d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9626,7 +9773,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d3",
+    "sortText": "000001da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9647,7 +9794,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d4",
+    "sortText": "000001db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9668,7 +9815,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d5",
+    "sortText": "000001dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9689,7 +9836,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d6",
+    "sortText": "000001dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9710,7 +9857,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d7",
+    "sortText": "000001de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9731,7 +9878,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d8",
+    "sortText": "000001df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9752,7 +9899,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d9",
+    "sortText": "000001e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9773,7 +9920,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001da",
+    "sortText": "000001e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9794,7 +9941,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001db",
+    "sortText": "000001e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9815,7 +9962,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001dc",
+    "sortText": "000001e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9836,7 +9983,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001dd",
+    "sortText": "000001e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9857,7 +10004,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001de",
+    "sortText": "000001e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9878,7 +10025,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001df",
+    "sortText": "000001e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9899,7 +10046,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e0",
+    "sortText": "000001e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9920,7 +10067,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e1",
+    "sortText": "000001e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9941,7 +10088,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e2",
+    "sortText": "000001e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9962,7 +10109,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e3",
+    "sortText": "000001ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9983,7 +10130,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e4",
+    "sortText": "000001eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10004,7 +10151,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e5",
+    "sortText": "000001ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10025,7 +10172,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e6",
+    "sortText": "000001ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10046,7 +10193,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e7",
+    "sortText": "000001ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10067,7 +10214,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e8",
+    "sortText": "000001ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10088,7 +10235,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e9",
+    "sortText": "000001f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10109,7 +10256,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ea",
+    "sortText": "000001f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10130,7 +10277,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001eb",
+    "sortText": "000001f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10151,7 +10298,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ec",
+    "sortText": "000001f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10172,7 +10319,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ed",
+    "sortText": "000001f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10193,7 +10340,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ee",
+    "sortText": "000001f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10214,7 +10361,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ef",
+    "sortText": "000001f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10235,7 +10382,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fe",
+    "sortText": "00000205",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10256,7 +10403,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ff",
+    "sortText": "00000206",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10277,7 +10424,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f0",
+    "sortText": "000001f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10298,7 +10445,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f1",
+    "sortText": "000001f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10319,7 +10466,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f2",
+    "sortText": "000001f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10340,7 +10487,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f3",
+    "sortText": "000001fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10361,7 +10508,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f4",
+    "sortText": "000001fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10382,7 +10529,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f5",
+    "sortText": "000001fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10403,7 +10550,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f6",
+    "sortText": "000001fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10424,7 +10571,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f7",
+    "sortText": "000001fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10445,7 +10592,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f8",
+    "sortText": "000001ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10466,7 +10613,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f9",
+    "sortText": "00000200",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10487,7 +10634,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fa",
+    "sortText": "00000201",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10508,7 +10655,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fb",
+    "sortText": "00000202",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10529,7 +10676,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fc",
+    "sortText": "00000203",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10550,7 +10697,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fd",
+    "sortText": "00000204",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10571,7 +10718,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000261",
+    "sortText": "00000269",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10592,7 +10739,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000265",
+    "sortText": "0000026d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10613,7 +10760,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000267",
+    "sortText": "0000026f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10634,7 +10781,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000269",
+    "sortText": "00000271",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10655,7 +10802,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026a",
+    "sortText": "00000272",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10676,7 +10823,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027b",
+    "sortText": "00000283",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10697,7 +10844,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000280",
+    "sortText": "00000288",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10718,7 +10865,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000282",
+    "sortText": "0000028a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10739,7 +10886,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000284",
+    "sortText": "0000028c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10760,7 +10907,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000253",
+    "sortText": "0000025b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10781,7 +10928,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000254",
+    "sortText": "0000025c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10802,7 +10949,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000255",
+    "sortText": "0000025d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10823,7 +10970,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000256",
+    "sortText": "0000025e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10844,7 +10991,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000257",
+    "sortText": "0000025f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10865,7 +11012,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000258",
+    "sortText": "00000260",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10886,7 +11033,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000259",
+    "sortText": "00000261",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10907,7 +11054,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025a",
+    "sortText": "00000262",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10928,7 +11075,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025b",
+    "sortText": "00000263",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10949,7 +11096,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025c",
+    "sortText": "00000264",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10970,7 +11117,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025d",
+    "sortText": "00000265",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10991,7 +11138,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025e",
+    "sortText": "00000266",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11012,7 +11159,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025f",
+    "sortText": "00000267",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11033,7 +11180,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000260",
+    "sortText": "00000268",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11054,7 +11201,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000262",
+    "sortText": "0000026a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11075,7 +11222,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000263",
+    "sortText": "0000026b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11096,7 +11243,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000264",
+    "sortText": "0000026c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11117,7 +11264,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000266",
+    "sortText": "0000026e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11138,7 +11285,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000268",
+    "sortText": "00000270",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11159,7 +11306,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026b",
+    "sortText": "00000273",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11180,7 +11327,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026c",
+    "sortText": "00000274",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11201,7 +11348,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026d",
+    "sortText": "00000275",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11222,7 +11369,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026e",
+    "sortText": "00000276",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11243,7 +11390,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026f",
+    "sortText": "00000277",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11264,7 +11411,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000270",
+    "sortText": "00000278",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11285,7 +11432,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000271",
+    "sortText": "00000279",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11306,7 +11453,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000272",
+    "sortText": "0000027a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11327,7 +11474,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000273",
+    "sortText": "0000027b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11348,7 +11495,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000274",
+    "sortText": "0000027c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11369,7 +11516,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000275",
+    "sortText": "0000027d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11390,7 +11537,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000276",
+    "sortText": "0000027e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11411,7 +11558,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000277",
+    "sortText": "0000027f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11432,7 +11579,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000278",
+    "sortText": "00000280",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11453,7 +11600,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000279",
+    "sortText": "00000281",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11474,7 +11621,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027a",
+    "sortText": "00000282",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11495,7 +11642,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027c",
+    "sortText": "00000284",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11516,7 +11663,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027d",
+    "sortText": "00000285",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11537,7 +11684,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027e",
+    "sortText": "00000286",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11558,7 +11705,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027f",
+    "sortText": "00000287",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11579,7 +11726,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000281",
+    "sortText": "00000289",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11600,7 +11747,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000283",
+    "sortText": "0000028b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11621,7 +11768,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000285",
+    "sortText": "0000028d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11642,7 +11789,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000286",
+    "sortText": "0000028e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11663,7 +11810,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000287",
+    "sortText": "0000028f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11684,7 +11831,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000288",
+    "sortText": "00000290",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11705,7 +11852,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000289",
+    "sortText": "00000291",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11726,7 +11873,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028a",
+    "sortText": "00000292",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11747,7 +11894,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028b",
+    "sortText": "00000293",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11768,7 +11915,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028c",
+    "sortText": "00000294",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11789,7 +11936,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028d",
+    "sortText": "00000295",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11810,7 +11957,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028e",
+    "sortText": "00000296",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11831,7 +11978,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028f",
+    "sortText": "00000297",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11852,7 +11999,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000290",
+    "sortText": "00000298",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11873,7 +12020,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000291",
+    "sortText": "00000299",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11894,7 +12041,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000292",
+    "sortText": "0000029a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11915,7 +12062,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000293",
+    "sortText": "0000029b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11936,7 +12083,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000294",
+    "sortText": "0000029c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11957,7 +12104,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000200",
+    "sortText": "00000207",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11978,7 +12125,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000201",
+    "sortText": "00000208",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11999,7 +12146,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000202",
+    "sortText": "00000209",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12020,7 +12167,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000203",
+    "sortText": "0000020a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12041,7 +12188,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000204",
+    "sortText": "0000020b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12062,7 +12209,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000205",
+    "sortText": "0000020c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12083,7 +12230,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000206",
+    "sortText": "0000020d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12104,7 +12251,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000207",
+    "sortText": "0000020e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12125,7 +12272,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000208",
+    "sortText": "0000020f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12146,7 +12293,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000209",
+    "sortText": "00000210",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12167,7 +12314,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020a",
+    "sortText": "00000211",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12188,12 +12335,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020b",
+    "sortText": "00000212",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/orders@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/publishers/offers/skus/versions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.DataBoxEdge/dataBoxEdgeDevices/publishers/offers/skus/versions`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000213",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.DataBoxEdge/dataBoxEdgeDevices/publishers/offers/skus/versions@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -12209,7 +12377,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020c",
+    "sortText": "00000214",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12230,7 +12398,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020d",
+    "sortText": "00000215",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12251,7 +12419,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020e",
+    "sortText": "00000216",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12272,7 +12440,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020f",
+    "sortText": "00000217",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12293,7 +12461,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000210",
+    "sortText": "00000218",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12314,7 +12482,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000211",
+    "sortText": "00000219",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12335,7 +12503,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000212",
+    "sortText": "0000021a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12356,7 +12524,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000213",
+    "sortText": "0000021b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12377,7 +12545,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000214",
+    "sortText": "0000021c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12398,7 +12566,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000215",
+    "sortText": "0000021d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12419,7 +12587,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021b",
+    "sortText": "00000223",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12440,7 +12608,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000220",
+    "sortText": "00000228",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12461,7 +12629,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000221",
+    "sortText": "00000229",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12482,7 +12650,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000222",
+    "sortText": "0000022a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12503,7 +12671,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000223",
+    "sortText": "0000022b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12524,7 +12692,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000224",
+    "sortText": "0000022c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12545,7 +12713,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000225",
+    "sortText": "0000022d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12566,7 +12734,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000226",
+    "sortText": "0000022e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12587,7 +12755,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000227",
+    "sortText": "0000022f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12608,7 +12776,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000228",
+    "sortText": "00000230",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12629,7 +12797,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000229",
+    "sortText": "00000231",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12650,7 +12818,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022a",
+    "sortText": "00000232",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12671,7 +12839,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022b",
+    "sortText": "00000233",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12692,7 +12860,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022c",
+    "sortText": "00000234",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12713,7 +12881,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022f",
+    "sortText": "00000237",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12734,7 +12902,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000232",
+    "sortText": "0000023a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12755,7 +12923,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022d",
+    "sortText": "00000235",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12776,7 +12944,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022e",
+    "sortText": "00000236",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12797,7 +12965,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000230",
+    "sortText": "00000238",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12818,7 +12986,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000231",
+    "sortText": "00000239",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12839,7 +13007,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000233",
+    "sortText": "0000023b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12860,7 +13028,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000234",
+    "sortText": "0000023c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12881,7 +13049,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000235",
+    "sortText": "0000023d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12902,7 +13070,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000236",
+    "sortText": "0000023e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12923,7 +13091,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000237",
+    "sortText": "0000023f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12944,7 +13112,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000238",
+    "sortText": "00000240",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12965,7 +13133,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000239",
+    "sortText": "00000241",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12986,7 +13154,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023a",
+    "sortText": "00000242",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13007,7 +13175,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023b",
+    "sortText": "00000243",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13028,7 +13196,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023c",
+    "sortText": "00000244",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13049,7 +13217,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023d",
+    "sortText": "00000245",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13070,7 +13238,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023e",
+    "sortText": "00000246",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13091,7 +13259,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023f",
+    "sortText": "00000247",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13112,7 +13280,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000240",
+    "sortText": "00000248",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13133,7 +13301,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000241",
+    "sortText": "00000249",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13154,7 +13322,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000242",
+    "sortText": "0000024a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13175,7 +13343,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000243",
+    "sortText": "0000024b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13196,7 +13364,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000244",
+    "sortText": "0000024c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13217,7 +13385,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000245",
+    "sortText": "0000024d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13238,7 +13406,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000246",
+    "sortText": "0000024e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13259,7 +13427,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000247",
+    "sortText": "0000024f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13280,7 +13448,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000248",
+    "sortText": "00000250",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13301,7 +13469,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000249",
+    "sortText": "00000251",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13322,7 +13490,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024f",
+    "sortText": "00000257",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13343,7 +13511,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000250",
+    "sortText": "00000258",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13364,7 +13532,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000251",
+    "sortText": "00000259",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13385,7 +13553,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024a",
+    "sortText": "00000252",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13406,7 +13574,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024b",
+    "sortText": "00000253",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13427,7 +13595,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024c",
+    "sortText": "00000254",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13448,7 +13616,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024d",
+    "sortText": "00000255",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13469,7 +13637,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024e",
+    "sortText": "00000256",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13490,7 +13658,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000252",
+    "sortText": "0000025a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13511,7 +13679,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000216",
+    "sortText": "0000021e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13532,7 +13700,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000217",
+    "sortText": "0000021f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13553,7 +13721,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000218",
+    "sortText": "00000220",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13574,7 +13742,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000219",
+    "sortText": "00000221",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13595,7 +13763,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021a",
+    "sortText": "00000222",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13616,7 +13784,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021c",
+    "sortText": "00000224",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13637,7 +13805,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021d",
+    "sortText": "00000225",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13658,7 +13826,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021e",
+    "sortText": "00000226",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13679,7 +13847,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021f",
+    "sortText": "00000227",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13700,7 +13868,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000295",
+    "sortText": "0000029d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13721,7 +13889,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000296",
+    "sortText": "0000029e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13742,7 +13910,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000297",
+    "sortText": "0000029f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13763,7 +13931,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000298",
+    "sortText": "000002a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13784,7 +13952,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000299",
+    "sortText": "000002a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13805,7 +13973,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029a",
+    "sortText": "000002a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13826,7 +13994,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029b",
+    "sortText": "000002a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13847,7 +14015,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029c",
+    "sortText": "000002a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13868,7 +14036,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029d",
+    "sortText": "000002a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13889,7 +14057,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029e",
+    "sortText": "000002a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13910,7 +14078,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029f",
+    "sortText": "000002a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13931,7 +14099,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a0",
+    "sortText": "000002a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13952,7 +14120,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a1",
+    "sortText": "000002a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13973,7 +14141,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a2",
+    "sortText": "000002aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13994,7 +14162,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a3",
+    "sortText": "000002ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14015,7 +14183,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a4",
+    "sortText": "000002ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14036,7 +14204,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a5",
+    "sortText": "000002ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14057,7 +14225,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a6",
+    "sortText": "000002ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14078,7 +14246,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a7",
+    "sortText": "000002af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14099,7 +14267,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a8",
+    "sortText": "000002b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14120,7 +14288,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a9",
+    "sortText": "000002b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14141,7 +14309,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002aa",
+    "sortText": "000002b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14162,7 +14330,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ab",
+    "sortText": "000002b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14183,7 +14351,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ac",
+    "sortText": "000002b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14204,7 +14372,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ad",
+    "sortText": "000002b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14225,7 +14393,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ae",
+    "sortText": "000002b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14246,7 +14414,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002af",
+    "sortText": "000002b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14267,7 +14435,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b0",
+    "sortText": "000002b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14288,7 +14456,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b1",
+    "sortText": "000002b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14309,7 +14477,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b2",
+    "sortText": "000002ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14330,7 +14498,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b3",
+    "sortText": "000002bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14351,7 +14519,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b4",
+    "sortText": "000002bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14372,7 +14540,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b5",
+    "sortText": "000002bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14393,7 +14561,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b6",
+    "sortText": "000002be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14414,7 +14582,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b7",
+    "sortText": "000002bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14435,7 +14603,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b8",
+    "sortText": "000002c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14456,7 +14624,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b9",
+    "sortText": "000002c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14477,7 +14645,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ba",
+    "sortText": "000002c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14498,7 +14666,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bb",
+    "sortText": "000002c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14519,7 +14687,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c8",
+    "sortText": "000002d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14540,7 +14708,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c9",
+    "sortText": "000002d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14561,7 +14729,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ca",
+    "sortText": "000002d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14582,7 +14750,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cb",
+    "sortText": "000002d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14603,7 +14771,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cc",
+    "sortText": "000002d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14624,7 +14792,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cd",
+    "sortText": "000002d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14645,7 +14813,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ce",
+    "sortText": "000002d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14666,7 +14834,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cf",
+    "sortText": "000002d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14687,7 +14855,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d0",
+    "sortText": "000002d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14708,7 +14876,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d1",
+    "sortText": "000002d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14729,7 +14897,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d2",
+    "sortText": "000002da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14750,7 +14918,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d3",
+    "sortText": "000002db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14771,7 +14939,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d4",
+    "sortText": "000002dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14792,7 +14960,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d5",
+    "sortText": "000002dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14813,7 +14981,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d6",
+    "sortText": "000002de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14834,7 +15002,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d7",
+    "sortText": "000002df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14855,7 +15023,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d8",
+    "sortText": "000002e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14876,7 +15044,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d9",
+    "sortText": "000002e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14897,7 +15065,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002da",
+    "sortText": "000002e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14918,7 +15086,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002db",
+    "sortText": "000002e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14939,7 +15107,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002dc",
+    "sortText": "000002e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14960,7 +15128,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002dd",
+    "sortText": "000002e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14981,7 +15149,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002de",
+    "sortText": "000002e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15002,7 +15170,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002df",
+    "sortText": "000002e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15023,7 +15191,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c3",
+    "sortText": "000002cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15044,7 +15212,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c4",
+    "sortText": "000002cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15065,7 +15233,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c5",
+    "sortText": "000002cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15086,7 +15254,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c6",
+    "sortText": "000002ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15107,7 +15275,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c7",
+    "sortText": "000002cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15128,7 +15296,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bc",
+    "sortText": "000002c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15149,7 +15317,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bd",
+    "sortText": "000002c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15170,7 +15338,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002be",
+    "sortText": "000002c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15191,7 +15359,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bf",
+    "sortText": "000002c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15212,7 +15380,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c0",
+    "sortText": "000002c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15233,7 +15401,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c1",
+    "sortText": "000002c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15254,7 +15422,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c2",
+    "sortText": "000002ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15275,7 +15443,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e0",
+    "sortText": "000002e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15296,7 +15464,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e1",
+    "sortText": "000002e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15317,7 +15485,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e2",
+    "sortText": "000002ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15338,7 +15506,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e3",
+    "sortText": "000002eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15359,7 +15527,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e4",
+    "sortText": "000002ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15380,7 +15548,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e5",
+    "sortText": "000002ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15401,7 +15569,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e6",
+    "sortText": "000002ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15422,7 +15590,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e7",
+    "sortText": "000002ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15443,7 +15611,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e8",
+    "sortText": "000002f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15464,7 +15632,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e9",
+    "sortText": "000002f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15485,7 +15653,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ea",
+    "sortText": "000002f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15506,7 +15674,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002eb",
+    "sortText": "000002f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15527,7 +15695,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ec",
+    "sortText": "000002f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15548,7 +15716,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ed",
+    "sortText": "000002f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15569,7 +15737,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ee",
+    "sortText": "000002f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15590,7 +15758,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ef",
+    "sortText": "000002f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15611,7 +15779,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f0",
+    "sortText": "000002f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15632,7 +15800,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f1",
+    "sortText": "000002f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15653,7 +15821,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f2",
+    "sortText": "000002fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15674,7 +15842,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f3",
+    "sortText": "000002fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15695,7 +15863,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f4",
+    "sortText": "000002fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15716,7 +15884,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f5",
+    "sortText": "000002fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15737,7 +15905,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f6",
+    "sortText": "000002fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15758,7 +15926,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f7",
+    "sortText": "000002ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15779,7 +15947,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f8",
+    "sortText": "00000300",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15800,7 +15968,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f9",
+    "sortText": "00000301",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15821,7 +15989,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fa",
+    "sortText": "00000302",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15842,7 +16010,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fb",
+    "sortText": "00000303",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15863,7 +16031,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fc",
+    "sortText": "00000304",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15884,7 +16052,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fd",
+    "sortText": "00000305",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15905,7 +16073,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fe",
+    "sortText": "00000306",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15926,7 +16094,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ff",
+    "sortText": "00000307",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15947,7 +16115,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000300",
+    "sortText": "00000308",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15968,7 +16136,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000301",
+    "sortText": "00000309",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15989,7 +16157,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000302",
+    "sortText": "0000030a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16010,7 +16178,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000303",
+    "sortText": "0000030b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16031,7 +16199,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000304",
+    "sortText": "0000030c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16052,7 +16220,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000305",
+    "sortText": "0000030d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16073,7 +16241,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000306",
+    "sortText": "0000030e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16094,7 +16262,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000307",
+    "sortText": "0000030f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16115,7 +16283,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000308",
+    "sortText": "00000310",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16136,7 +16304,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000309",
+    "sortText": "00000311",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16157,7 +16325,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030a",
+    "sortText": "00000312",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16178,7 +16346,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030b",
+    "sortText": "00000313",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16199,7 +16367,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030c",
+    "sortText": "00000314",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16220,7 +16388,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030d",
+    "sortText": "00000315",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16241,7 +16409,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030e",
+    "sortText": "00000316",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16262,7 +16430,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030f",
+    "sortText": "00000317",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16283,7 +16451,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000310",
+    "sortText": "00000318",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16304,7 +16472,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000311",
+    "sortText": "00000319",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16325,7 +16493,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000312",
+    "sortText": "0000031a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16346,7 +16514,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000313",
+    "sortText": "0000031b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16367,7 +16535,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000314",
+    "sortText": "0000031c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16388,7 +16556,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000315",
+    "sortText": "0000031d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16409,7 +16577,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000316",
+    "sortText": "0000031e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16430,7 +16598,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000317",
+    "sortText": "0000031f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16451,7 +16619,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000318",
+    "sortText": "00000320",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16472,7 +16640,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000319",
+    "sortText": "00000321",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16493,7 +16661,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031a",
+    "sortText": "00000322",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16514,7 +16682,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031b",
+    "sortText": "00000323",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16535,7 +16703,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031c",
+    "sortText": "00000324",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16556,7 +16724,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031d",
+    "sortText": "00000325",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16577,7 +16745,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031e",
+    "sortText": "00000326",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16598,7 +16766,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031f",
+    "sortText": "00000327",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16619,7 +16787,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000320",
+    "sortText": "00000328",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16640,7 +16808,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000321",
+    "sortText": "00000329",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16661,7 +16829,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000322",
+    "sortText": "0000032a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16682,7 +16850,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000323",
+    "sortText": "0000032b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16703,7 +16871,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000324",
+    "sortText": "0000032c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16724,7 +16892,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000325",
+    "sortText": "0000032d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16745,7 +16913,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000326",
+    "sortText": "0000032e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16766,7 +16934,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000327",
+    "sortText": "0000032f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16787,7 +16955,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000328",
+    "sortText": "00000330",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16808,7 +16976,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000329",
+    "sortText": "00000331",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16829,7 +16997,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032a",
+    "sortText": "00000332",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16850,7 +17018,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032b",
+    "sortText": "00000333",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16871,7 +17039,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032c",
+    "sortText": "00000334",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16892,7 +17060,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032d",
+    "sortText": "00000335",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16913,7 +17081,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032e",
+    "sortText": "00000336",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16934,7 +17102,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032f",
+    "sortText": "00000337",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16955,7 +17123,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000330",
+    "sortText": "00000338",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16976,7 +17144,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000331",
+    "sortText": "00000339",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16997,7 +17165,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000332",
+    "sortText": "0000033a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17018,7 +17186,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000333",
+    "sortText": "0000033b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17039,7 +17207,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000334",
+    "sortText": "0000033c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17060,7 +17228,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000335",
+    "sortText": "0000033d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17081,7 +17249,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000336",
+    "sortText": "0000033e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17102,7 +17270,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000337",
+    "sortText": "0000033f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17123,7 +17291,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000338",
+    "sortText": "00000340",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17144,7 +17312,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000339",
+    "sortText": "00000341",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17165,7 +17333,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033a",
+    "sortText": "00000342",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17186,7 +17354,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033b",
+    "sortText": "00000343",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17207,7 +17375,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033c",
+    "sortText": "00000344",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17228,7 +17396,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033d",
+    "sortText": "00000345",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17249,7 +17417,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033e",
+    "sortText": "00000346",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17270,7 +17438,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033f",
+    "sortText": "00000347",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17291,7 +17459,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000340",
+    "sortText": "00000348",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17312,7 +17480,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000341",
+    "sortText": "00000349",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17333,7 +17501,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000345",
+    "sortText": "0000034d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17354,7 +17522,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000342",
+    "sortText": "0000034a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17375,7 +17543,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000343",
+    "sortText": "0000034b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17396,7 +17564,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000344",
+    "sortText": "0000034c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17417,7 +17585,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000346",
+    "sortText": "0000034e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17438,7 +17606,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000347",
+    "sortText": "0000034f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17459,7 +17627,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000348",
+    "sortText": "00000350",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17480,7 +17648,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034b",
+    "sortText": "00000353",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17501,7 +17669,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000349",
+    "sortText": "00000351",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17522,7 +17690,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034a",
+    "sortText": "00000352",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17543,7 +17711,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034c",
+    "sortText": "00000354",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17564,7 +17732,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034d",
+    "sortText": "00000355",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17585,7 +17753,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034e",
+    "sortText": "00000356",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17606,7 +17774,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034f",
+    "sortText": "00000357",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17627,7 +17795,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000350",
+    "sortText": "00000358",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17648,7 +17816,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000351",
+    "sortText": "00000359",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17669,7 +17837,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000352",
+    "sortText": "0000035a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17690,7 +17858,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000353",
+    "sortText": "0000035b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17711,7 +17879,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000354",
+    "sortText": "0000035c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17732,7 +17900,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000355",
+    "sortText": "0000035d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17753,7 +17921,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000356",
+    "sortText": "0000035e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17774,7 +17942,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000357",
+    "sortText": "0000035f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17795,7 +17963,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000358",
+    "sortText": "00000360",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17816,7 +17984,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000359",
+    "sortText": "00000361",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17837,7 +18005,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035a",
+    "sortText": "00000362",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17858,7 +18026,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035b",
+    "sortText": "00000363",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17879,7 +18047,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000360",
+    "sortText": "00000368",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17900,7 +18068,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000361",
+    "sortText": "00000369",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17921,7 +18089,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000362",
+    "sortText": "0000036a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17942,7 +18110,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000363",
+    "sortText": "0000036b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17963,7 +18131,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035c",
+    "sortText": "00000364",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17984,7 +18152,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035d",
+    "sortText": "00000365",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18005,7 +18173,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035e",
+    "sortText": "00000366",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18026,7 +18194,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035f",
+    "sortText": "00000367",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18047,7 +18215,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000364",
+    "sortText": "0000036c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18068,7 +18236,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000365",
+    "sortText": "0000036d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18089,7 +18257,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000366",
+    "sortText": "0000036e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18110,7 +18278,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000367",
+    "sortText": "0000036f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18131,12 +18299,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000368",
+    "sortText": "00000370",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.HealthcareApis/workspaces@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.HealthcareApis/workspaces/analyticsconnectors'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.HealthcareApis/workspaces/analyticsconnectors`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000371",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.HealthcareApis/workspaces/analyticsconnectors@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -18152,7 +18341,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000369",
+    "sortText": "00000372",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18173,7 +18362,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036a",
+    "sortText": "00000373",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18194,7 +18383,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036b",
+    "sortText": "00000374",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18215,7 +18404,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036c",
+    "sortText": "00000375",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18236,7 +18425,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036d",
+    "sortText": "00000376",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18257,7 +18446,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036e",
+    "sortText": "00000377",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18278,7 +18467,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036f",
+    "sortText": "00000378",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18299,7 +18488,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000370",
+    "sortText": "00000379",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18320,7 +18509,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000371",
+    "sortText": "0000037a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18341,7 +18530,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000372",
+    "sortText": "0000037b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18362,7 +18551,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000373",
+    "sortText": "0000037c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18383,7 +18572,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000374",
+    "sortText": "0000037d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18404,7 +18593,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000375",
+    "sortText": "0000037e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18425,7 +18614,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000376",
+    "sortText": "0000037f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18446,7 +18635,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000377",
+    "sortText": "00000380",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18467,7 +18656,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000378",
+    "sortText": "00000381",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18488,7 +18677,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000379",
+    "sortText": "00000382",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18509,7 +18698,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037a",
+    "sortText": "00000383",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18530,7 +18719,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037b",
+    "sortText": "00000384",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18551,7 +18740,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037c",
+    "sortText": "00000385",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18572,7 +18761,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037d",
+    "sortText": "00000386",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18593,7 +18782,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037e",
+    "sortText": "00000387",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18614,7 +18803,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037f",
+    "sortText": "00000388",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18635,7 +18824,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000380",
+    "sortText": "00000389",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18656,7 +18845,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000381",
+    "sortText": "0000038a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18677,7 +18866,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000382",
+    "sortText": "0000038b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18698,7 +18887,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000383",
+    "sortText": "0000038c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18719,7 +18908,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000384",
+    "sortText": "0000038d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18740,7 +18929,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000385",
+    "sortText": "0000038e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18761,7 +18950,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000386",
+    "sortText": "0000038f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18782,7 +18971,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000387",
+    "sortText": "00000390",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18803,7 +18992,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000389",
+    "sortText": "00000392",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18824,7 +19013,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038b",
+    "sortText": "00000394",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18845,7 +19034,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038c",
+    "sortText": "00000395",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18866,7 +19055,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038d",
+    "sortText": "00000396",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18887,7 +19076,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000394",
+    "sortText": "0000039d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18908,7 +19097,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038f",
+    "sortText": "00000398",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18929,7 +19118,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000390",
+    "sortText": "00000399",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18950,7 +19139,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000395",
+    "sortText": "0000039e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18971,7 +19160,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000396",
+    "sortText": "0000039f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18992,7 +19181,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000397",
+    "sortText": "000003a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19013,7 +19202,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000398",
+    "sortText": "000003a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19034,7 +19223,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039a",
+    "sortText": "000003a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19055,7 +19244,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039d",
+    "sortText": "000003a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19076,7 +19265,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039e",
+    "sortText": "000003a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19097,7 +19286,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039f",
+    "sortText": "000003a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19118,7 +19307,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a1",
+    "sortText": "000003aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19139,7 +19328,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a2",
+    "sortText": "000003ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19160,7 +19349,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a3",
+    "sortText": "000003ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19181,7 +19370,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a4",
+    "sortText": "000003ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19202,7 +19391,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a5",
+    "sortText": "000003ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19223,7 +19412,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a6",
+    "sortText": "000003af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19244,7 +19433,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a7",
+    "sortText": "000003b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19265,7 +19454,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a9",
+    "sortText": "000003b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19286,7 +19475,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003aa",
+    "sortText": "000003b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19307,7 +19496,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ac",
+    "sortText": "000003b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19328,7 +19517,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ad",
+    "sortText": "000003b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19349,7 +19538,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ae",
+    "sortText": "000003b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19370,7 +19559,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003af",
+    "sortText": "000003b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19391,7 +19580,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b0",
+    "sortText": "000003b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19412,7 +19601,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b1",
+    "sortText": "000003ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19433,7 +19622,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b2",
+    "sortText": "000003bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19454,7 +19643,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b3",
+    "sortText": "000003bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19475,7 +19664,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b4",
+    "sortText": "000003bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19496,7 +19685,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b5",
+    "sortText": "000003be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19517,7 +19706,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b6",
+    "sortText": "000003bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19538,7 +19727,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b7",
+    "sortText": "000003c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19559,7 +19748,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b8",
+    "sortText": "000003c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19580,7 +19769,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b9",
+    "sortText": "000003c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19601,7 +19790,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ba",
+    "sortText": "000003c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19622,7 +19811,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bb",
+    "sortText": "000003c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19643,7 +19832,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bc",
+    "sortText": "000003c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19664,7 +19853,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bd",
+    "sortText": "000003c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19685,7 +19874,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003be",
+    "sortText": "000003c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19706,7 +19895,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bf",
+    "sortText": "000003c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19727,7 +19916,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c0",
+    "sortText": "000003c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19748,7 +19937,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c1",
+    "sortText": "000003ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19769,7 +19958,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c2",
+    "sortText": "000003cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19790,7 +19979,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c3",
+    "sortText": "000003cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19811,7 +20000,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c4",
+    "sortText": "000003cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19832,7 +20021,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c5",
+    "sortText": "000003ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19853,7 +20042,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c6",
+    "sortText": "000003cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19874,7 +20063,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c7",
+    "sortText": "000003d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19895,7 +20084,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c8",
+    "sortText": "000003d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19916,7 +20105,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ca",
+    "sortText": "000003d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19937,7 +20126,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c9",
+    "sortText": "000003d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19958,7 +20147,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cb",
+    "sortText": "000003d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19979,7 +20168,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cc",
+    "sortText": "000003d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20000,7 +20189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cd",
+    "sortText": "000003d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20021,7 +20210,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ce",
+    "sortText": "000003d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20042,7 +20231,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cf",
+    "sortText": "000003d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20063,7 +20252,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d0",
+    "sortText": "000003d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20084,7 +20273,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d1",
+    "sortText": "000003da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20105,7 +20294,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d2",
+    "sortText": "000003db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20126,7 +20315,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d3",
+    "sortText": "000003dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20147,7 +20336,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d4",
+    "sortText": "000003dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20168,7 +20357,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d5",
+    "sortText": "000003de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20189,7 +20378,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d6",
+    "sortText": "000003df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20210,7 +20399,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d7",
+    "sortText": "000003e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20231,7 +20420,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d8",
+    "sortText": "000003e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20252,7 +20441,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d9",
+    "sortText": "000003e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20273,7 +20462,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003da",
+    "sortText": "000003e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20294,7 +20483,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e1",
+    "sortText": "000003ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20315,7 +20504,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e2",
+    "sortText": "000003eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20336,7 +20525,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003db",
+    "sortText": "000003e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20357,7 +20546,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003dc",
+    "sortText": "000003e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20378,7 +20567,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003dd",
+    "sortText": "000003e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20399,7 +20588,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003de",
+    "sortText": "000003e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20420,7 +20609,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003df",
+    "sortText": "000003e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20441,7 +20630,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e0",
+    "sortText": "000003e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20462,7 +20651,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e3",
+    "sortText": "000003ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20483,7 +20672,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e4",
+    "sortText": "000003ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20504,7 +20693,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e5",
+    "sortText": "000003ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20525,7 +20714,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e6",
+    "sortText": "000003ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20546,7 +20735,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e7",
+    "sortText": "000003f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20567,7 +20756,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e8",
+    "sortText": "000003f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20588,7 +20777,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e9",
+    "sortText": "000003f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20609,7 +20798,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ea",
+    "sortText": "000003f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20630,7 +20819,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003eb",
+    "sortText": "000003f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20651,7 +20840,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ec",
+    "sortText": "000003f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20672,7 +20861,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ed",
+    "sortText": "000003f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20693,7 +20882,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ee",
+    "sortText": "000003f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20714,7 +20903,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ef",
+    "sortText": "000003f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20735,7 +20924,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f0",
+    "sortText": "000003f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20756,7 +20945,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f1",
+    "sortText": "000003fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20777,7 +20966,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f2",
+    "sortText": "000003fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20798,7 +20987,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f3",
+    "sortText": "000003fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20819,7 +21008,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f4",
+    "sortText": "000003fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20840,7 +21029,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f5",
+    "sortText": "000003fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20861,7 +21050,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f6",
+    "sortText": "000003ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20882,7 +21071,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f7",
+    "sortText": "00000400",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20903,7 +21092,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f8",
+    "sortText": "00000401",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20924,7 +21113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f9",
+    "sortText": "00000402",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20945,7 +21134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fa",
+    "sortText": "00000403",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20966,7 +21155,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fb",
+    "sortText": "00000404",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20987,7 +21176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fc",
+    "sortText": "00000405",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21008,7 +21197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fd",
+    "sortText": "00000406",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21029,7 +21218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fe",
+    "sortText": "00000407",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21050,7 +21239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ff",
+    "sortText": "00000408",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21071,7 +21260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000400",
+    "sortText": "00000409",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21092,7 +21281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000401",
+    "sortText": "0000040a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21113,7 +21302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000402",
+    "sortText": "0000040b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21134,7 +21323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000403",
+    "sortText": "0000040c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21155,7 +21344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000404",
+    "sortText": "0000040d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21176,7 +21365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000405",
+    "sortText": "0000040e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21197,7 +21386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000406",
+    "sortText": "0000040f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21218,7 +21407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000407",
+    "sortText": "00000410",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21239,7 +21428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000408",
+    "sortText": "00000411",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21260,7 +21449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000409",
+    "sortText": "00000412",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21281,7 +21470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040a",
+    "sortText": "00000413",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21302,7 +21491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040b",
+    "sortText": "00000414",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21323,7 +21512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040c",
+    "sortText": "00000415",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21344,7 +21533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040d",
+    "sortText": "00000416",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21365,7 +21554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040e",
+    "sortText": "00000417",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21386,7 +21575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040f",
+    "sortText": "00000418",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21407,7 +21596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000410",
+    "sortText": "00000419",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21428,7 +21617,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000411",
+    "sortText": "0000041a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21449,7 +21638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000412",
+    "sortText": "0000041b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21470,7 +21659,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000413",
+    "sortText": "0000041c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21491,7 +21680,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000414",
+    "sortText": "0000041d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21512,7 +21701,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000415",
+    "sortText": "0000041e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21533,7 +21722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000416",
+    "sortText": "0000041f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21554,7 +21743,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000417",
+    "sortText": "00000420",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21575,7 +21764,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000418",
+    "sortText": "00000421",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21596,7 +21785,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000419",
+    "sortText": "00000422",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21617,7 +21806,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041a",
+    "sortText": "00000423",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21638,7 +21827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041b",
+    "sortText": "00000424",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21659,7 +21848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041c",
+    "sortText": "00000425",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21680,7 +21869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041d",
+    "sortText": "00000426",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21701,7 +21890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041e",
+    "sortText": "00000427",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21722,7 +21911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041f",
+    "sortText": "00000428",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21743,7 +21932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000420",
+    "sortText": "00000429",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21764,7 +21953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000421",
+    "sortText": "0000042a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21785,7 +21974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000422",
+    "sortText": "0000042b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21806,7 +21995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000423",
+    "sortText": "0000042c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21827,7 +22016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000424",
+    "sortText": "0000042d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21848,7 +22037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000425",
+    "sortText": "0000042e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21869,7 +22058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000426",
+    "sortText": "0000042f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21890,7 +22079,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000427",
+    "sortText": "00000430",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21911,7 +22100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000428",
+    "sortText": "00000431",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21932,7 +22121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000429",
+    "sortText": "00000432",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21953,7 +22142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042a",
+    "sortText": "00000433",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21974,7 +22163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042b",
+    "sortText": "00000434",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21995,7 +22184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042c",
+    "sortText": "00000435",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22016,7 +22205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042d",
+    "sortText": "00000436",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22037,7 +22226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042e",
+    "sortText": "00000437",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22058,7 +22247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042f",
+    "sortText": "00000438",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22079,7 +22268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000430",
+    "sortText": "00000439",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22100,7 +22289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000431",
+    "sortText": "0000043a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22121,7 +22310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000432",
+    "sortText": "0000043b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22142,7 +22331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000433",
+    "sortText": "0000043c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22163,7 +22352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000434",
+    "sortText": "0000043d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22184,7 +22373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000435",
+    "sortText": "0000043e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22205,7 +22394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000436",
+    "sortText": "0000043f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22226,7 +22415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000437",
+    "sortText": "00000440",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22247,7 +22436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000438",
+    "sortText": "00000441",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22268,7 +22457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000439",
+    "sortText": "00000442",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22289,7 +22478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043a",
+    "sortText": "00000443",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22310,7 +22499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043b",
+    "sortText": "00000444",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22331,7 +22520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043c",
+    "sortText": "00000445",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22352,7 +22541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043d",
+    "sortText": "00000446",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22373,7 +22562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043e",
+    "sortText": "00000447",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22394,7 +22583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043f",
+    "sortText": "00000448",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22415,7 +22604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000440",
+    "sortText": "00000449",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22436,7 +22625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000441",
+    "sortText": "0000044a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22457,7 +22646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000442",
+    "sortText": "0000044b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22478,7 +22667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000443",
+    "sortText": "0000044c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22499,7 +22688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000444",
+    "sortText": "0000044d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22520,7 +22709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000445",
+    "sortText": "0000044e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22541,7 +22730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000446",
+    "sortText": "0000044f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22562,7 +22751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000447",
+    "sortText": "00000450",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22583,7 +22772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000448",
+    "sortText": "00000451",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22604,7 +22793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000449",
+    "sortText": "00000452",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22625,7 +22814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044a",
+    "sortText": "00000453",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22646,7 +22835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044b",
+    "sortText": "00000454",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22667,7 +22856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044c",
+    "sortText": "00000455",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22688,7 +22877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044d",
+    "sortText": "00000456",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22709,7 +22898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044e",
+    "sortText": "00000457",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22730,7 +22919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044f",
+    "sortText": "00000458",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22751,7 +22940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000450",
+    "sortText": "00000459",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22772,7 +22961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000451",
+    "sortText": "0000045a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22793,7 +22982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000452",
+    "sortText": "0000045b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22814,7 +23003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000453",
+    "sortText": "0000045c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22835,7 +23024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000454",
+    "sortText": "0000045d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22856,7 +23045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000455",
+    "sortText": "0000045e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22877,7 +23066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000456",
+    "sortText": "0000045f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22898,7 +23087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000457",
+    "sortText": "00000460",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22919,7 +23108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000458",
+    "sortText": "00000461",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22940,7 +23129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000459",
+    "sortText": "00000462",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22961,7 +23150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045a",
+    "sortText": "00000463",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22982,7 +23171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045b",
+    "sortText": "00000464",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23003,7 +23192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045c",
+    "sortText": "00000465",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23024,7 +23213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045d",
+    "sortText": "00000466",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23045,7 +23234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045e",
+    "sortText": "00000467",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23066,7 +23255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045f",
+    "sortText": "00000468",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23087,7 +23276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000460",
+    "sortText": "00000469",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23108,7 +23297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000461",
+    "sortText": "0000046a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23129,7 +23318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000462",
+    "sortText": "0000046b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23150,7 +23339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000463",
+    "sortText": "0000046c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23171,7 +23360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000465",
+    "sortText": "0000046e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23192,7 +23381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000466",
+    "sortText": "0000046f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23213,7 +23402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000467",
+    "sortText": "00000470",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23234,7 +23423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000468",
+    "sortText": "00000471",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23255,7 +23444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000469",
+    "sortText": "00000472",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23276,7 +23465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046a",
+    "sortText": "00000473",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23297,7 +23486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046f",
+    "sortText": "00000478",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23318,7 +23507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000474",
+    "sortText": "0000047d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23339,7 +23528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000475",
+    "sortText": "0000047e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23360,7 +23549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000476",
+    "sortText": "0000047f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23381,7 +23570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000477",
+    "sortText": "00000480",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23402,7 +23591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000464",
+    "sortText": "0000046d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23423,7 +23612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046b",
+    "sortText": "00000474",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23444,7 +23633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046c",
+    "sortText": "00000475",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23465,7 +23654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046d",
+    "sortText": "00000476",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23486,7 +23675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046e",
+    "sortText": "00000477",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23507,7 +23696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000470",
+    "sortText": "00000479",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23528,7 +23717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000471",
+    "sortText": "0000047a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23549,7 +23738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000472",
+    "sortText": "0000047b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23570,7 +23759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000473",
+    "sortText": "0000047c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23591,7 +23780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000478",
+    "sortText": "00000481",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23612,7 +23801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000479",
+    "sortText": "00000482",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23633,7 +23822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047a",
+    "sortText": "00000483",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23654,7 +23843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047b",
+    "sortText": "00000484",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23675,7 +23864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047c",
+    "sortText": "00000485",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23696,7 +23885,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047d",
+    "sortText": "00000486",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23717,7 +23906,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047e",
+    "sortText": "00000487",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23738,7 +23927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047f",
+    "sortText": "00000488",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23759,7 +23948,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000480",
+    "sortText": "00000489",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23780,7 +23969,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000481",
+    "sortText": "0000048a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23801,7 +23990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000482",
+    "sortText": "0000048b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23822,7 +24011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000483",
+    "sortText": "0000048c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23843,7 +24032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000484",
+    "sortText": "0000048d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23864,7 +24053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000485",
+    "sortText": "0000048e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23885,7 +24074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000486",
+    "sortText": "0000048f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23906,7 +24095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000487",
+    "sortText": "00000490",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23927,7 +24116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000488",
+    "sortText": "00000491",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23948,7 +24137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000489",
+    "sortText": "00000492",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23969,7 +24158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048c",
+    "sortText": "00000495",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23990,7 +24179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048d",
+    "sortText": "00000496",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24011,7 +24200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048a",
+    "sortText": "00000493",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24032,7 +24221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048b",
+    "sortText": "00000494",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24053,7 +24242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048e",
+    "sortText": "00000497",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24074,7 +24263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048f",
+    "sortText": "00000498",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24095,7 +24284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000490",
+    "sortText": "00000499",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24116,7 +24305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000491",
+    "sortText": "0000049a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24137,7 +24326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000492",
+    "sortText": "0000049b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24158,7 +24347,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000493",
+    "sortText": "0000049c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24179,7 +24368,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000494",
+    "sortText": "0000049d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24200,7 +24389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000495",
+    "sortText": "0000049e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24221,7 +24410,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000496",
+    "sortText": "0000049f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24242,7 +24431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000497",
+    "sortText": "000004a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24263,7 +24452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000498",
+    "sortText": "000004a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24284,7 +24473,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000499",
+    "sortText": "000004a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24305,7 +24494,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049a",
+    "sortText": "000004a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24326,7 +24515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049b",
+    "sortText": "000004a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24347,7 +24536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049c",
+    "sortText": "000004a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24368,7 +24557,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049d",
+    "sortText": "000004a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24389,7 +24578,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049e",
+    "sortText": "000004a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24410,7 +24599,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049f",
+    "sortText": "000004a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24431,7 +24620,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a0",
+    "sortText": "000004a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24452,7 +24641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a4",
+    "sortText": "000004ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24473,7 +24662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a1",
+    "sortText": "000004aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24494,7 +24683,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a2",
+    "sortText": "000004ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24515,7 +24704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a3",
+    "sortText": "000004ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24536,7 +24725,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a5",
+    "sortText": "000004ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24557,7 +24746,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a6",
+    "sortText": "000004af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24578,7 +24767,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a7",
+    "sortText": "000004b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24599,7 +24788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a8",
+    "sortText": "000004b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24620,7 +24809,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a9",
+    "sortText": "000004b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24641,7 +24830,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004aa",
+    "sortText": "000004b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24662,7 +24851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ab",
+    "sortText": "000004b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24683,7 +24872,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ac",
+    "sortText": "000004b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24704,7 +24893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ad",
+    "sortText": "000004b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24725,7 +24914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ae",
+    "sortText": "000004b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24746,7 +24935,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004af",
+    "sortText": "000004b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24767,7 +24956,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b0",
+    "sortText": "000004b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24788,7 +24977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b1",
+    "sortText": "000004ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24809,7 +24998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b2",
+    "sortText": "000004bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24830,7 +25019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b3",
+    "sortText": "000004bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24851,7 +25040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b4",
+    "sortText": "000004bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24872,7 +25061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b9",
+    "sortText": "000004c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24893,7 +25082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e7",
+    "sortText": "000004f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24914,7 +25103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e9",
+    "sortText": "000004f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24935,7 +25124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ea",
+    "sortText": "000004f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24956,7 +25145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f3",
+    "sortText": "000004fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24977,7 +25166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f5",
+    "sortText": "000004fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24998,7 +25187,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000501",
+    "sortText": "0000050a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25019,7 +25208,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000502",
+    "sortText": "0000050b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25040,7 +25229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b5",
+    "sortText": "000004be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25061,7 +25250,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b6",
+    "sortText": "000004bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25082,7 +25271,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b7",
+    "sortText": "000004c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25103,7 +25292,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b8",
+    "sortText": "000004c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25124,7 +25313,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ba",
+    "sortText": "000004c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25145,7 +25334,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bb",
+    "sortText": "000004c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25166,7 +25355,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bc",
+    "sortText": "000004c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25187,7 +25376,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bd",
+    "sortText": "000004c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25208,7 +25397,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004be",
+    "sortText": "000004c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25229,7 +25418,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bf",
+    "sortText": "000004c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25250,7 +25439,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c0",
+    "sortText": "000004c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25271,7 +25460,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c1",
+    "sortText": "000004ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25292,7 +25481,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c2",
+    "sortText": "000004cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25313,7 +25502,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c3",
+    "sortText": "000004cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25334,7 +25523,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c4",
+    "sortText": "000004cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25355,7 +25544,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c5",
+    "sortText": "000004ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25376,7 +25565,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c6",
+    "sortText": "000004cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25397,7 +25586,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c7",
+    "sortText": "000004d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25418,7 +25607,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c8",
+    "sortText": "000004d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25439,7 +25628,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ca",
+    "sortText": "000004d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25460,7 +25649,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cc",
+    "sortText": "000004d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25481,7 +25670,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ce",
+    "sortText": "000004d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25502,7 +25691,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cf",
+    "sortText": "000004d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25523,7 +25712,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d1",
+    "sortText": "000004da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25544,7 +25733,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d3",
+    "sortText": "000004dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25565,7 +25754,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d5",
+    "sortText": "000004de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25586,7 +25775,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d7",
+    "sortText": "000004e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25607,7 +25796,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d9",
+    "sortText": "000004e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25628,7 +25817,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004db",
+    "sortText": "000004e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25649,7 +25838,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c9",
+    "sortText": "000004d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25670,7 +25859,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cb",
+    "sortText": "000004d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25691,7 +25880,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cd",
+    "sortText": "000004d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25712,7 +25901,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d0",
+    "sortText": "000004d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25733,7 +25922,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d2",
+    "sortText": "000004db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25754,7 +25943,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d4",
+    "sortText": "000004dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25775,7 +25964,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d6",
+    "sortText": "000004df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25796,7 +25985,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d8",
+    "sortText": "000004e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25817,7 +26006,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004da",
+    "sortText": "000004e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25838,7 +26027,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004dc",
+    "sortText": "000004e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25859,7 +26048,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004dd",
+    "sortText": "000004e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25880,7 +26069,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004de",
+    "sortText": "000004e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25901,7 +26090,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004df",
+    "sortText": "000004e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25922,7 +26111,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e0",
+    "sortText": "000004e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25943,7 +26132,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e1",
+    "sortText": "000004ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25964,7 +26153,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e2",
+    "sortText": "000004eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25985,7 +26174,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e3",
+    "sortText": "000004ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26006,7 +26195,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e4",
+    "sortText": "000004ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26027,7 +26216,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e5",
+    "sortText": "000004ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26048,7 +26237,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e6",
+    "sortText": "000004ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26069,7 +26258,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e8",
+    "sortText": "000004f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26090,7 +26279,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004eb",
+    "sortText": "000004f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26111,7 +26300,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ec",
+    "sortText": "000004f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26132,7 +26321,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ed",
+    "sortText": "000004f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26153,7 +26342,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ee",
+    "sortText": "000004f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26174,7 +26363,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ef",
+    "sortText": "000004f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26195,7 +26384,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f0",
+    "sortText": "000004f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26216,7 +26405,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f1",
+    "sortText": "000004fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26237,7 +26426,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f2",
+    "sortText": "000004fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26258,7 +26447,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f4",
+    "sortText": "000004fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26279,7 +26468,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f6",
+    "sortText": "000004ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26300,7 +26489,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f7",
+    "sortText": "00000500",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26321,7 +26510,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f8",
+    "sortText": "00000501",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26342,7 +26531,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f9",
+    "sortText": "00000502",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26363,7 +26552,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fa",
+    "sortText": "00000503",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26384,7 +26573,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fb",
+    "sortText": "00000504",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26405,7 +26594,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fc",
+    "sortText": "00000505",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26426,7 +26615,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fd",
+    "sortText": "00000506",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26447,7 +26636,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fe",
+    "sortText": "00000507",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26468,7 +26657,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ff",
+    "sortText": "00000508",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26489,7 +26678,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000500",
+    "sortText": "00000509",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26510,7 +26699,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000503",
+    "sortText": "0000050c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26531,7 +26720,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000504",
+    "sortText": "0000050d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26552,7 +26741,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000505",
+    "sortText": "0000050e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26573,7 +26762,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000506",
+    "sortText": "0000050f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26594,7 +26783,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000507",
+    "sortText": "00000510",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26615,7 +26804,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000508",
+    "sortText": "00000511",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26636,7 +26825,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000509",
+    "sortText": "00000512",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26657,7 +26846,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050a",
+    "sortText": "00000513",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26678,7 +26867,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050b",
+    "sortText": "00000514",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26699,7 +26888,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050c",
+    "sortText": "00000515",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26720,7 +26909,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050d",
+    "sortText": "00000516",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26741,7 +26930,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050e",
+    "sortText": "00000517",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26762,7 +26951,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050f",
+    "sortText": "00000518",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26783,7 +26972,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000510",
+    "sortText": "00000519",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26804,7 +26993,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000511",
+    "sortText": "0000051a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26825,7 +27014,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000512",
+    "sortText": "0000051b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26846,7 +27035,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000513",
+    "sortText": "0000051c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26867,7 +27056,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000514",
+    "sortText": "0000051d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26888,7 +27077,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000515",
+    "sortText": "0000051e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26909,7 +27098,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000516",
+    "sortText": "0000051f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26930,7 +27119,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000517",
+    "sortText": "00000520",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26951,7 +27140,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000518",
+    "sortText": "00000521",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26972,7 +27161,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000519",
+    "sortText": "00000522",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26993,7 +27182,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051a",
+    "sortText": "00000523",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27014,7 +27203,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051b",
+    "sortText": "00000524",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27035,7 +27224,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051f",
+    "sortText": "00000528",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27056,7 +27245,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051c",
+    "sortText": "00000525",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27077,7 +27266,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051d",
+    "sortText": "00000526",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27098,7 +27287,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051e",
+    "sortText": "00000527",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27119,7 +27308,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000520",
+    "sortText": "00000529",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27140,7 +27329,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000521",
+    "sortText": "0000052a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27161,7 +27350,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000522",
+    "sortText": "0000052b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27182,7 +27371,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000523",
+    "sortText": "0000052c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27203,7 +27392,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000524",
+    "sortText": "0000052d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27224,7 +27413,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000525",
+    "sortText": "0000052e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27245,7 +27434,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000526",
+    "sortText": "0000052f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27266,7 +27455,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000527",
+    "sortText": "00000530",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27287,7 +27476,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000528",
+    "sortText": "00000531",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27308,7 +27497,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000529",
+    "sortText": "00000532",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27329,7 +27518,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052a",
+    "sortText": "00000533",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27350,7 +27539,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052b",
+    "sortText": "00000534",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27371,7 +27560,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052c",
+    "sortText": "00000535",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27392,7 +27581,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052d",
+    "sortText": "00000536",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27413,7 +27602,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052e",
+    "sortText": "00000537",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27434,7 +27623,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052f",
+    "sortText": "00000538",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27455,7 +27644,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000530",
+    "sortText": "00000539",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27476,7 +27665,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000531",
+    "sortText": "0000053a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27497,7 +27686,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000532",
+    "sortText": "0000053b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27518,7 +27707,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000533",
+    "sortText": "0000053c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27539,7 +27728,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000534",
+    "sortText": "0000053d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27560,7 +27749,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000535",
+    "sortText": "0000053e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27581,7 +27770,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000536",
+    "sortText": "0000053f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27602,7 +27791,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000537",
+    "sortText": "00000540",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27623,7 +27812,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000538",
+    "sortText": "00000541",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27644,7 +27833,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000539",
+    "sortText": "00000542",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27665,7 +27854,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053a",
+    "sortText": "00000543",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27686,7 +27875,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053b",
+    "sortText": "00000544",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27707,7 +27896,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053c",
+    "sortText": "00000545",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27728,7 +27917,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000542",
+    "sortText": "0000054b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27749,7 +27938,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053d",
+    "sortText": "00000546",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27770,7 +27959,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053e",
+    "sortText": "00000547",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27791,7 +27980,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053f",
+    "sortText": "00000548",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27812,7 +28001,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000541",
+    "sortText": "0000054a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27833,7 +28022,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000540",
+    "sortText": "00000549",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27854,7 +28043,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000543",
+    "sortText": "0000054c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27875,7 +28064,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000544",
+    "sortText": "0000054d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27896,7 +28085,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000545",
+    "sortText": "0000054e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27917,7 +28106,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000546",
+    "sortText": "0000054f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27938,7 +28127,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000547",
+    "sortText": "00000550",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27959,7 +28148,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000548",
+    "sortText": "00000551",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27980,7 +28169,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000549",
+    "sortText": "00000552",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28001,7 +28190,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054a",
+    "sortText": "00000553",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28022,7 +28211,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054b",
+    "sortText": "00000554",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28043,7 +28232,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054d",
+    "sortText": "00000556",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28064,7 +28253,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000553",
+    "sortText": "0000055c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28085,7 +28274,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054e",
+    "sortText": "00000557",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28106,7 +28295,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000550",
+    "sortText": "00000559",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28127,7 +28316,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000552",
+    "sortText": "0000055b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28148,7 +28337,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000554",
+    "sortText": "0000055d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28169,7 +28358,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000555",
+    "sortText": "0000055e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28190,7 +28379,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000556",
+    "sortText": "0000055f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28211,7 +28400,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000557",
+    "sortText": "00000560",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28232,7 +28421,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054c",
+    "sortText": "00000555",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28253,7 +28442,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054f",
+    "sortText": "00000558",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28274,7 +28463,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000551",
+    "sortText": "0000055a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28295,7 +28484,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000558",
+    "sortText": "00000561",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28316,7 +28505,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000559",
+    "sortText": "00000562",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28337,7 +28526,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055a",
+    "sortText": "00000563",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28358,7 +28547,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055b",
+    "sortText": "00000564",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28379,7 +28568,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055c",
+    "sortText": "00000565",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28400,7 +28589,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055d",
+    "sortText": "00000566",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28421,7 +28610,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055e",
+    "sortText": "00000567",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28442,7 +28631,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055f",
+    "sortText": "00000568",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28463,7 +28652,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000560",
+    "sortText": "00000569",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28484,7 +28673,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000561",
+    "sortText": "0000056a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28505,7 +28694,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000562",
+    "sortText": "0000056b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28526,7 +28715,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000563",
+    "sortText": "0000056c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28547,7 +28736,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000564",
+    "sortText": "0000056d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28568,7 +28757,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000565",
+    "sortText": "0000056e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28589,7 +28778,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000566",
+    "sortText": "0000056f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28610,7 +28799,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000567",
+    "sortText": "00000570",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28631,7 +28820,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000568",
+    "sortText": "00000571",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28652,7 +28841,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000569",
+    "sortText": "00000572",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28673,7 +28862,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056b",
+    "sortText": "00000574",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28694,7 +28883,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056c",
+    "sortText": "00000575",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28715,7 +28904,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056a",
+    "sortText": "00000573",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28736,7 +28925,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056d",
+    "sortText": "00000576",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28757,7 +28946,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056e",
+    "sortText": "00000577",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28778,7 +28967,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056f",
+    "sortText": "00000578",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28799,7 +28988,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000570",
+    "sortText": "00000579",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28820,7 +29009,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000571",
+    "sortText": "0000057a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28841,7 +29030,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000572",
+    "sortText": "0000057b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28862,7 +29051,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000573",
+    "sortText": "0000057c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28883,12 +29072,138 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000574",
+    "sortText": "0000057d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.OperationalInsights/workspaces/dataSources@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.OperationalInsights/workspaces/features/clientGroups'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/clientGroups`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "0000057e",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.OperationalInsights/workspaces/features/clientGroups@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.OperationalInsights/workspaces/features/machineGroups'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machineGroups`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "0000057f",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.OperationalInsights/workspaces/features/machineGroups@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.OperationalInsights/workspaces/features/machines'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000580",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.OperationalInsights/workspaces/features/machines@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.OperationalInsights/workspaces/features/machines/ports'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines/ports`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000581",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.OperationalInsights/workspaces/features/machines/ports@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.OperationalInsights/workspaces/features/machines/processes'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/machines/processes`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000582",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.OperationalInsights/workspaces/features/machines/processes@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.OperationalInsights/workspaces/features/summaries'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.OperationalInsights/workspaces/features/summaries`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000583",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.OperationalInsights/workspaces/features/summaries@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -28904,7 +29219,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000575",
+    "sortText": "00000584",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28925,7 +29240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000576",
+    "sortText": "00000585",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28946,7 +29261,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000577",
+    "sortText": "00000586",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28967,7 +29282,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000578",
+    "sortText": "00000587",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -28988,7 +29303,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000579",
+    "sortText": "00000588",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29009,7 +29324,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057a",
+    "sortText": "00000589",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29030,7 +29345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057b",
+    "sortText": "0000058a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29051,7 +29366,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057c",
+    "sortText": "0000058b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29072,7 +29387,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057d",
+    "sortText": "0000058c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29093,7 +29408,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057e",
+    "sortText": "0000058d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29114,7 +29429,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057f",
+    "sortText": "0000058e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29135,7 +29450,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000580",
+    "sortText": "0000058f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29156,7 +29471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000584",
+    "sortText": "00000593",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29177,7 +29492,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000585",
+    "sortText": "00000594",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29198,7 +29513,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000586",
+    "sortText": "00000595",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29219,7 +29534,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000581",
+    "sortText": "00000590",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29240,7 +29555,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000582",
+    "sortText": "00000591",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29261,7 +29576,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000583",
+    "sortText": "00000592",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29282,7 +29597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000587",
+    "sortText": "00000596",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29303,7 +29618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000588",
+    "sortText": "00000597",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29324,7 +29639,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000589",
+    "sortText": "00000598",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29345,7 +29660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058a",
+    "sortText": "00000599",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29366,7 +29681,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058b",
+    "sortText": "0000059a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29387,7 +29702,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058c",
+    "sortText": "0000059b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29408,7 +29723,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058d",
+    "sortText": "0000059c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29429,7 +29744,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058e",
+    "sortText": "0000059d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29450,7 +29765,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058f",
+    "sortText": "0000059e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29471,7 +29786,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000590",
+    "sortText": "0000059f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29492,7 +29807,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000591",
+    "sortText": "000005a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29513,7 +29828,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000592",
+    "sortText": "000005a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29534,7 +29849,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000593",
+    "sortText": "000005a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29555,7 +29870,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000594",
+    "sortText": "000005a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29576,7 +29891,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000595",
+    "sortText": "000005a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29597,7 +29912,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000596",
+    "sortText": "000005a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29618,7 +29933,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000597",
+    "sortText": "000005a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29639,7 +29954,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000598",
+    "sortText": "000005a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29660,7 +29975,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000599",
+    "sortText": "000005a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29681,7 +29996,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059a",
+    "sortText": "000005a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29702,7 +30017,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059b",
+    "sortText": "000005aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29723,7 +30038,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059c",
+    "sortText": "000005ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29744,7 +30059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059d",
+    "sortText": "000005ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29765,7 +30080,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059e",
+    "sortText": "000005ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29786,7 +30101,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059f",
+    "sortText": "000005ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29807,7 +30122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a0",
+    "sortText": "000005af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29828,7 +30143,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a1",
+    "sortText": "000005b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29849,7 +30164,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a2",
+    "sortText": "000005b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29870,7 +30185,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a3",
+    "sortText": "000005b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29891,7 +30206,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a4",
+    "sortText": "000005b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29912,7 +30227,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a5",
+    "sortText": "000005b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29933,7 +30248,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a6",
+    "sortText": "000005b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29954,7 +30269,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a7",
+    "sortText": "000005b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29975,7 +30290,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a8",
+    "sortText": "000005b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29996,7 +30311,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a9",
+    "sortText": "000005b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30017,7 +30332,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005aa",
+    "sortText": "000005b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30038,7 +30353,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ab",
+    "sortText": "000005ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30059,7 +30374,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ad",
+    "sortText": "000005bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30080,7 +30395,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ae",
+    "sortText": "000005bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30101,7 +30416,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005af",
+    "sortText": "000005be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30122,7 +30437,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b0",
+    "sortText": "000005bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30143,7 +30458,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b1",
+    "sortText": "000005c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30164,7 +30479,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b2",
+    "sortText": "000005c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30185,7 +30500,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b3",
+    "sortText": "000005c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30206,7 +30521,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b4",
+    "sortText": "000005c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30227,7 +30542,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b5",
+    "sortText": "000005c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30248,7 +30563,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b6",
+    "sortText": "000005c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30269,7 +30584,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b7",
+    "sortText": "000005c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30290,7 +30605,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b8",
+    "sortText": "000005c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30311,7 +30626,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ac",
+    "sortText": "000005bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30332,7 +30647,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b9",
+    "sortText": "000005c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30353,7 +30668,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ba",
+    "sortText": "000005c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30374,7 +30689,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bb",
+    "sortText": "000005ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30395,7 +30710,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bc",
+    "sortText": "000005cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30416,7 +30731,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bd",
+    "sortText": "000005cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30437,7 +30752,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005be",
+    "sortText": "000005cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30458,7 +30773,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bf",
+    "sortText": "000005ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30479,7 +30794,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c0",
+    "sortText": "000005cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30500,7 +30815,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c1",
+    "sortText": "000005d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30521,7 +30836,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c2",
+    "sortText": "000005d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30542,7 +30857,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c3",
+    "sortText": "000005d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30563,7 +30878,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c4",
+    "sortText": "000005d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30584,7 +30899,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c5",
+    "sortText": "000005d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30605,7 +30920,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c6",
+    "sortText": "000005d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30626,7 +30941,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c7",
+    "sortText": "000005d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30647,7 +30962,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c8",
+    "sortText": "000005d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30668,7 +30983,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c9",
+    "sortText": "000005d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30689,7 +31004,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ca",
+    "sortText": "000005d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30710,7 +31025,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cb",
+    "sortText": "000005da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30731,7 +31046,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cc",
+    "sortText": "000005db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30752,7 +31067,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cd",
+    "sortText": "000005dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30773,7 +31088,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ce",
+    "sortText": "000005dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30794,7 +31109,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cf",
+    "sortText": "000005de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30815,7 +31130,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d0",
+    "sortText": "000005df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30836,7 +31151,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d1",
+    "sortText": "000005e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30857,7 +31172,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d2",
+    "sortText": "000005e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30878,7 +31193,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d3",
+    "sortText": "000005e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30899,12 +31214,96 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d4",
+    "sortText": "000005e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.RedHatOpenShift/openShiftClusters@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RedHatOpenShift/openshiftclusters/machinePool'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/machinePool`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005e4",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RedHatOpenShift/openshiftclusters/machinePool@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RedHatOpenShift/openshiftclusters/secret'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/secret`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005e5",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RedHatOpenShift/openshiftclusters/secret@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RedHatOpenShift/openshiftclusters/syncIdentityProvider'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/syncIdentityProvider`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005e6",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RedHatOpenShift/openshiftclusters/syncIdentityProvider@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RedHatOpenShift/openshiftclusters/syncSet'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RedHatOpenShift/openshiftclusters/syncSet`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005e7",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RedHatOpenShift/openshiftclusters/syncSet@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -30920,7 +31319,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d5",
+    "sortText": "000005e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30941,7 +31340,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d7",
+    "sortText": "000005ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30962,7 +31361,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d9",
+    "sortText": "000005ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30983,7 +31382,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005db",
+    "sortText": "000005ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31004,7 +31403,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005df",
+    "sortText": "000005f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31025,7 +31424,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e1",
+    "sortText": "000005f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31046,7 +31445,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d6",
+    "sortText": "000005e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31067,7 +31466,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d8",
+    "sortText": "000005eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31088,7 +31487,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005da",
+    "sortText": "000005ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31109,7 +31508,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005dc",
+    "sortText": "000005ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31130,7 +31529,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005dd",
+    "sortText": "000005f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31151,7 +31550,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005de",
+    "sortText": "000005f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31172,7 +31571,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e0",
+    "sortText": "000005f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31193,7 +31592,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e2",
+    "sortText": "000005f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31214,7 +31613,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e3",
+    "sortText": "000005f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31235,7 +31634,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e4",
+    "sortText": "000005f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31256,7 +31655,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e5",
+    "sortText": "000005f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31277,7 +31676,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e6",
+    "sortText": "000005f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31298,7 +31697,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e7",
+    "sortText": "000005fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31319,7 +31718,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e8",
+    "sortText": "000005fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31340,7 +31739,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e9",
+    "sortText": "000005fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31361,7 +31760,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ea",
+    "sortText": "000005fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31382,7 +31781,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ec",
+    "sortText": "000005ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31403,7 +31802,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ed",
+    "sortText": "00000600",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31424,7 +31823,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005eb",
+    "sortText": "000005fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31445,7 +31844,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ee",
+    "sortText": "00000601",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31466,7 +31865,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ef",
+    "sortText": "00000602",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31487,7 +31886,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f0",
+    "sortText": "00000603",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31508,7 +31907,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f1",
+    "sortText": "00000604",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31529,7 +31928,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f2",
+    "sortText": "00000605",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31550,7 +31949,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f5",
+    "sortText": "00000608",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31571,7 +31970,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f6",
+    "sortText": "00000609",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31592,7 +31991,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f8",
+    "sortText": "0000060b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31613,7 +32012,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f7",
+    "sortText": "0000060a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31634,7 +32033,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f9",
+    "sortText": "0000060c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31655,7 +32054,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fa",
+    "sortText": "0000060d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31676,7 +32075,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fb",
+    "sortText": "0000060e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31697,7 +32096,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f3",
+    "sortText": "00000606",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31718,7 +32117,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f4",
+    "sortText": "00000607",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31739,7 +32138,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fc",
+    "sortText": "0000060f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31760,7 +32159,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fd",
+    "sortText": "00000610",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31781,7 +32180,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fe",
+    "sortText": "00000611",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31802,7 +32201,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ff",
+    "sortText": "00000612",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31823,7 +32222,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000600",
+    "sortText": "00000613",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31844,7 +32243,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000601",
+    "sortText": "00000614",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31865,7 +32264,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000602",
+    "sortText": "00000615",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31886,7 +32285,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000603",
+    "sortText": "00000616",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31907,7 +32306,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000604",
+    "sortText": "00000617",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31928,7 +32327,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000605",
+    "sortText": "00000618",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31949,7 +32348,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000606",
+    "sortText": "00000619",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31970,7 +32369,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000607",
+    "sortText": "0000061a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31991,7 +32390,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000608",
+    "sortText": "0000061b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32012,7 +32411,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060a",
+    "sortText": "0000061d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32033,7 +32432,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000609",
+    "sortText": "0000061c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32054,7 +32453,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060b",
+    "sortText": "0000061e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32075,7 +32474,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060c",
+    "sortText": "0000061f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32096,7 +32495,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060d",
+    "sortText": "00000620",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32117,7 +32516,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060e",
+    "sortText": "00000621",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32138,7 +32537,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060f",
+    "sortText": "00000622",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32159,7 +32558,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000610",
+    "sortText": "00000623",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32180,7 +32579,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000611",
+    "sortText": "00000624",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32201,7 +32600,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000612",
+    "sortText": "00000625",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32222,7 +32621,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000613",
+    "sortText": "00000626",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32243,7 +32642,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000614",
+    "sortText": "00000627",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32264,7 +32663,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000615",
+    "sortText": "00000628",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32285,7 +32684,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000616",
+    "sortText": "00000629",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32306,7 +32705,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000617",
+    "sortText": "0000062a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32327,7 +32726,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000619",
+    "sortText": "0000062c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32348,7 +32747,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000618",
+    "sortText": "0000062b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32369,7 +32768,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061b",
+    "sortText": "0000062e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32390,7 +32789,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061a",
+    "sortText": "0000062d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32411,7 +32810,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061c",
+    "sortText": "0000062f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32432,7 +32831,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000621",
+    "sortText": "00000634",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32453,7 +32852,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061d",
+    "sortText": "00000630",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32474,7 +32873,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061e",
+    "sortText": "00000631",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32495,7 +32894,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061f",
+    "sortText": "00000632",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32516,7 +32915,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000620",
+    "sortText": "00000633",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32537,7 +32936,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000622",
+    "sortText": "00000635",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32558,7 +32957,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000623",
+    "sortText": "00000636",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32579,7 +32978,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000624",
+    "sortText": "00000637",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32600,7 +32999,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000625",
+    "sortText": "00000638",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32621,7 +33020,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000626",
+    "sortText": "00000639",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32642,7 +33041,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000627",
+    "sortText": "0000063a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32663,7 +33062,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000628",
+    "sortText": "0000063b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32684,7 +33083,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000629",
+    "sortText": "0000063c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32705,7 +33104,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062a",
+    "sortText": "0000063d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32726,7 +33125,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062b",
+    "sortText": "0000063e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32747,7 +33146,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062c",
+    "sortText": "0000063f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32768,7 +33167,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062d",
+    "sortText": "00000640",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32789,7 +33188,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062e",
+    "sortText": "00000641",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32810,7 +33209,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062f",
+    "sortText": "00000642",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32831,7 +33230,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000630",
+    "sortText": "00000643",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32852,7 +33251,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000631",
+    "sortText": "00000644",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32873,7 +33272,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000632",
+    "sortText": "00000645",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32894,7 +33293,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000633",
+    "sortText": "00000646",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32915,7 +33314,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000634",
+    "sortText": "00000647",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32936,7 +33335,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000635",
+    "sortText": "00000648",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32957,7 +33356,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000636",
+    "sortText": "00000649",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32978,7 +33377,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000637",
+    "sortText": "0000064a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32999,7 +33398,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000638",
+    "sortText": "0000064b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33020,7 +33419,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000639",
+    "sortText": "0000064c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33041,7 +33440,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063a",
+    "sortText": "0000064d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33062,7 +33461,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063b",
+    "sortText": "0000064e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33083,7 +33482,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063c",
+    "sortText": "0000064f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33104,7 +33503,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063d",
+    "sortText": "00000650",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33125,7 +33524,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063e",
+    "sortText": "00000651",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33146,7 +33545,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063f",
+    "sortText": "00000652",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33167,7 +33566,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000640",
+    "sortText": "00000653",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33188,7 +33587,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000641",
+    "sortText": "00000654",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33209,7 +33608,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000642",
+    "sortText": "00000655",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33230,7 +33629,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000643",
+    "sortText": "00000656",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33251,7 +33650,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000644",
+    "sortText": "00000657",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33272,7 +33671,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000645",
+    "sortText": "00000658",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33293,7 +33692,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000646",
+    "sortText": "00000659",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33314,7 +33713,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000647",
+    "sortText": "0000065a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33335,7 +33734,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000648",
+    "sortText": "0000065b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33356,7 +33755,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000649",
+    "sortText": "0000065c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33377,7 +33776,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064a",
+    "sortText": "0000065d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33398,7 +33797,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064b",
+    "sortText": "0000065e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33419,7 +33818,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064c",
+    "sortText": "0000065f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33440,7 +33839,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064f",
+    "sortText": "00000662",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33461,7 +33860,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064d",
+    "sortText": "00000660",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33482,7 +33881,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064e",
+    "sortText": "00000661",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33503,7 +33902,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000650",
+    "sortText": "00000663",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33524,7 +33923,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000651",
+    "sortText": "00000664",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33545,7 +33944,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000652",
+    "sortText": "00000665",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33566,7 +33965,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000653",
+    "sortText": "00000666",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33587,7 +33986,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000654",
+    "sortText": "00000667",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33608,7 +34007,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000655",
+    "sortText": "00000668",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33629,7 +34028,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000656",
+    "sortText": "00000669",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33650,7 +34049,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000657",
+    "sortText": "0000066a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33671,7 +34070,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000658",
+    "sortText": "0000066b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33692,7 +34091,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000659",
+    "sortText": "0000066c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33713,7 +34112,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065a",
+    "sortText": "0000066d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33734,7 +34133,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065b",
+    "sortText": "0000066e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33755,7 +34154,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065c",
+    "sortText": "0000066f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33776,7 +34175,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065d",
+    "sortText": "00000670",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33797,12 +34196,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065e",
+    "sortText": "00000671",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.SecurityInsights/incidents/relations@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.SecurityInsights/incidents/tasks'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.SecurityInsights/incidents/tasks`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000672",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.SecurityInsights/incidents/tasks@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -33818,7 +34238,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065f",
+    "sortText": "00000673",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33839,7 +34259,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000660",
+    "sortText": "00000674",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33860,7 +34280,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000661",
+    "sortText": "00000675",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33881,7 +34301,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000662",
+    "sortText": "00000676",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33902,7 +34322,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000663",
+    "sortText": "00000677",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33923,7 +34343,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000664",
+    "sortText": "00000678",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33944,7 +34364,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000665",
+    "sortText": "00000679",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33965,7 +34385,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000666",
+    "sortText": "0000067a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33986,7 +34406,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000667",
+    "sortText": "0000067b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34007,7 +34427,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000668",
+    "sortText": "0000067c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34028,7 +34448,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000669",
+    "sortText": "0000067d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34049,7 +34469,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066a",
+    "sortText": "0000067e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34070,7 +34490,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066b",
+    "sortText": "0000067f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34091,7 +34511,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066d",
+    "sortText": "00000681",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34112,7 +34532,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066c",
+    "sortText": "00000680",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34133,7 +34553,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066e",
+    "sortText": "00000682",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34154,7 +34574,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066f",
+    "sortText": "00000683",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34175,7 +34595,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000670",
+    "sortText": "00000684",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34196,7 +34616,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000671",
+    "sortText": "00000685",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34217,7 +34637,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000672",
+    "sortText": "00000686",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34238,7 +34658,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000673",
+    "sortText": "00000687",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34259,7 +34679,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000674",
+    "sortText": "00000688",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34280,7 +34700,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000675",
+    "sortText": "00000689",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34301,7 +34721,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000676",
+    "sortText": "0000068a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34322,7 +34742,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000677",
+    "sortText": "0000068b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34343,7 +34763,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000678",
+    "sortText": "0000068c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34364,7 +34784,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000679",
+    "sortText": "0000068d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34385,7 +34805,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067c",
+    "sortText": "00000690",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34406,7 +34826,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067d",
+    "sortText": "00000691",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34427,7 +34847,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067a",
+    "sortText": "0000068e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34448,7 +34868,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067b",
+    "sortText": "0000068f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34469,7 +34889,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067e",
+    "sortText": "00000692",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34490,7 +34910,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000683",
+    "sortText": "00000697",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34511,7 +34931,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000681",
+    "sortText": "00000695",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34532,7 +34952,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000682",
+    "sortText": "00000696",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34553,7 +34973,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067f",
+    "sortText": "00000693",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34574,7 +34994,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000680",
+    "sortText": "00000694",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34595,7 +35015,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000684",
+    "sortText": "00000698",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34616,7 +35036,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000685",
+    "sortText": "00000699",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34637,7 +35057,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000686",
+    "sortText": "0000069a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34658,7 +35078,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000687",
+    "sortText": "0000069b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34679,7 +35099,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000688",
+    "sortText": "0000069c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34700,7 +35120,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000689",
+    "sortText": "0000069d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34721,7 +35141,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068a",
+    "sortText": "0000069e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34742,7 +35162,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068b",
+    "sortText": "0000069f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34763,7 +35183,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068c",
+    "sortText": "000006a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34784,7 +35204,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068d",
+    "sortText": "000006a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34805,7 +35225,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068e",
+    "sortText": "000006a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34826,7 +35246,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068f",
+    "sortText": "000006a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34847,7 +35267,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000690",
+    "sortText": "000006a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34868,7 +35288,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000691",
+    "sortText": "000006a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34889,7 +35309,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000693",
+    "sortText": "000006a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34910,7 +35330,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000692",
+    "sortText": "000006a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34931,7 +35351,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000694",
+    "sortText": "000006a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34952,7 +35372,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000695",
+    "sortText": "000006a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34973,7 +35393,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000696",
+    "sortText": "000006aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34994,7 +35414,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000697",
+    "sortText": "000006ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35015,7 +35435,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000698",
+    "sortText": "000006ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35036,7 +35456,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000699",
+    "sortText": "000006ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35057,7 +35477,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069a",
+    "sortText": "000006ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35078,7 +35498,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069b",
+    "sortText": "000006af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35099,7 +35519,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069c",
+    "sortText": "000006b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35120,7 +35540,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069d",
+    "sortText": "000006b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35141,7 +35561,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069e",
+    "sortText": "000006b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35162,7 +35582,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069f",
+    "sortText": "000006b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35183,7 +35603,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a0",
+    "sortText": "000006b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35204,7 +35624,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a1",
+    "sortText": "000006b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35225,7 +35645,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a2",
+    "sortText": "000006b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35246,7 +35666,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a3",
+    "sortText": "000006b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35267,7 +35687,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a4",
+    "sortText": "000006b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35288,7 +35708,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a5",
+    "sortText": "000006b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35309,7 +35729,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a6",
+    "sortText": "000006ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35330,7 +35750,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a7",
+    "sortText": "000006bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35351,7 +35771,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a8",
+    "sortText": "000006bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35372,7 +35792,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a9",
+    "sortText": "000006bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35393,7 +35813,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006aa",
+    "sortText": "000006be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35414,7 +35834,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ab",
+    "sortText": "000006bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35435,7 +35855,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ac",
+    "sortText": "000006c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35456,7 +35876,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ad",
+    "sortText": "000006c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35477,7 +35897,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ae",
+    "sortText": "000006c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35498,7 +35918,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006af",
+    "sortText": "000006c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35519,7 +35939,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b0",
+    "sortText": "000006c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35540,7 +35960,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b1",
+    "sortText": "000006c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35561,7 +35981,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b2",
+    "sortText": "000006c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35582,7 +36002,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b3",
+    "sortText": "000006c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35603,7 +36023,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b4",
+    "sortText": "000006c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35624,7 +36044,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b5",
+    "sortText": "000006c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35645,7 +36065,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b6",
+    "sortText": "000006ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35666,7 +36086,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b7",
+    "sortText": "000006cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35687,7 +36107,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b8",
+    "sortText": "000006cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35708,7 +36128,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b9",
+    "sortText": "000006cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35729,7 +36149,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ba",
+    "sortText": "000006ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35750,7 +36170,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bb",
+    "sortText": "000006cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35771,7 +36191,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bc",
+    "sortText": "000006d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35792,7 +36212,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bd",
+    "sortText": "000006d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35813,7 +36233,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006be",
+    "sortText": "000006d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35834,7 +36254,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bf",
+    "sortText": "000006d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35855,7 +36275,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c0",
+    "sortText": "000006d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35876,7 +36296,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c1",
+    "sortText": "000006d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35897,7 +36317,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c2",
+    "sortText": "000006d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35918,7 +36338,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c3",
+    "sortText": "000006d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35939,7 +36359,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c4",
+    "sortText": "000006d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35960,7 +36380,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c5",
+    "sortText": "000006d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35981,7 +36401,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c6",
+    "sortText": "000006da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36002,7 +36422,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c7",
+    "sortText": "000006db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36023,7 +36443,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c8",
+    "sortText": "000006dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36044,7 +36464,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c9",
+    "sortText": "000006dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36065,7 +36485,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ca",
+    "sortText": "000006de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36086,7 +36506,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cb",
+    "sortText": "000006df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36107,7 +36527,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cc",
+    "sortText": "000006e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36128,7 +36548,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cd",
+    "sortText": "000006e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36149,7 +36569,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ce",
+    "sortText": "000006e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36170,7 +36590,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cf",
+    "sortText": "000006e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36191,7 +36611,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d0",
+    "sortText": "000006e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36212,7 +36632,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d1",
+    "sortText": "000006e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36233,7 +36653,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d2",
+    "sortText": "000006e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36254,7 +36674,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d3",
+    "sortText": "000006e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36275,7 +36695,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d4",
+    "sortText": "000006e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36296,7 +36716,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d5",
+    "sortText": "000006e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36317,7 +36737,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d6",
+    "sortText": "000006ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36338,7 +36758,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d7",
+    "sortText": "000006eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36359,7 +36779,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d8",
+    "sortText": "000006ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36380,7 +36800,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d9",
+    "sortText": "000006ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36401,7 +36821,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006da",
+    "sortText": "000006ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36422,7 +36842,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006db",
+    "sortText": "000006ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36443,7 +36863,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006dc",
+    "sortText": "000006f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36464,7 +36884,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006dd",
+    "sortText": "000006f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36485,7 +36905,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006de",
+    "sortText": "000006f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36506,7 +36926,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006df",
+    "sortText": "000006f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36527,7 +36947,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e0",
+    "sortText": "000006f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36548,7 +36968,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e1",
+    "sortText": "000006f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36569,7 +36989,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e2",
+    "sortText": "000006f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36590,7 +37010,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e3",
+    "sortText": "000006f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36611,7 +37031,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e4",
+    "sortText": "000006f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36632,7 +37052,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e5",
+    "sortText": "000006f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36653,7 +37073,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e6",
+    "sortText": "000006fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36674,7 +37094,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e7",
+    "sortText": "000006fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36695,7 +37115,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e8",
+    "sortText": "000006fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36716,7 +37136,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e9",
+    "sortText": "000006fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36737,7 +37157,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ea",
+    "sortText": "000006fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36758,7 +37178,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006eb",
+    "sortText": "000006ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36779,7 +37199,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ec",
+    "sortText": "00000700",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36800,7 +37220,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ed",
+    "sortText": "00000701",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36821,7 +37241,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ee",
+    "sortText": "00000702",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36842,7 +37262,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ef",
+    "sortText": "00000703",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36863,7 +37283,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f0",
+    "sortText": "00000704",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36884,7 +37304,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f1",
+    "sortText": "00000705",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36905,7 +37325,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f2",
+    "sortText": "00000706",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36926,7 +37346,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f3",
+    "sortText": "00000707",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36947,7 +37367,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f4",
+    "sortText": "00000708",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36968,7 +37388,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f5",
+    "sortText": "00000709",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36989,7 +37409,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f6",
+    "sortText": "0000070a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37010,7 +37430,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f7",
+    "sortText": "0000070b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37031,7 +37451,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f8",
+    "sortText": "0000070c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37052,7 +37472,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f9",
+    "sortText": "0000070d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37073,7 +37493,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fa",
+    "sortText": "0000070e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37094,7 +37514,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fb",
+    "sortText": "0000070f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37115,7 +37535,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fc",
+    "sortText": "00000710",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37136,7 +37556,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fd",
+    "sortText": "00000711",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37157,7 +37577,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fe",
+    "sortText": "00000712",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37178,7 +37598,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ff",
+    "sortText": "00000713",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37199,7 +37619,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000700",
+    "sortText": "00000714",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37220,7 +37640,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000701",
+    "sortText": "00000715",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37241,7 +37661,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000702",
+    "sortText": "00000716",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37262,7 +37682,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000703",
+    "sortText": "00000717",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37283,7 +37703,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000704",
+    "sortText": "00000718",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37304,7 +37724,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000705",
+    "sortText": "00000719",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37325,7 +37745,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000706",
+    "sortText": "0000071a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37346,7 +37766,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000707",
+    "sortText": "0000071b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37367,7 +37787,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000708",
+    "sortText": "0000071c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37388,7 +37808,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000709",
+    "sortText": "0000071d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37409,7 +37829,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070a",
+    "sortText": "0000071e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37430,7 +37850,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070b",
+    "sortText": "0000071f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37451,7 +37871,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070c",
+    "sortText": "00000720",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37472,7 +37892,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070d",
+    "sortText": "00000721",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37493,7 +37913,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070e",
+    "sortText": "00000722",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37514,7 +37934,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070f",
+    "sortText": "00000723",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37535,7 +37955,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000710",
+    "sortText": "00000724",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37556,7 +37976,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000711",
+    "sortText": "00000725",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37577,7 +37997,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000712",
+    "sortText": "00000726",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37598,7 +38018,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000713",
+    "sortText": "00000727",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37619,7 +38039,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000714",
+    "sortText": "00000728",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37640,7 +38060,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000715",
+    "sortText": "00000729",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37661,7 +38081,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000716",
+    "sortText": "0000072a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37682,7 +38102,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000717",
+    "sortText": "0000072b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37703,7 +38123,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000718",
+    "sortText": "0000072c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37724,7 +38144,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000719",
+    "sortText": "0000072d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37745,7 +38165,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071a",
+    "sortText": "0000072e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37766,7 +38186,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071b",
+    "sortText": "0000072f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37787,7 +38207,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071c",
+    "sortText": "00000730",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37808,7 +38228,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071d",
+    "sortText": "00000731",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37829,7 +38249,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071e",
+    "sortText": "00000732",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37850,7 +38270,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071f",
+    "sortText": "00000733",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37871,7 +38291,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000720",
+    "sortText": "00000734",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37892,7 +38312,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000721",
+    "sortText": "00000735",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37913,7 +38333,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000722",
+    "sortText": "00000736",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37934,7 +38354,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000723",
+    "sortText": "00000737",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37955,7 +38375,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000724",
+    "sortText": "00000738",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37976,7 +38396,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000725",
+    "sortText": "00000739",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37997,7 +38417,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000748",
+    "sortText": "0000075c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38018,7 +38438,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000749",
+    "sortText": "0000075d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38039,7 +38459,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074a",
+    "sortText": "0000075e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38060,7 +38480,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074b",
+    "sortText": "0000075f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38081,7 +38501,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074c",
+    "sortText": "00000760",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38102,7 +38522,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074d",
+    "sortText": "00000761",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38123,7 +38543,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074e",
+    "sortText": "00000762",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38144,7 +38564,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074f",
+    "sortText": "00000763",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38165,7 +38585,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000750",
+    "sortText": "00000764",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38186,7 +38606,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000751",
+    "sortText": "00000765",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38207,7 +38627,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000752",
+    "sortText": "00000766",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38228,7 +38648,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000753",
+    "sortText": "00000767",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38249,7 +38669,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000754",
+    "sortText": "00000768",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38270,7 +38690,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000755",
+    "sortText": "00000769",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38291,7 +38711,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000756",
+    "sortText": "0000076a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38312,7 +38732,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000757",
+    "sortText": "0000076b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38333,7 +38753,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000758",
+    "sortText": "0000076c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38354,7 +38774,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000759",
+    "sortText": "0000076d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38375,7 +38795,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075a",
+    "sortText": "0000076e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38396,7 +38816,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000726",
+    "sortText": "0000073a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38417,7 +38837,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000727",
+    "sortText": "0000073b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38438,7 +38858,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000728",
+    "sortText": "0000073c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38459,7 +38879,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000729",
+    "sortText": "0000073d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38480,7 +38900,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072a",
+    "sortText": "0000073e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38501,7 +38921,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072b",
+    "sortText": "0000073f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38522,7 +38942,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072c",
+    "sortText": "00000740",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38543,7 +38963,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072d",
+    "sortText": "00000741",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38564,7 +38984,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072e",
+    "sortText": "00000742",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38585,7 +39005,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072f",
+    "sortText": "00000743",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38606,7 +39026,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000730",
+    "sortText": "00000744",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38627,7 +39047,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000731",
+    "sortText": "00000745",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38648,7 +39068,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000732",
+    "sortText": "00000746",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38669,7 +39089,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000733",
+    "sortText": "00000747",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38690,7 +39110,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000734",
+    "sortText": "00000748",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38711,7 +39131,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000735",
+    "sortText": "00000749",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38732,7 +39152,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000736",
+    "sortText": "0000074a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38753,7 +39173,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000737",
+    "sortText": "0000074b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38774,7 +39194,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000738",
+    "sortText": "0000074c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38795,7 +39215,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000739",
+    "sortText": "0000074d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38816,7 +39236,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073a",
+    "sortText": "0000074e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38837,7 +39257,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073b",
+    "sortText": "0000074f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38858,7 +39278,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073c",
+    "sortText": "00000750",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38879,7 +39299,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073d",
+    "sortText": "00000751",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38900,7 +39320,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073e",
+    "sortText": "00000752",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38921,7 +39341,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073f",
+    "sortText": "00000753",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38942,7 +39362,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000740",
+    "sortText": "00000754",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38963,7 +39383,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000741",
+    "sortText": "00000755",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38984,7 +39404,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000742",
+    "sortText": "00000756",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39005,7 +39425,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000743",
+    "sortText": "00000757",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39026,7 +39446,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000744",
+    "sortText": "00000758",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39047,7 +39467,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000745",
+    "sortText": "00000759",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39068,7 +39488,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000746",
+    "sortText": "0000075a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39089,7 +39509,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000747",
+    "sortText": "0000075b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39110,7 +39530,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075b",
+    "sortText": "0000076f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39131,7 +39551,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075c",
+    "sortText": "00000770",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39152,7 +39572,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075d",
+    "sortText": "00000771",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39173,7 +39593,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075e",
+    "sortText": "00000772",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39194,7 +39614,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075f",
+    "sortText": "00000773",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39215,7 +39635,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000760",
+    "sortText": "00000774",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39236,7 +39656,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000761",
+    "sortText": "00000775",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39257,7 +39677,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000762",
+    "sortText": "00000776",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39278,7 +39698,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000763",
+    "sortText": "00000777",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39299,7 +39719,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000764",
+    "sortText": "00000778",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39320,7 +39740,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000765",
+    "sortText": "00000779",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39341,7 +39761,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000766",
+    "sortText": "0000077a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39362,7 +39782,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000767",
+    "sortText": "0000077b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39383,7 +39803,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000768",
+    "sortText": "0000077c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39404,7 +39824,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000769",
+    "sortText": "0000077d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39425,7 +39845,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076a",
+    "sortText": "0000077e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39446,7 +39866,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076b",
+    "sortText": "0000077f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39467,7 +39887,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076c",
+    "sortText": "00000780",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39488,7 +39908,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076d",
+    "sortText": "00000781",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39509,7 +39929,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076e",
+    "sortText": "00000782",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39530,7 +39950,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076f",
+    "sortText": "00000783",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39551,7 +39971,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000770",
+    "sortText": "00000784",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39572,7 +39992,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000771",
+    "sortText": "00000785",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39593,7 +40013,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000772",
+    "sortText": "00000786",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39614,7 +40034,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000773",
+    "sortText": "00000787",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39635,7 +40055,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000774",
+    "sortText": "00000788",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39656,7 +40076,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000775",
+    "sortText": "00000789",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39677,7 +40097,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000776",
+    "sortText": "0000078a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39698,7 +40118,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000777",
+    "sortText": "0000078b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39719,7 +40139,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000778",
+    "sortText": "0000078c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39740,7 +40160,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000779",
+    "sortText": "0000078d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39761,7 +40181,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077a",
+    "sortText": "0000078e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39782,7 +40202,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077b",
+    "sortText": "0000078f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39803,7 +40223,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077c",
+    "sortText": "00000790",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39824,7 +40244,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077d",
+    "sortText": "00000791",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39845,7 +40265,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077e",
+    "sortText": "00000792",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39866,7 +40286,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077f",
+    "sortText": "00000793",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39887,7 +40307,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000780",
+    "sortText": "00000794",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39908,7 +40328,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000781",
+    "sortText": "00000795",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39929,7 +40349,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000782",
+    "sortText": "00000796",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39950,7 +40370,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000783",
+    "sortText": "00000797",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39971,7 +40391,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000784",
+    "sortText": "00000798",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39992,7 +40412,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000785",
+    "sortText": "00000799",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40013,7 +40433,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000786",
+    "sortText": "0000079a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40034,7 +40454,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000787",
+    "sortText": "0000079b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40055,7 +40475,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000788",
+    "sortText": "0000079c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40076,7 +40496,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000789",
+    "sortText": "0000079d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40097,7 +40517,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078a",
+    "sortText": "0000079e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40118,7 +40538,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078b",
+    "sortText": "0000079f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40139,7 +40559,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078c",
+    "sortText": "000007a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40160,7 +40580,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078d",
+    "sortText": "000007a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40181,7 +40601,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078e",
+    "sortText": "000007a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40202,7 +40622,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078f",
+    "sortText": "000007a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40223,7 +40643,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000790",
+    "sortText": "000007a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40244,7 +40664,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000791",
+    "sortText": "000007a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40265,7 +40685,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000792",
+    "sortText": "000007a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40286,7 +40706,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000793",
+    "sortText": "000007a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40307,7 +40727,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000794",
+    "sortText": "000007a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40328,7 +40748,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000795",
+    "sortText": "000007a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40349,7 +40769,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000796",
+    "sortText": "000007aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40370,7 +40790,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000797",
+    "sortText": "000007ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40391,7 +40811,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000798",
+    "sortText": "000007ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40412,7 +40832,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000799",
+    "sortText": "000007ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40433,7 +40853,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079a",
+    "sortText": "000007ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40454,7 +40874,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079b",
+    "sortText": "000007af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40475,7 +40895,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079c",
+    "sortText": "000007b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40496,7 +40916,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079d",
+    "sortText": "000007b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40517,7 +40937,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079e",
+    "sortText": "000007b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40538,7 +40958,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079f",
+    "sortText": "000007b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40559,7 +40979,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a0",
+    "sortText": "000007b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40580,7 +41000,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a1",
+    "sortText": "000007b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40601,7 +41021,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a2",
+    "sortText": "000007b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40622,7 +41042,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a3",
+    "sortText": "000007b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40643,7 +41063,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a4",
+    "sortText": "000007b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40664,7 +41084,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a5",
+    "sortText": "000007b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40685,7 +41105,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a6",
+    "sortText": "000007ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40706,7 +41126,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a7",
+    "sortText": "000007bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40727,7 +41147,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a8",
+    "sortText": "000007bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40748,7 +41168,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a9",
+    "sortText": "000007bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40769,7 +41189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007aa",
+    "sortText": "000007be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40790,7 +41210,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ab",
+    "sortText": "000007bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40811,7 +41231,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ac",
+    "sortText": "000007c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40832,7 +41252,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ad",
+    "sortText": "000007c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40853,7 +41273,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ae",
+    "sortText": "000007c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40874,7 +41294,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007af",
+    "sortText": "000007c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40895,7 +41315,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b6",
+    "sortText": "000007ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40916,7 +41336,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b7",
+    "sortText": "000007cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40937,7 +41357,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b8",
+    "sortText": "000007cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40958,7 +41378,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b0",
+    "sortText": "000007c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40979,7 +41399,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b1",
+    "sortText": "000007c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41000,12 +41420,75 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b2",
+    "sortText": "000007c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.VirtualMachineImages/imageTemplates/runOutputs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.VoiceServices/communicationsGateways'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.VoiceServices/communicationsGateways`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000007cd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.VoiceServices/communicationsGateways@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.VoiceServices/communicationsGateways/contacts'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/contacts`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000007ce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.VoiceServices/communicationsGateways/contacts@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.VoiceServices/communicationsGateways/testLines'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/testLines`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000007cf",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.VoiceServices/communicationsGateways/testLines@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -41021,7 +41504,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b9",
+    "sortText": "000007d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41042,7 +41525,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ba",
+    "sortText": "000007d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41063,7 +41546,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bb",
+    "sortText": "000007d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41084,7 +41567,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bc",
+    "sortText": "000007d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41105,7 +41588,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bd",
+    "sortText": "000007d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41126,7 +41609,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007be",
+    "sortText": "000007d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41147,7 +41630,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bf",
+    "sortText": "000007d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41168,7 +41651,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c0",
+    "sortText": "000007d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41189,7 +41672,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c1",
+    "sortText": "000007d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41210,7 +41693,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c2",
+    "sortText": "000007d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41231,7 +41714,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c3",
+    "sortText": "000007da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41252,7 +41735,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c4",
+    "sortText": "000007db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41273,7 +41756,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c5",
+    "sortText": "000007dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41294,7 +41777,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c6",
+    "sortText": "000007dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41315,7 +41798,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c7",
+    "sortText": "000007de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41336,7 +41819,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c8",
+    "sortText": "000007df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41357,7 +41840,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c9",
+    "sortText": "000007e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41378,7 +41861,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ca",
+    "sortText": "000007e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41399,7 +41882,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cb",
+    "sortText": "000007e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41420,7 +41903,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cc",
+    "sortText": "000007e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41441,7 +41924,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cd",
+    "sortText": "000007e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41462,7 +41945,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ce",
+    "sortText": "000007e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41483,7 +41966,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cf",
+    "sortText": "000007e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41504,7 +41987,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d0",
+    "sortText": "000007e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41525,7 +42008,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d1",
+    "sortText": "000007e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41546,7 +42029,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d2",
+    "sortText": "000007e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41567,7 +42050,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d3",
+    "sortText": "000007ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41588,7 +42071,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d4",
+    "sortText": "000007eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41609,7 +42092,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d5",
+    "sortText": "000007ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41630,7 +42113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d6",
+    "sortText": "000007ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41651,7 +42134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d7",
+    "sortText": "000007ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41672,7 +42155,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d8",
+    "sortText": "000007ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41693,7 +42176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d9",
+    "sortText": "000007f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41714,7 +42197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007da",
+    "sortText": "000007f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41735,7 +42218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007db",
+    "sortText": "000007f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41756,7 +42239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007dc",
+    "sortText": "000007f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41777,7 +42260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007dd",
+    "sortText": "000007f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41798,7 +42281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007de",
+    "sortText": "000007f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41819,7 +42302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e0",
+    "sortText": "000007f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41840,7 +42323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007df",
+    "sortText": "000007f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41861,7 +42344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e1",
+    "sortText": "000007f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41882,7 +42365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e2",
+    "sortText": "000007f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41903,7 +42386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e3",
+    "sortText": "000007fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41924,7 +42407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e4",
+    "sortText": "000007fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41945,7 +42428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e5",
+    "sortText": "000007fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41966,7 +42449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e6",
+    "sortText": "000007fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41987,7 +42470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e7",
+    "sortText": "000007fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42008,7 +42491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e8",
+    "sortText": "000007ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42029,7 +42512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e9",
+    "sortText": "00000800",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42050,7 +42533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ea",
+    "sortText": "00000801",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42071,7 +42554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007eb",
+    "sortText": "00000802",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42092,7 +42575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ec",
+    "sortText": "00000803",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42113,7 +42596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ed",
+    "sortText": "00000804",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42134,7 +42617,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ee",
+    "sortText": "00000805",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42155,7 +42638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ef",
+    "sortText": "00000806",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42176,7 +42659,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f0",
+    "sortText": "00000807",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42197,7 +42680,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f1",
+    "sortText": "00000808",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42218,7 +42701,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f3",
+    "sortText": "0000080a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42239,7 +42722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f2",
+    "sortText": "00000809",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42260,7 +42743,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f4",
+    "sortText": "0000080b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42281,7 +42764,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f5",
+    "sortText": "0000080c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42302,7 +42785,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f6",
+    "sortText": "0000080d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42323,7 +42806,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f7",
+    "sortText": "0000080e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42344,7 +42827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f8",
+    "sortText": "0000080f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42365,7 +42848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f9",
+    "sortText": "00000810",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42386,7 +42869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fa",
+    "sortText": "00000811",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42407,7 +42890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fb",
+    "sortText": "00000812",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42428,7 +42911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fc",
+    "sortText": "00000813",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42449,7 +42932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fd",
+    "sortText": "00000814",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42470,7 +42953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fe",
+    "sortText": "00000815",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42491,7 +42974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ff",
+    "sortText": "00000816",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42512,7 +42995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000800",
+    "sortText": "00000817",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42533,7 +43016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000801",
+    "sortText": "00000818",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42554,7 +43037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000802",
+    "sortText": "00000819",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42575,7 +43058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000803",
+    "sortText": "0000081a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42596,7 +43079,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000804",
+    "sortText": "0000081b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42617,7 +43100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000805",
+    "sortText": "0000081c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42638,7 +43121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000806",
+    "sortText": "0000081d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42659,7 +43142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000807",
+    "sortText": "0000081e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42680,7 +43163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000808",
+    "sortText": "0000081f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42701,7 +43184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000809",
+    "sortText": "00000820",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42722,7 +43205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080a",
+    "sortText": "00000821",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42743,7 +43226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080b",
+    "sortText": "00000822",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42764,7 +43247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080c",
+    "sortText": "00000823",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42785,7 +43268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080d",
+    "sortText": "00000824",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42806,7 +43289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080e",
+    "sortText": "00000825",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42827,7 +43310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000810",
+    "sortText": "00000827",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42848,7 +43331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080f",
+    "sortText": "00000826",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42869,7 +43352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000811",
+    "sortText": "00000828",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42890,7 +43373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000812",
+    "sortText": "00000829",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42911,7 +43394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000813",
+    "sortText": "0000082a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42932,7 +43415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000814",
+    "sortText": "0000082b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42953,7 +43436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000815",
+    "sortText": "0000082c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42974,7 +43457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000816",
+    "sortText": "0000082d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42995,7 +43478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000817",
+    "sortText": "0000082e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43016,7 +43499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000818",
+    "sortText": "0000082f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43037,7 +43520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000819",
+    "sortText": "00000830",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43058,7 +43541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081b",
+    "sortText": "00000832",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43079,7 +43562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081a",
+    "sortText": "00000831",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43100,7 +43583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081c",
+    "sortText": "00000833",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43121,7 +43604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081d",
+    "sortText": "00000834",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43142,7 +43625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081e",
+    "sortText": "00000835",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43163,7 +43646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081f",
+    "sortText": "00000836",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43184,7 +43667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000820",
+    "sortText": "00000837",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43205,7 +43688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000821",
+    "sortText": "00000838",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43226,7 +43709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000822",
+    "sortText": "00000839",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43247,7 +43730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000823",
+    "sortText": "0000083a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43268,7 +43751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000824",
+    "sortText": "0000083b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43289,7 +43772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000825",
+    "sortText": "0000083c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43310,7 +43793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000826",
+    "sortText": "0000083d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43331,7 +43814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000827",
+    "sortText": "0000083e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43352,7 +43835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000828",
+    "sortText": "0000083f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43373,7 +43856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000829",
+    "sortText": "00000840",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43394,7 +43877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082a",
+    "sortText": "00000841",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43415,7 +43898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082b",
+    "sortText": "00000842",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43436,7 +43919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082c",
+    "sortText": "00000843",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43457,7 +43940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082d",
+    "sortText": "00000844",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43478,7 +43961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082e",
+    "sortText": "00000845",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43499,7 +43982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082f",
+    "sortText": "00000846",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43520,7 +44003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000830",
+    "sortText": "00000847",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43541,7 +44024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000831",
+    "sortText": "00000848",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43562,7 +44045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000832",
+    "sortText": "00000849",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43583,7 +44066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000833",
+    "sortText": "0000084a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43604,7 +44087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000834",
+    "sortText": "0000084b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43625,7 +44108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000835",
+    "sortText": "0000084c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43646,7 +44129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000836",
+    "sortText": "0000084d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43667,7 +44150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000837",
+    "sortText": "0000084e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43688,7 +44171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000838",
+    "sortText": "0000084f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43709,7 +44192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000839",
+    "sortText": "00000850",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43730,7 +44213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083a",
+    "sortText": "00000851",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43751,7 +44234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083b",
+    "sortText": "00000852",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43772,7 +44255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083c",
+    "sortText": "00000853",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43793,7 +44276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083d",
+    "sortText": "00000854",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43814,7 +44297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083e",
+    "sortText": "00000855",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43835,7 +44318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083f",
+    "sortText": "00000856",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43856,7 +44339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000840",
+    "sortText": "00000857",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43877,7 +44360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000841",
+    "sortText": "00000858",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43898,7 +44381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000842",
+    "sortText": "00000859",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43919,7 +44402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000843",
+    "sortText": "0000085a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43940,7 +44423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000844",
+    "sortText": "0000085b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43961,7 +44444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000845",
+    "sortText": "0000085c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43982,7 +44465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000846",
+    "sortText": "0000085d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44003,7 +44486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000847",
+    "sortText": "0000085e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44024,7 +44507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000848",
+    "sortText": "0000085f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44045,7 +44528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000849",
+    "sortText": "00000860",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44066,7 +44549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084a",
+    "sortText": "00000861",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44087,7 +44570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084b",
+    "sortText": "00000862",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44108,7 +44591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084c",
+    "sortText": "00000863",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44129,7 +44612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084d",
+    "sortText": "00000864",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44150,7 +44633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084e",
+    "sortText": "00000865",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44171,7 +44654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084f",
+    "sortText": "00000866",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44192,7 +44675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000850",
+    "sortText": "00000867",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44213,7 +44696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000851",
+    "sortText": "00000868",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44234,7 +44717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000852",
+    "sortText": "00000869",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44255,7 +44738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000853",
+    "sortText": "0000086a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44276,7 +44759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000854",
+    "sortText": "0000086b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44297,7 +44780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000855",
+    "sortText": "0000086c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44318,12 +44801,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000856",
+    "sortText": "0000086d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Nginx.NginxPlus/nginxDeployments/configurations@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Qumulo.Storage/fileSystems'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Qumulo.Storage/fileSystems`  \n`"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "0000086e",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Qumulo.Storage/fileSystems@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -44339,7 +44843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ab",
+    "sortText": "000001b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44360,7 +44864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ad",
+    "sortText": "000001b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44486,7 +44990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000016",
+    "sortText": "00000018",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44507,7 +45011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ac",
+    "sortText": "000001b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44528,7 +45032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000388",
+    "sortText": "00000391",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44549,7 +45053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038a",
+    "sortText": "00000393",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44570,7 +45074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038e",
+    "sortText": "00000397",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44591,7 +45095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000391",
+    "sortText": "0000039a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44612,7 +45116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000392",
+    "sortText": "0000039b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44633,7 +45137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000393",
+    "sortText": "0000039c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44654,7 +45158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000399",
+    "sortText": "000003a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44675,7 +45179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039b",
+    "sortText": "000003a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44696,7 +45200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039c",
+    "sortText": "000003a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44717,7 +45221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a0",
+    "sortText": "000003a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44738,7 +45242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a8",
+    "sortText": "000003b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44759,7 +45263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ab",
+    "sortText": "000003b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44780,7 +45284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b3",
+    "sortText": "000007c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44801,7 +45305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b4",
+    "sortText": "000007c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44822,7 +45326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b5",
+    "sortText": "000007c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1976,7 +1976,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -104,10 +104,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1985,7 +1985,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Azure.Deployments.Templates" Version="1.0.815" />
     <PackageReference Include="Azure.Deployments.Expression" Version="1.0.815" />
     <PackageReference Include="Azure.Bicep.Types" Version="0.3.99" />
-    <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.238" />
+    <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.324" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.233" />
     <PackageReference Include="System.IO.Abstractions" Version="19.1.5" />
     <PackageReference Include="Azure.Bicep.Internal.RoslynAnalyzers" Version="0.1.17" PrivateAssets="all" />

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -19,11 +19,11 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Direct",
-        "requested": "[0.2.238, )",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "requested": "[0.2.324, )",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1981,7 +1981,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1981,7 +1981,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -40,10 +40,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1700,7 +1700,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -105,10 +105,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1990,7 +1990,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -92,10 +92,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1989,7 +1989,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -64,10 +64,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1874,7 +1874,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -2083,7 +2083,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -70,10 +70,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -2025,7 +2025,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -71,10 +71,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -2083,7 +2083,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -171,10 +171,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -2008,7 +2008,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -52,10 +52,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -2077,7 +2077,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -65,10 +65,10 @@
       },
       "Azure.Bicep.Types.Az": {
         "type": "Transitive",
-        "resolved": "0.2.238",
-        "contentHash": "6SlW+kGqncwHMeOMy3L8KRkFo2l82k0KJUF3ViBSGWU+Mx8SQWOXlnH1zy+90iS4t3SAjaiPxisya2fHvkrXSQ==",
+        "resolved": "0.2.324",
+        "contentHash": "RuW8lHsvaPEKKEpc5ez7ItJR/NpsiibMl1tt50woCY5EPgulhnOyZ6TMho9HIztQncr5ZyiO3ei/EScEkPl75A==",
         "dependencies": {
-          "Azure.Bicep.Types": "0.3.41"
+          "Azure.Bicep.Types": "0.3.99"
         }
       },
       "Azure.Bicep.Types.K8s": {
@@ -1844,7 +1844,7 @@
         "type": "Project",
         "dependencies": {
           "Azure.Bicep.Types": "[0.3.99, )",
-          "Azure.Bicep.Types.Az": "[0.2.238, )",
+          "Azure.Bicep.Types.Az": "[0.2.324, )",
           "Azure.Bicep.Types.K8s": "[0.1.233, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0-beta.4, )",
           "Azure.Deployments.Core": "[1.0.815, )",


### PR DESCRIPTION
Bumping Azure.Bicep.Types.Az version for Bicep Release 0.14.0

![image](https://user-images.githubusercontent.com/94467694/215617791-e1edd42a-33e9-4747-94ca-5eb95943b175.png)

Following instructions here: https://github.com/Azure/bicep/issues/2192

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9697)