### PR TITLE
Handle tuples in allowed([...])-derived param type

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4238,5 +4238,22 @@ resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
 
             CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
         }
+
+        // https://github.com/Azure/bicep/issues/9713
+        [TestMethod]
+        public void Test_9713()
+        {
+            var result = CompilationHelper.Compile(@"
+@allowed([
+  ['blob', 'file']
+  ['blob', 'file', 'table', 'queue']
+])
+param storageServices array = ['blob', 'file']
+
+output storageService string = storageServices[0]
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -487,7 +487,7 @@ param invalidPermutation array = [
 ])
 param invalidDefaultWithAllowedArrayDecorator array = true
 //@[06:045) [no-unused-params (Warning)] Parameter "invalidDefaultWithAllowedArrayDecorator" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |invalidDefaultWithAllowedArrayDecorator|
-//@[54:058) [BCP033 (Error)] Expected a value of type "(['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts'])[]" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[54:058) [BCP033 (Error)] Expected a value of type "['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']" but the provided value is of type "true". (CodeDescription: none) |true|
 
 // unterminated multi-line comment
 /*    

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -350,7 +350,7 @@ param invalidPermutation array = [
 	]
 ])
 param invalidDefaultWithAllowedArrayDecorator array = true
-//@[06:045) Parameter invalidDefaultWithAllowedArrayDecorator. Type: (['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts'])[]. Declaration start char: 0, length: 245
+//@[06:045) Parameter invalidDefaultWithAllowedArrayDecorator. Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']. Declaration start char: 0, length: 245
 
 // unterminated multi-line comment
 /*    


### PR DESCRIPTION
Resolves #9713 

Handling of the `@allowed()` decorator's impact on assigned types was not handling the case where each allowed value was an array.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9717)