### PR TITLE
Add a fix for a known cause of issue 1931

### DIFF
--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -182,5 +182,12 @@ namespace Bicep.Core.FileSystem
 
         private static string NormalizeExtension(string extension) =>
             extension.StartsWith(".") ? extension : $".{extension}";
+
+        public static bool IsSubPathOf(Uri parent, Uri child)
+        {
+            var parentPath = parent.AbsolutePath.EndsWith('/') ? parent.AbsolutePath : $"{parent.AbsolutePath}/";
+
+            return child.AbsolutePath.StartsWith(parentPath);
+        }
     }
 }

--- a/src/Bicep.Core/Workspaces/Workspace.cs
+++ b/src/Bicep.Core/Workspaces/Workspace.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Bicep.Core.FileSystem;
 
 namespace Bicep.Core.Workspaces
 {
@@ -20,7 +21,7 @@ namespace Bicep.Core.Workspaces
 
         public IEnumerable<ISourceFile> GetSourceFilesForDirectory(Uri fileUri)
             => activeFiles
-                .Where(kvp => fileUri.IsBaseOf(kvp.Key))
+                .Where(kvp => PathHelper.IsSubPathOf(fileUri, kvp.Key))
                 .Select(kvp => kvp.Value);
 
         public ImmutableDictionary<Uri, ISourceFile> GetActiveSourceFilesByUri()

--- a/src/Bicep.LangServer.IntegrationTests/LangServerScenarioTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/LangServerScenarioTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.LangServer.IntegrationTests.Assertions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+
+namespace Bicep.LangServer.IntegrationTests;
+
+[TestClass]
+public class LangServerScenarioTests
+{
+    [NotNull]
+    public TestContext? TestContext { get; set; }
+
+    [TestMethod]
+    public async Task Test_Issue1931()
+    {
+        // repro for https://github.com/Azure/bicep/issues/1931#issuecomment-1088061552
+        var bicepFileUri = new Uri("file:///Users/ant/Desktop/asdfasdf/main.bicep");
+        var textFileUri = new Uri("file:///Users/ant/Desktop/asdfasdf/a.txt");
+
+        var helper = await MultiFileLanguageServerHelper.StartLanguageServer(TestContext);
+
+        await helper.OpenFileOnceAsync(TestContext, "param foo string", bicepFileUri);
+
+        // Deleting an unrelated .txt file in the same directory should have no impact on the .bicep file.
+        helper.Client.Workspace.DidChangeWatchedFiles(new()
+        {
+            Changes = new Container<FileEvent>(
+                new FileEvent
+                {
+                    Type = FileChangeType.Deleted,
+                    Uri = textFileUri,
+                }),
+        });
+
+        // Validate that the .bicep file compilation still works by requesting hovers and asserting we get a response.
+        var hover = await helper.Client.RequestHover(new HoverParams
+        {
+            TextDocument = new(bicepFileUri),
+            Position = new(0, 8),
+        });
+
+        hover!.Contents.MarkupContent!.Value.Should().Contain(@"```bicep
+param foo: string
+```");
+    }
+}


### PR DESCRIPTION
See comment [here](https://github.com/Azure/bicep/issues/1931#issuecomment-1411398391) for an explanation:

> > I seem to have a reproducible scenario:
> 
> @StephenWeatherford  - this comment from back in April gave me what I needed to repro in the test suite! I ran through your steps with LSP tracing enabled, and managed to figure out the minimal set of steps to hit the issue.
> 
> Here's a PR to check-in a repro (not a fix) for it: https://github.com/Azure/bicep/pull/9711
> 
> FWIW, looks like this is the offending logic. For reasons that I cannot recall, we simply remove the `.bicep` file from the set of active contexts if an unrelated file in the same dir is deleted: https://github.com/Azure/bicep/blob/78cd96b1eae5bdcd04a9dd484f0676a7da4bae5f/src/Bicep.LangServer/BicepCompilationManager.cs#L187-L193

Turns out I didn't read the docs for [Uri.IsBaseOf](https://learn.microsoft.com/en-us/dotnet/api/system.uri.isbaseof?view=net-7.0) when implementing #712, and it doesn't do what I thought it did - it actually returns `true` for 2 file URIs that are in the same folder. I have replaced the usage with a function that does the correct thing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9711)