### PR TITLE
Type inference for tuple index access

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -425,4 +425,50 @@ output quux string = foos[0]!.bar.baz.quux
         result.Should().NotHaveAnyDiagnostics();
         result.Should().HaveTemplateWithOutput("quux", "[parameters('foos')[0].bar.baz.quux]");
     }
+
+    [TestMethod]
+    public void Tuples_with_a_literal_index_use_type_at_index()
+    {
+        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes,
+("main.bicep", @"
+var myArray = ['foo', 'bar']
+
+module mod './mod.bicep' = {
+  name: 'mod'
+  params: {
+    myParam: myArray[0]
+  }
+}
+"),
+("mod.bicep", @"
+param myParam 'foo'
+"));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void Tuples_with_a_literal_union_index_use_type_at_indices()
+    {
+        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes,
+("main.bicep", @"
+param index 0 | 1
+
+var myArray = ['foo', 'bar', 'baz']
+
+module mod './mod.bicep' = {
+  name: 'mod'
+  params: {
+    myParam: myArray[index]
+  }
+}
+"),
+("mod.bicep", @"
+param myParam 'foo' | 'bar'
+"));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().NotBeNull();
+    }
 }

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -1476,6 +1476,48 @@
     }
   },
   {
+    "label": "nonExistentIndex1",
+    "kind": "variable",
+    "detail": "nonExistentIndex1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex1"
+    }
+  },
+  {
+    "label": "nonExistentIndex2",
+    "kind": "variable",
+    "detail": "nonExistentIndex2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex2"
+    }
+  },
+  {
+    "label": "nonExistentIndex3",
+    "kind": "variable",
+    "detail": "nonExistentIndex3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex3"
+    }
+  },
+  {
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/symbols.json
@@ -1498,6 +1498,48 @@
     }
   },
   {
+    "label": "nonExistentIndex1",
+    "kind": "variable",
+    "detail": "nonExistentIndex1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex1"
+    }
+  },
+  {
+    "label": "nonExistentIndex2",
+    "kind": "variable",
+    "detail": "nonExistentIndex2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex2"
+    }
+  },
+  {
+    "label": "nonExistentIndex3",
+    "kind": "variable",
+    "detail": "nonExistentIndex3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex3"
+    }
+  },
+  {
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -1494,6 +1494,48 @@
     }
   },
   {
+    "label": "nonExistentIndex1",
+    "kind": "variable",
+    "detail": "nonExistentIndex1",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex1",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex1"
+    }
+  },
+  {
+    "label": "nonExistentIndex2",
+    "kind": "variable",
+    "detail": "nonExistentIndex2",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex2",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex2"
+    }
+  },
+  {
+    "label": "nonExistentIndex3",
+    "kind": "variable",
+    "detail": "nonExistentIndex3",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_nonExistentIndex3",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nonExistentIndex3"
+    }
+  },
+  {
     "label": "nonTopLevelLoop",
     "kind": "variable",
     "detail": "nonTopLevelLoop",

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.bicep
@@ -87,6 +87,11 @@ var myConcat = sys.concat('a', az.concat('b', 'c'))
 // invalid string using double quotes
 var doubleString = "bad string"
 
+// invalid index on array literal
+var nonExistentIndex1 = [][0]
+var nonExistentIndex2 = ['foo'][1]
+var nonExistentIndex3 = ['foo', 'bar'][-1]
+
 var resourceGroup = ''
 var rgName = resourceGroup().name
 

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.diagnostics.bicep
@@ -162,6 +162,17 @@ var doubleString = "bad string"
 //@[19:20) [BCP103 (Error)] The following token is not recognized: """. Strings are defined using single quotes in bicep. (CodeDescription: none) |"|
 //@[30:31) [BCP103 (Error)] The following token is not recognized: """. Strings are defined using single quotes in bicep. (CodeDescription: none) |"|
 
+// invalid index on array literal
+var nonExistentIndex1 = [][0]
+//@[04:21) [no-unused-vars (Warning)] Variable "nonExistentIndex1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nonExistentIndex1|
+//@[27:28) [BCP311 (Error)] The provided index value of "0" is not valid for type "<empty array>". (CodeDescription: none) |0|
+var nonExistentIndex2 = ['foo'][1]
+//@[04:21) [no-unused-vars (Warning)] Variable "nonExistentIndex2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nonExistentIndex2|
+//@[32:33) [BCP311 (Error)] The provided index value of "1" is not valid for type "['foo']". Indexes for this type must be between 0 and 0. (CodeDescription: none) |1|
+var nonExistentIndex3 = ['foo', 'bar'][-1]
+//@[04:21) [no-unused-vars (Warning)] Variable "nonExistentIndex3" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |nonExistentIndex3|
+//@[39:41) [BCP311 (Error)] The provided index value of "-1" is not valid for type "['foo', 'bar']". Indexes for this type must be between 0 and 1. (CodeDescription: none) |-1|
+
 var resourceGroup = ''
 var rgName = resourceGroup().name
 //@[04:10) [no-unused-vars (Warning)] Variable "rgName" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |rgName|
@@ -226,6 +237,7 @@ var objectVarTopLevelCompletions2 = objectLiteralType.
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
 //@[04:29) [no-unused-vars (Warning)] Variable "mixedArrayTypeCompletions" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |mixedArrayTypeCompletions|
+//@[59:60) [BCP053 (Error)] The type "object" does not contain property "o". Available properties include "one". (CodeDescription: none) |o|
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
 //@[04:30) [no-unused-vars (Warning)] Variable "mixedArrayTypeCompletions2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |mixedArrayTypeCompletions2|

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.formatted.bicep
@@ -86,6 +86,11 @@ var myConcat = sys.concat('a', az.concat('b', 'c'))
 // invalid string using double quotes
 var doubleString = "bad string"
 
+// invalid index on array literal
+var nonExistentIndex1 = [][0]
+var nonExistentIndex2 = [ 'foo' ][1]
+var nonExistentIndex3 = [ 'foo', 'bar' ][-1]
+
 var resourceGroup = ''
 var rgName = resourceGroup().name
 

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
@@ -114,6 +114,14 @@ var myConcat = sys.concat('a', az.concat('b', 'c'))
 var doubleString = "bad string"
 //@[04:16) Variable doubleString. Type: error. Declaration start char: 0, length: 31
 
+// invalid index on array literal
+var nonExistentIndex1 = [][0]
+//@[04:21) Variable nonExistentIndex1. Type: error. Declaration start char: 0, length: 29
+var nonExistentIndex2 = ['foo'][1]
+//@[04:21) Variable nonExistentIndex2. Type: error. Declaration start char: 0, length: 34
+var nonExistentIndex3 = ['foo', 'bar'][-1]
+//@[04:21) Variable nonExistentIndex3. Type: error. Declaration start char: 0, length: 42
+
 var resourceGroup = ''
 //@[04:17) Variable resourceGroup. Type: ''. Declaration start char: 0, length: 22
 var rgName = resourceGroup().name
@@ -172,10 +180,10 @@ var objectVarTopLevelCompletions2 = objectLiteralType.
 // this does not produce any completions because mixed array items are of type "any"
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions = objectLiteralType.fifth[0].o
-//@[04:29) Variable mixedArrayTypeCompletions. Type: any. Declaration start char: 0, length: 60
+//@[04:29) Variable mixedArrayTypeCompletions. Type: error. Declaration start char: 0, length: 60
 // #completionTest(60) -> mixedArrayProperties
 var mixedArrayTypeCompletions2 = objectLiteralType.fifth[0].
-//@[04:30) Variable mixedArrayTypeCompletions2. Type: any. Declaration start char: 0, length: 60
+//@[04:30) Variable mixedArrayTypeCompletions2. Type: error. Declaration start char: 0, length: 60
 
 // #completionTest(58) -> oneArrayItemProperties
 var oneArrayItemCompletions = objectLiteralType.sixth[0].t

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[00:5538) ProgramSyntax
+//@[00:5681) ProgramSyntax
 //@[00:0001) ├─Token(NewLine) |\n|
 // unknown declaration
 //@[22:0023) ├─Token(NewLine) |\n|
@@ -488,6 +488,66 @@ var doubleString = "bad string"
 //@[24:0030) |   ├─Token(Identifier) |string|
 //@[30:0031) |   └─Token(Unrecognized) |"|
 //@[31:0033) ├─Token(NewLine) |\n\n|
+
+// invalid index on array literal
+//@[33:0034) ├─Token(NewLine) |\n|
+var nonExistentIndex1 = [][0]
+//@[00:0029) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0021) | ├─IdentifierSyntax
+//@[04:0021) | | └─Token(Identifier) |nonExistentIndex1|
+//@[22:0023) | ├─Token(Assignment) |=|
+//@[24:0029) | └─ArrayAccessSyntax
+//@[24:0026) |   ├─ArraySyntax
+//@[24:0025) |   | ├─Token(LeftSquare) |[|
+//@[25:0026) |   | └─Token(RightSquare) |]|
+//@[26:0027) |   ├─Token(LeftSquare) |[|
+//@[27:0028) |   ├─IntegerLiteralSyntax
+//@[27:0028) |   | └─Token(Integer) |0|
+//@[28:0029) |   └─Token(RightSquare) |]|
+//@[29:0030) ├─Token(NewLine) |\n|
+var nonExistentIndex2 = ['foo'][1]
+//@[00:0034) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0021) | ├─IdentifierSyntax
+//@[04:0021) | | └─Token(Identifier) |nonExistentIndex2|
+//@[22:0023) | ├─Token(Assignment) |=|
+//@[24:0034) | └─ArrayAccessSyntax
+//@[24:0031) |   ├─ArraySyntax
+//@[24:0025) |   | ├─Token(LeftSquare) |[|
+//@[25:0030) |   | ├─ArrayItemSyntax
+//@[25:0030) |   | | └─StringSyntax
+//@[25:0030) |   | |   └─Token(StringComplete) |'foo'|
+//@[30:0031) |   | └─Token(RightSquare) |]|
+//@[31:0032) |   ├─Token(LeftSquare) |[|
+//@[32:0033) |   ├─IntegerLiteralSyntax
+//@[32:0033) |   | └─Token(Integer) |1|
+//@[33:0034) |   └─Token(RightSquare) |]|
+//@[34:0035) ├─Token(NewLine) |\n|
+var nonExistentIndex3 = ['foo', 'bar'][-1]
+//@[00:0042) ├─VariableDeclarationSyntax
+//@[00:0003) | ├─Token(Identifier) |var|
+//@[04:0021) | ├─IdentifierSyntax
+//@[04:0021) | | └─Token(Identifier) |nonExistentIndex3|
+//@[22:0023) | ├─Token(Assignment) |=|
+//@[24:0042) | └─ArrayAccessSyntax
+//@[24:0038) |   ├─ArraySyntax
+//@[24:0025) |   | ├─Token(LeftSquare) |[|
+//@[25:0030) |   | ├─ArrayItemSyntax
+//@[25:0030) |   | | └─StringSyntax
+//@[25:0030) |   | |   └─Token(StringComplete) |'foo'|
+//@[30:0031) |   | ├─Token(Comma) |,|
+//@[32:0037) |   | ├─ArrayItemSyntax
+//@[32:0037) |   | | └─StringSyntax
+//@[32:0037) |   | |   └─Token(StringComplete) |'bar'|
+//@[37:0038) |   | └─Token(RightSquare) |]|
+//@[38:0039) |   ├─Token(LeftSquare) |[|
+//@[39:0041) |   ├─UnaryOperationSyntax
+//@[39:0040) |   | ├─Token(Minus) |-|
+//@[40:0041) |   | └─IntegerLiteralSyntax
+//@[40:0041) |   |   └─Token(Integer) |1|
+//@[41:0042) |   └─Token(RightSquare) |]|
+//@[42:0044) ├─Token(NewLine) |\n\n|
 
 var resourceGroup = ''
 //@[00:0022) ├─VariableDeclarationSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.tokens.bicep
@@ -325,6 +325,44 @@ var doubleString = "bad string"
 //@[30:31) Unrecognized |"|
 //@[31:33) NewLine |\n\n|
 
+// invalid index on array literal
+//@[33:34) NewLine |\n|
+var nonExistentIndex1 = [][0]
+//@[00:03) Identifier |var|
+//@[04:21) Identifier |nonExistentIndex1|
+//@[22:23) Assignment |=|
+//@[24:25) LeftSquare |[|
+//@[25:26) RightSquare |]|
+//@[26:27) LeftSquare |[|
+//@[27:28) Integer |0|
+//@[28:29) RightSquare |]|
+//@[29:30) NewLine |\n|
+var nonExistentIndex2 = ['foo'][1]
+//@[00:03) Identifier |var|
+//@[04:21) Identifier |nonExistentIndex2|
+//@[22:23) Assignment |=|
+//@[24:25) LeftSquare |[|
+//@[25:30) StringComplete |'foo'|
+//@[30:31) RightSquare |]|
+//@[31:32) LeftSquare |[|
+//@[32:33) Integer |1|
+//@[33:34) RightSquare |]|
+//@[34:35) NewLine |\n|
+var nonExistentIndex3 = ['foo', 'bar'][-1]
+//@[00:03) Identifier |var|
+//@[04:21) Identifier |nonExistentIndex3|
+//@[22:23) Assignment |=|
+//@[24:25) LeftSquare |[|
+//@[25:30) StringComplete |'foo'|
+//@[30:31) Comma |,|
+//@[32:37) StringComplete |'bar'|
+//@[37:38) RightSquare |]|
+//@[38:39) LeftSquare |[|
+//@[39:40) Minus |-|
+//@[40:41) Integer |1|
+//@[41:42) RightSquare |]|
+//@[42:44) NewLine |\n\n|
+
 var resourceGroup = ''
 //@[00:03) Identifier |var|
 //@[04:17) Identifier |resourceGroup|

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11699777311316241424"
+      "templateHash": "10197341916052980146"
     }
   },
   "definitions": {
@@ -62,7 +62,7 @@
           "$ref": "#/definitions/foo"
         }
       },
-      "sealed": true,
+      "additionalProperties": false,
       "metadata": {
         "description": "The foo type"
       }
@@ -168,7 +168,22 @@
       "type": "string"
     },
     "tuple": {
-      "type": "array"
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "string",
+          "metadata": {
+            "description": "A leading string"
+          }
+        },
+        {
+          "$ref": "#/definitions/bar",
+          "metadata": {
+            "description": "A second element using a type alias"
+          }
+        }
+      ],
+      "items": false
     },
     "stringStringDictionary": {
       "type": "object",

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
@@ -48,7 +48,7 @@ type foo = {
 //@          "$ref": "#/definitions/foo"
 //@        }
 //@      },
-//@      "sealed": true,
+//@      "additionalProperties": false,
 //@      "metadata": {
 //@      }
 //@    },
@@ -261,12 +261,27 @@ param paramUsingType mixedArray
 
 type tuple = [
 //@    "tuple": {
-//@      "type": "array"
+//@      "type": "array",
+//@      "prefixItems": [
+//@        {
+//@          "type": "string",
+//@          "metadata": {
+//@          }
+//@        },
+//@        {
+//@          "$ref": "#/definitions/bar",
+//@          "metadata": {
+//@          }
+//@        }
+//@      ],
+//@      "items": false
 //@    },
     @description('A leading string')
+//@            "description": "A leading string"
     string
 
     @description('A second element using a type alias')
+//@            "description": "A second element using a type alias"
     bar
 ]
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11699777311316241424"
+      "templateHash": "10197341916052980146"
     }
   },
   "definitions": {
@@ -62,7 +62,7 @@
           "$ref": "#/definitions/foo"
         }
       },
-      "sealed": true,
+      "additionalProperties": false,
       "metadata": {
         "description": "The foo type"
       }
@@ -168,7 +168,22 @@
       "type": "string"
     },
     "tuple": {
-      "type": "array"
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "string",
+          "metadata": {
+            "description": "A leading string"
+          }
+        },
+        {
+          "$ref": "#/definitions/bar",
+          "metadata": {
+            "description": "A second element using a type alias"
+          }
+        }
+      ],
+      "items": false
     },
     "stringStringDictionary": {
       "type": "object",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -984,34 +984,6 @@
     }
   },
   {
-    "label": "functionOnIndexer2",
-    "kind": "variable",
-    "detail": "functionOnIndexer2",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_functionOnIndexer2",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "functionOnIndexer2"
-    }
-  },
-  {
-    "label": "functionOnIndexer3",
-    "kind": "variable",
-    "detail": "functionOnIndexer3",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_functionOnIndexer3",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "functionOnIndexer3"
-    }
-  },
-  {
     "label": "greater",
     "kind": "variable",
     "detail": "greater",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.bicep
@@ -110,12 +110,6 @@ var functionOnIndexer1 = concat([
   's'
 ][0], 's')
 
-var functionOnIndexer2 = concat([
-][0], 's')
-
-var functionOnIndexer3 = concat([
-][0], any('s'))
-
 var singleQuote = '\''
 var myPropertyName = '${singleQuote}foo${singleQuote}'
 

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.diagnostics.bicep
@@ -145,15 +145,6 @@ var functionOnIndexer1 = concat([
   's'
 ][0], 's')
 
-var functionOnIndexer2 = concat([
-//@[04:22) [no-unused-vars (Warning)] Variable "functionOnIndexer2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |functionOnIndexer2|
-//@[25:44) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (CodeDescription: bicep core(https://aka.ms/bicep/linter/prefer-interpolation)) |concat([\n][0], 's')|
-][0], 's')
-
-var functionOnIndexer3 = concat([
-//@[04:22) [no-unused-vars (Warning)] Variable "functionOnIndexer3" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |functionOnIndexer3|
-][0], any('s'))
-
 var singleQuote = '\''
 var myPropertyName = '${singleQuote}foo${singleQuote}'
 //@[04:18) [no-unused-vars (Warning)] Variable "myPropertyName" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |myPropertyName|

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.formatted.bicep
@@ -109,12 +109,6 @@ var functionOnIndexer1 = concat([
     's'
   ][0], 's')
 
-var functionOnIndexer2 = concat([
-  ][0], 's')
-
-var functionOnIndexer3 = concat([
-  ][0], any('s'))
-
 var singleQuote = '\''
 var myPropertyName = '${singleQuote}foo${singleQuote}'
 

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 
-//@[000:7513) ProgramExpression
+//@[000:7416) ProgramExpression
 // int
 @sys.description('an int variable')
 //@[000:0050) ├─DeclaredVariableExpression { Name = myInt }
@@ -311,24 +311,6 @@ var functionOnIndexer1 = concat([
 ][0], 's')
 //@[002:0003) |   | ├─IntegerLiteralExpression { Value = 0 }
 //@[006:0009) |   └─StringLiteralExpression { Value = s }
-
-var functionOnIndexer2 = concat([
-//@[000:0044) ├─DeclaredVariableExpression { Name = functionOnIndexer2 }
-//@[025:0044) | └─FunctionCallExpression { Name = concat }
-//@[032:0038) |   ├─ArrayAccessExpression
-//@[032:0035) |   | └─ArrayExpression
-][0], 's')
-//@[002:0003) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[006:0009) |   └─StringLiteralExpression { Value = s }
-
-var functionOnIndexer3 = concat([
-//@[000:0049) ├─DeclaredVariableExpression { Name = functionOnIndexer3 }
-//@[025:0049) | └─FunctionCallExpression { Name = concat }
-//@[032:0038) |   ├─ArrayAccessExpression
-//@[032:0035) |   | └─ArrayExpression
-][0], any('s'))
-//@[002:0003) |   | ├─IntegerLiteralExpression { Value = 0 }
-//@[010:0013) |   └─StringLiteralExpression { Value = s }
 
 var singleQuote = '\''
 //@[000:0022) ├─DeclaredVariableExpression { Name = singleQuote }

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8820744274097135450"
+      "templateHash": "10834818401270956504"
     }
   },
   "parameters": {
@@ -146,8 +146,6 @@
     "namedPropertyIndexer": "[createObject('foo', 's').foo]",
     "intIndexer": "[createArray('s')[0]]",
     "functionOnIndexer1": "[concat(createArray('s')[0], 's')]",
-    "functionOnIndexer2": "[concat(createArray()[0], 's')]",
-    "functionOnIndexer3": "[concat(createArray()[0], 's')]",
     "singleQuote": "'",
     "myPropertyName": "[format('{0}foo{1}', variables('singleQuote'), variables('singleQuote'))]",
     "previousEmitLimit": [

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.sourcemap.bicep
@@ -182,14 +182,6 @@ var functionOnIndexer1 = concat([
   's'
 ][0], 's')
 
-var functionOnIndexer2 = concat([
-//@    "functionOnIndexer2": "[concat(createArray()[0], 's')]",
-][0], 's')
-
-var functionOnIndexer3 = concat([
-//@    "functionOnIndexer3": "[concat(createArray()[0], 's')]",
-][0], any('s'))
-
 var singleQuote = '\''
 //@    "singleQuote": "'",
 var myPropertyName = '${singleQuote}foo${singleQuote}'

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4655166543508546916"
+      "templateHash": "2414029487247477729"
     }
   },
   "parameters": {
@@ -148,8 +148,6 @@
     "namedPropertyIndexer": "[createObject('foo', 's').foo]",
     "intIndexer": "[createArray('s')[0]]",
     "functionOnIndexer1": "[concat(createArray('s')[0], 's')]",
-    "functionOnIndexer2": "[concat(createArray()[0], 's')]",
-    "functionOnIndexer3": "[concat(createArray()[0], 's')]",
     "singleQuote": "'",
     "myPropertyName": "[format('{0}foo{1}', variables('singleQuote'), variables('singleQuote'))]",
     "previousEmitLimit": [

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.symbols.bicep
@@ -146,14 +146,6 @@ var functionOnIndexer1 = concat([
   's'
 ][0], 's')
 
-var functionOnIndexer2 = concat([
-//@[04:22) Variable functionOnIndexer2. Type: string. Declaration start char: 0, length: 44
-][0], 's')
-
-var functionOnIndexer3 = concat([
-//@[04:22) Variable functionOnIndexer3. Type: array. Declaration start char: 0, length: 49
-][0], any('s'))
-
 var singleQuote = '\''
 //@[04:15) Variable singleQuote. Type: '\''. Declaration start char: 0, length: 22
 var myPropertyName = '${singleQuote}foo${singleQuote}'

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:7513) ProgramSyntax
+//@[000:7416) ProgramSyntax
 //@[000:0001) ├─Token(NewLine) |\n|
 // int
 //@[006:0007) ├─Token(NewLine) |\n|
@@ -937,68 +937,6 @@ var functionOnIndexer1 = concat([
 //@[006:0009) |   |   └─Token(StringComplete) |'s'|
 //@[009:0010) |   └─Token(RightParen) |)|
 //@[010:0012) ├─Token(NewLine) |\n\n|
-
-var functionOnIndexer2 = concat([
-//@[000:0044) ├─VariableDeclarationSyntax
-//@[000:0003) | ├─Token(Identifier) |var|
-//@[004:0022) | ├─IdentifierSyntax
-//@[004:0022) | | └─Token(Identifier) |functionOnIndexer2|
-//@[023:0024) | ├─Token(Assignment) |=|
-//@[025:0044) | └─FunctionCallSyntax
-//@[025:0031) |   ├─IdentifierSyntax
-//@[025:0031) |   | └─Token(Identifier) |concat|
-//@[031:0032) |   ├─Token(LeftParen) |(|
-//@[032:0038) |   ├─FunctionArgumentSyntax
-//@[032:0038) |   | └─ArrayAccessSyntax
-//@[032:0035) |   |   ├─ArraySyntax
-//@[032:0033) |   |   | ├─Token(LeftSquare) |[|
-//@[033:0034) |   |   | ├─Token(NewLine) |\n|
-][0], 's')
-//@[000:0001) |   |   | └─Token(RightSquare) |]|
-//@[001:0002) |   |   ├─Token(LeftSquare) |[|
-//@[002:0003) |   |   ├─IntegerLiteralSyntax
-//@[002:0003) |   |   | └─Token(Integer) |0|
-//@[003:0004) |   |   └─Token(RightSquare) |]|
-//@[004:0005) |   ├─Token(Comma) |,|
-//@[006:0009) |   ├─FunctionArgumentSyntax
-//@[006:0009) |   | └─StringSyntax
-//@[006:0009) |   |   └─Token(StringComplete) |'s'|
-//@[009:0010) |   └─Token(RightParen) |)|
-//@[010:0012) ├─Token(NewLine) |\n\n|
-
-var functionOnIndexer3 = concat([
-//@[000:0049) ├─VariableDeclarationSyntax
-//@[000:0003) | ├─Token(Identifier) |var|
-//@[004:0022) | ├─IdentifierSyntax
-//@[004:0022) | | └─Token(Identifier) |functionOnIndexer3|
-//@[023:0024) | ├─Token(Assignment) |=|
-//@[025:0049) | └─FunctionCallSyntax
-//@[025:0031) |   ├─IdentifierSyntax
-//@[025:0031) |   | └─Token(Identifier) |concat|
-//@[031:0032) |   ├─Token(LeftParen) |(|
-//@[032:0038) |   ├─FunctionArgumentSyntax
-//@[032:0038) |   | └─ArrayAccessSyntax
-//@[032:0035) |   |   ├─ArraySyntax
-//@[032:0033) |   |   | ├─Token(LeftSquare) |[|
-//@[033:0034) |   |   | ├─Token(NewLine) |\n|
-][0], any('s'))
-//@[000:0001) |   |   | └─Token(RightSquare) |]|
-//@[001:0002) |   |   ├─Token(LeftSquare) |[|
-//@[002:0003) |   |   ├─IntegerLiteralSyntax
-//@[002:0003) |   |   | └─Token(Integer) |0|
-//@[003:0004) |   |   └─Token(RightSquare) |]|
-//@[004:0005) |   ├─Token(Comma) |,|
-//@[006:0014) |   ├─FunctionArgumentSyntax
-//@[006:0014) |   | └─FunctionCallSyntax
-//@[006:0009) |   |   ├─IdentifierSyntax
-//@[006:0009) |   |   | └─Token(Identifier) |any|
-//@[009:0010) |   |   ├─Token(LeftParen) |(|
-//@[010:0013) |   |   ├─FunctionArgumentSyntax
-//@[010:0013) |   |   | └─StringSyntax
-//@[010:0013) |   |   |   └─Token(StringComplete) |'s'|
-//@[013:0014) |   |   └─Token(RightParen) |)|
-//@[014:0015) |   └─Token(RightParen) |)|
-//@[015:0017) ├─Token(NewLine) |\n\n|
 
 var singleQuote = '\''
 //@[000:0022) ├─VariableDeclarationSyntax

--- a/src/Bicep.Core.Samples/Files/Variables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/main.tokens.bicep
@@ -603,45 +603,6 @@ var functionOnIndexer1 = concat([
 //@[009:010) RightParen |)|
 //@[010:012) NewLine |\n\n|
 
-var functionOnIndexer2 = concat([
-//@[000:003) Identifier |var|
-//@[004:022) Identifier |functionOnIndexer2|
-//@[023:024) Assignment |=|
-//@[025:031) Identifier |concat|
-//@[031:032) LeftParen |(|
-//@[032:033) LeftSquare |[|
-//@[033:034) NewLine |\n|
-][0], 's')
-//@[000:001) RightSquare |]|
-//@[001:002) LeftSquare |[|
-//@[002:003) Integer |0|
-//@[003:004) RightSquare |]|
-//@[004:005) Comma |,|
-//@[006:009) StringComplete |'s'|
-//@[009:010) RightParen |)|
-//@[010:012) NewLine |\n\n|
-
-var functionOnIndexer3 = concat([
-//@[000:003) Identifier |var|
-//@[004:022) Identifier |functionOnIndexer3|
-//@[023:024) Assignment |=|
-//@[025:031) Identifier |concat|
-//@[031:032) LeftParen |(|
-//@[032:033) LeftSquare |[|
-//@[033:034) NewLine |\n|
-][0], any('s'))
-//@[000:001) RightSquare |]|
-//@[001:002) LeftSquare |[|
-//@[002:003) Integer |0|
-//@[003:004) RightSquare |]|
-//@[004:005) Comma |,|
-//@[006:009) Identifier |any|
-//@[009:010) LeftParen |(|
-//@[010:013) StringComplete |'s'|
-//@[013:014) RightParen |)|
-//@[014:015) RightParen |)|
-//@[015:017) NewLine |\n\n|
-
 var singleQuote = '\''
 //@[000:003) Identifier |var|
 //@[004:015) Identifier |singleQuote|

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1777,10 +1777,16 @@ namespace Bicep.Core.Diagnostics
                 "BCP310",
                 $@"Using a strongly-typed tuple type declaration requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.UserDefinedTypes)}"".");
 
-            public ErrorDiagnostic IndexOutOfBounds(string typeName, long tupleLength, long indexSought) => new(
-                TextSpan,
-                "BCP311",
-                $@"The provided index value of ""{indexSought}"" is not valid for type ""{typeName}"". Indexes for this type must be between 0 and {tupleLength - 1}");
+            public ErrorDiagnostic IndexOutOfBounds(string typeName, long tupleLength, long indexSought)
+            {
+                var message = new StringBuilder("The provided index value of \"").Append(indexSought).Append("\" is not valid for type \"").Append(typeName).Append("\".");
+                if (tupleLength > 0)
+                {
+                    message.Append(" Indexes for this type must be between 0 and ").Append(tupleLength - 1).Append(".");
+                }
+
+                return new(TextSpan, "BCP311", message.ToString());
+            }
 
             public ErrorDiagnostic MultipleAdditionalPropertiesDeclarations() => new(
                 TextSpan,

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -407,13 +407,12 @@ namespace Bicep.Core.Emit
         private ObjectExpression GetTypePropertiesForTupleType(TupleTypeSyntax syntax) => ExpressionFactory.CreateObject(new[]
         {
             TypeProperty(LanguageConstants.ArrayType),
-            // TODO uncomment the lines below when ARM w46 has finished rolling out
-            // SyntaxFactory.CreateObjectProperty("prefixItems",
-            //     SyntaxFactory.CreateArray(syntax.Items.Select(item => AddDecoratorsToBody(
-            //         item,
-            //         TypePropertiesForTypeExpression(item.Value),
-            //         Context.SemanticModel.GetDeclaredType(item) ?? ErrorType.Empty())))),
-            // SyntaxFactory.CreateObjectProperty("items", SyntaxFactory.CreateBooleanLiteral(false)),
+            ExpressionFactory.CreateObjectProperty("prefixItems",
+                ExpressionFactory.CreateArray(syntax.Items.Select(item => AddDecoratorsToBody(
+                    item,
+                    TypePropertiesForTypeExpression(item.Value),
+                    Context.SemanticModel.GetDeclaredType(item) ?? ErrorType.Empty())))),
+            ExpressionFactory.CreateObjectProperty("items", ExpressionFactory.CreateBooleanLiteral(false)),
         });
 
         private ObjectExpression GetTypePropertiesForStringSyntax(StringSyntax syntax) => ExpressionFactory.CreateObject(new[]
@@ -518,7 +517,7 @@ namespace Bicep.Core.Emit
                 foreach (var variable in nonLoopVariables)
                 {
                     emitter.EmitProperty(variable.Name, variable.Value);
-                }                
+                }
             });
         }
 
@@ -534,7 +533,7 @@ namespace Bicep.Core.Emit
                 {
                     var settings = import.NamespaceType.Settings;
 
-                    emitter.EmitObjectProperty(import.Name, () => 
+                    emitter.EmitObjectProperty(import.Name, () =>
                     {
                         emitter.EmitProperty("provider", settings.ArmTemplateProviderName);
                         emitter.EmitProperty("version", settings.ArmTemplateProviderVersion);
@@ -760,7 +759,7 @@ namespace Bicep.Core.Emit
                     }
                 }
 
-                emitter.EmitObjectProperty("properties", () => 
+                emitter.EmitObjectProperty("properties", () =>
                 {
                     emitter.EmitObjectProperty("expressionEvaluationOptions", () =>
                     {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -282,7 +282,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("first")
                 .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) =>
                 {
-                    return new(argumentTypes[0] switch 
+                    return new(argumentTypes[0] switch
                     {
                         TupleType tupleType => tupleType.Items.FirstOrDefault()?.Type ?? LanguageConstants.Null,
                         ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
@@ -304,7 +304,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("last")
                 .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) =>
                 {
-                    return new(argumentTypes[0] switch 
+                    return new(argumentTypes[0] switch
                     {
                         TupleType tupleType => tupleType.Items.LastOrDefault()?.Type ?? LanguageConstants.Null,
                         ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
@@ -1149,7 +1149,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     if (!TypeValidator.AreTypesAssignable(targetType, LanguageConstants.Array))
                     {
                         // the resource/module declaration is not a collection
-                        // (the compile-time constnat and resource/module placement is already enforced, so we don't need a deeper type check)
+                        // (the compile-time constant and resource/module placement is already enforced, so we don't need a deeper type check)
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).BatchSizeNotAllowed(decoratorName));
                     }
 
@@ -1181,9 +1181,7 @@ namespace Bicep.Core.Semantics.Namespaces
                             diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).SealedIncompatibleWithAdditionalPropertiesDeclaration());
                         }
                     })
-                    .WithEvaluator((_, targetType, targetObject) => targetObject.MergeProperty(LanguageConstants.ParameterSealedPropertyName, new BooleanLiteralExpression(null, true)))
-                    // TODO delete the above line and uncomment the line below when ARM w46 has finished rolling out
-                    // .WithEvaluator((_, targetType, targetObject) => targetObject.MergeProperty("additionalProperties", SyntaxFactory.CreateBooleanLiteral(false)))
+                    .WithEvaluator((_, targetType, targetObject) => targetObject.MergeProperty("additionalProperties", ExpressionFactory.CreateBooleanLiteral(false)))
                     .Build();
             }
         }


### PR DESCRIPTION
Resolves #3504 

This PR updates `TypeAssignmentVisitor` to infer more specific types when the type of the index expression used is an integer literal or a union composed entirely of integer literals.

While regenerating baselines, I noticed that some of the code generating the ARM JSON representation of tuples was commented out pending the rollout of w46; now that the rollout has completed, this code has been uncommented.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9724)