### PR TITLE
Relax nullability tracking on signatures of `first` and `last`

### DIFF
--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -282,10 +282,11 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("first")
                 .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) =>
                 {
-                    return new(argumentTypes[0] switch 
+                    return new(argumentTypes[0] switch
                     {
                         TupleType tupleType => tupleType.Items.FirstOrDefault()?.Type ?? LanguageConstants.Null,
-                        ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
+                        // TODO update this next branch to only match when arrayType.minLength >= 1 (once types carry constraint data)
+                        ArrayType arrayType => arrayType.Item.Type,
                         _ => LanguageConstants.Any
                     });
                 }, LanguageConstants.Any)
@@ -304,10 +305,11 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("last")
                 .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) =>
                 {
-                    return new(argumentTypes[0] switch 
+                    return new(argumentTypes[0] switch
                     {
                         TupleType tupleType => tupleType.Items.LastOrDefault()?.Type ?? LanguageConstants.Null,
-                        ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
+                        // TODO update this next branch to only match when arrayType.minLength >= 1 (once types carry constraint data)
+                        ArrayType arrayType => arrayType.Item.Type,
                         _ => LanguageConstants.Any
                     });
                 }, LanguageConstants.Any)


### PR DESCRIPTION
Resolves #9715 

`first(split(...` and `last(split(...` are a really common pattern, and return type resolvers for `first` and `last` currently have no way of knowing that the return value of `split` will always contain at least one element.

This change should be revisited once #9571 or something like it is implemented.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9719)