### PR TITLE
Add view type definition support for MCR modules

### DIFF
--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -223,7 +223,8 @@ namespace Bicep.Core.UnitTests.Registry
             var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", bicepFileContents, testOutputPath);
             var parentModuleUri = DocumentUri.FromFileSystemPath(bicepPath).ToUri();
 
-            var ociArtifactModuleReference = GetModuleReferenceAndSaveManifestFile(
+            var ociArtifactModuleReference = OciArtifactModuleReferenceHelper.GetModuleReferenceAndSaveManifestFile(
+                TestContext,
                 registory,
                 repository,
                 manifestFileContents,
@@ -252,22 +253,6 @@ namespace Bicep.Core.UnitTests.Registry
             }
 
             return features.Object;
-        }
-
-        private OciArtifactModuleReference GetModuleReferenceAndSaveManifestFile(string registory, string repository, string manifestFileContents, string testOutputPath, Uri parentModuleUri, string? digest = null, string? tag = null)
-        {
-            if (digest is not null)
-            {
-                var manifestFilePath = Path.Combine(testOutputPath, "br", registory, repository.Replace("/", "$"), digest.Replace(":", "#"));
-                FileHelper.SaveResultFile(TestContext, "manifest", manifestFileContents, manifestFilePath);
-            }
-            else if (tag is not null)
-            {
-                var manifestFilePath = Path.Combine(testOutputPath, "br", registory, repository.Replace("/", "$"), tag + '$');
-                FileHelper.SaveResultFile(TestContext, "manifest", manifestFileContents, manifestFilePath);
-            }
-
-            return new OciArtifactModuleReference(registory, repository, tag, digest, parentModuleUri);
         }
     }
 }

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -201,13 +201,13 @@ namespace Bicep.Core.UnitTests.Registry
                 bicepFileContents,
                 manifestFileContents,
                 "mcr.microsoft.com",
-                "bicep/app/dapr-containerapps-environment",
+                "bicep/app/dapr-containerapps-environment/bicep/core",
                 tag: "1.0.1");
 
             var result = ociModuleRegistry.GetDocumentationUri(ociArtifactModuleReference);
 
             result.Should().NotBeNull();
-            result.Should().BeEquivalentTo("https://github.com/Azure/bicep-registry-modules/tree/app/dapr-containerapps-environment/1.0.1/modules/app/dapr-containerapps-environment/README.md");
+            result.Should().BeEquivalentTo("https://github.com/Azure/bicep-registry-modules/tree/app/dapr-containerapps-environment/bicep/core/1.0.1/modules/app/dapr-containerapps-environment/bicep/core/README.md");
         }
 
         private (OciModuleRegistry, OciArtifactModuleReference) GetOciModuleRegistryAndOciArtifactModuleReference(

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -165,7 +165,7 @@ namespace Bicep.Core.UnitTests.Registry
         }
 
         [TestMethod]
-        public void GetDocumentationUri_WithMcrModuleReference_WithNoDocumentationUriInManifestFile_ShouldReturnReadmeLink()
+        public void GetDocumentationUri_WithMcrModuleReferenceAndNoDocumentationUriInManifestFile_ShouldReturnReadmeLink()
         {
             var manifestFileContents = @"{
   ""schemaVersion"": 2,

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -127,7 +127,7 @@ namespace Bicep.Core.UnitTests.Registry
         }
 
         [TestMethod]
-        public void GetDocumentationUri_WithValiddocumentationUriInManifestFile_ShouldDocumentationUri()
+        public void GetDocumentationUri_WithValidDocumentationUriInManifestFile_ShouldReturnDocumentationUri()
         {
             var documentationUri = @"https://github.com/Azure/bicep-registry-modules/blob/main/modules/samples/hello-world/README.md";
             var manifestFileContents = @"{
@@ -165,7 +165,7 @@ namespace Bicep.Core.UnitTests.Registry
         }
 
         [TestMethod]
-        public void GetDocumentationUri_WithMcrModuleReferenceAndNoDocumentationUriInManifestFile_ShouldReturnReadmeLink()
+        public void GetDocumentationUri_WithMcrModuleReferenceAndNoDocumentationUriInManifestFile_ShouldReturnDocumentationUriThatPointsToReadmeLink()
         {
             var manifestFileContents = @"{
   ""schemaVersion"": 2,

--- a/src/Bicep.Core.UnitTests/Utils/OciArtifactModuleReferenceHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciArtifactModuleReferenceHelper.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Bicep.Core.Modules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Utils
+{
+    public static class OciArtifactModuleReferenceHelper
+    {
+        public static OciArtifactModuleReference GetModuleReferenceAndSaveManifestFile(
+            TestContext testContext,
+            string registory,
+            string repository,
+            string manifestFileContents,
+            string testOutputPath,
+            Uri parentModuleUri,
+            string? digest,
+            string? tag)
+        {
+            string? manifestFilePath = null;
+
+            if (digest is not null)
+            {
+                manifestFilePath = Path.Combine(testOutputPath, "br", registory, repository.Replace("/", "$"), digest.Replace(":", "#"));
+            }
+            else if (tag is not null)
+            {
+                manifestFilePath = Path.Combine(testOutputPath, "br", registory, repository.Replace("/", "$"), tag + "$");
+            }
+
+            if (!string.IsNullOrWhiteSpace(manifestFilePath))
+            {
+                FileHelper.SaveResultFile(testContext, "manifest", manifestFileContents, manifestFilePath);
+            }
+
+            return new OciArtifactModuleReference(registory, repository, tag, digest, parentModuleUri);
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/Utils/OciArtifactModuleReferenceHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciArtifactModuleReferenceHelper.cs
@@ -12,7 +12,7 @@ namespace Bicep.Core.UnitTests.Utils
     {
         public static OciArtifactModuleReference GetModuleReferenceAndSaveManifestFile(
             TestContext testContext,
-            string registory,
+            string registry,
             string repository,
             string manifestFileContents,
             string testOutputPath,
@@ -24,11 +24,11 @@ namespace Bicep.Core.UnitTests.Utils
 
             if (digest is not null)
             {
-                manifestFilePath = Path.Combine(testOutputPath, "br", registory, repository.Replace("/", "$"), digest.Replace(":", "#"));
+                manifestFilePath = Path.Combine(testOutputPath, "br", registry, repository.Replace("/", "$"), digest.Replace(":", "#"));
             }
             else if (tag is not null)
             {
-                manifestFilePath = Path.Combine(testOutputPath, "br", registory, repository.Replace("/", "$"), tag + "$");
+                manifestFilePath = Path.Combine(testOutputPath, "br", registry, repository.Replace("/", "$"), tag + "$");
             }
 
             if (!string.IsNullOrWhiteSpace(manifestFilePath))
@@ -36,7 +36,7 @@ namespace Bicep.Core.UnitTests.Utils
                 FileHelper.SaveResultFile(testContext, "manifest", manifestFileContents, manifestFilePath);
             }
 
-            return new OciArtifactModuleReference(registory, repository, tag, digest, parentModuleUri);
+            return new OciArtifactModuleReference(registry, repository, tag, digest, parentModuleUri);
         }
     }
 }

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -95,6 +95,8 @@ namespace Bicep.Core
 
         public const string ListFunctionPrefix = "list";
 
+        public const string McrRegistry = "mcr.microsoft.com";
+        public const string McrRepositoryPrefix = "bicep/";
         public const string OciOpenContainerImageDocumentationAnnotation = "org.opencontainers.image.documentation";
 
         public static readonly ImmutableDictionary<string, TokenType> Keywords = new Dictionary<string, TokenType>(StringComparer.Ordinal)

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -107,12 +107,10 @@ namespace Bicep.Core.Registry
             if (!ociAnnotations.Any() || (ociAnnotations.TryGetValue(LanguageConstants.OciOpenContainerImageDocumentationAnnotation, out string? documentationUri) &&
                 string.IsNullOrWhiteSpace(documentationUri)))
             {
-                if (ociArtifactModuleReference.Registry == "mcr.microsoft.com")
+                if (ociArtifactModuleReference.Registry == LanguageConstants.McrRegistry && ociArtifactModuleReference.Repository.StartsWith(LanguageConstants.McrRepositoryPrefix))
                 {
-                    var tag = ociArtifactModuleReference.Tag;
-                    var repository = Regex.Replace(ociArtifactModuleReference.Repository, "bicep/", string.Empty);
-
-                    return $"https://github.com/Azure/bicep-registry-modules/tree/{repository}/{tag}/modules/{repository}/README.md";
+                    var repository = ociArtifactModuleReference.Repository.Substring(LanguageConstants.McrRepositoryPrefix.Length);
+                    return $"https://github.com/Azure/bicep-registry-modules/tree/{repository}/{ociArtifactModuleReference.Tag}/modules/{repository}/README.md";
                 }
 
                 return null;

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure;
 using Bicep.Core.Configuration;
@@ -106,6 +107,14 @@ namespace Bicep.Core.Registry
             if (!ociAnnotations.Any() || (ociAnnotations.TryGetValue(LanguageConstants.OciOpenContainerImageDocumentationAnnotation, out string? documentationUri) &&
                 string.IsNullOrWhiteSpace(documentationUri)))
             {
+                if (ociArtifactModuleReference.Registry == "mcr.microsoft.com")
+                {
+                    var tag = ociArtifactModuleReference.Tag;
+                    var artifact = Regex.Replace(ociArtifactModuleReference.Repository, "bicep/", string.Empty);
+
+                    return $"https://github.com/Azure/bicep-registry-modules/tree/{artifact}/{tag}/modules/{artifact}/README.md";
+                }
+
                 return null;
             }
 

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -110,9 +110,9 @@ namespace Bicep.Core.Registry
                 if (ociArtifactModuleReference.Registry == "mcr.microsoft.com")
                 {
                     var tag = ociArtifactModuleReference.Tag;
-                    var artifact = Regex.Replace(ociArtifactModuleReference.Repository, "bicep/", string.Empty);
+                    var repository = Regex.Replace(ociArtifactModuleReference.Repository, "bicep/", string.Empty);
 
-                    return $"https://github.com/Azure/bicep-registry-modules/tree/{artifact}/{tag}/modules/{artifact}/README.md";
+                    return $"https://github.com/Azure/bicep-registry-modules/tree/{repository}/{tag}/modules/{repository}/README.md";
                 }
 
                 return null;

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -107,7 +107,7 @@ namespace Bicep.Core.Registry
             if (!ociAnnotations.Any() || (ociAnnotations.TryGetValue(LanguageConstants.OciOpenContainerImageDocumentationAnnotation, out string? documentationUri) &&
                 string.IsNullOrWhiteSpace(documentationUri)))
             {
-                if (ociArtifactModuleReference.Registry == LanguageConstants.McrRegistry && ociArtifactModuleReference.Repository.StartsWith(LanguageConstants.McrRepositoryPrefix))
+                if (ociArtifactModuleReference.Registry == LanguageConstants.McrRegistry && ociArtifactModuleReference.Repository.StartsWith(LanguageConstants.McrRepositoryPrefix, StringComparison.Ordinal))
                 {
                     var repository = ociArtifactModuleReference.Repository.Substring(LanguageConstants.McrRepositoryPrefix.Length);
                     return $"https://github.com/Azure/bicep-registry-modules/tree/{repository}/{ociArtifactModuleReference.Tag}/modules/{repository}/README.md";

--- a/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
+++ b/src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Bicep.Core.UnitTests\Bicep.Core.UnitTests.csproj" />
     <ProjectReference Include="..\Bicep.Core.Samples\Bicep.Core.Samples.csproj" />
     <ProjectReference Include="..\Bicep.LangServer\Bicep.LangServer.csproj" />
   </ItemGroup>

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -2062,6 +2062,7 @@
         "type": "Project",
         "dependencies": {
           "Bicep.Core.Samples": "[1.0.0, )",
+          "Bicep.Core.UnitTests": "[1.0.0, )",
           "Bicep.LangServer": "[1.0.0, )",
           "FluentAssertions": "[6.9.0, )",
           "MSTest.TestAdapter": "[3.0.2, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -2150,6 +2150,7 @@
         "type": "Project",
         "dependencies": {
           "Bicep.Core.Samples": "[1.0.0, )",
+          "Bicep.Core.UnitTests": "[1.0.0, )",
           "Bicep.LangServer": "[1.0.0, )",
           "FluentAssertions": "[6.9.0, )",
           "MSTest.TestAdapter": "[3.0.2, )",


### PR DESCRIPTION
Add view type definition support for MCR modules. 

**ACR:**
![ACR_ViewTypeDefinition](https://user-images.githubusercontent.com/30270536/215930440-bf97d882-8b22-4314-aee8-910dbba56874.gif)

**MCR:**
**Note:** View Type Defintion link points to readme in bicep-registry-modules repo

![MCR_ViewTypeDefinition](https://user-images.githubusercontent.com/30270536/215930410-0573f42b-f521-421f-a57c-efcded4ac59d.gif)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9709)