### PR TITLE
Warn (don't error) on nullables throughout

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4207,38 +4207,6 @@ output sql resource = sql
             });
         }
 
-        // https://github.com/Azure/bicep/issues/9653
-        [TestMethod]
-        public void Test_9653()
-        {
-            var templateWithNullablyTypedName = @"
-param input string
-
-resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
-  name: last(split(input, '/'))
-}
-";
-            var templateWithNonNullAssertion = @"
-param input string
-
-resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
-  name: last(split(input, '/'))!
-}
-";
-
-            var result = CompilationHelper.Compile(templateWithNullablyTypedName);
-            result.Template.Should().NotBeNull();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-            {
-                ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
-            });
-
-            result.ExcludingLinterDiagnostics().Diagnostics.Single().Should().BeAssignableTo<IFixable>();
-            result.ExcludingLinterDiagnostics().Diagnostics.Single().As<IFixable>().Fixes.Single().Should().HaveResult(templateWithNullablyTypedName, templateWithNonNullAssertion);
-
-            CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-        }
-
         // https://github.com/Azure/bicep/issues/9713
         [TestMethod]
         public void Test_9713()
@@ -4254,66 +4222,6 @@ output storageService string = storageServices[0]
 ");
 
             result.Should().NotHaveAnyDiagnostics();
-        }
-
-        // https://github.com/Azure/bicep/issues/9720
-        [TestMethod]
-        public void Test_9720()
-        {
-            var templateWithNullablyTypedArg = @"
-param input string
-
-output out string = uniqueString(last(split(input, '/')))
-";
-            var templateWithNonNullAssertion = @"
-param input string
-
-output out string = uniqueString(last(split(input, '/'))!)
-";
-
-            var result = CompilationHelper.Compile(templateWithNullablyTypedArg);
-            result.Template.Should().NotBeNull();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-            {
-                ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
-            });
-
-            result.ExcludingLinterDiagnostics().Diagnostics.Single().Should().BeAssignableTo<IFixable>();
-            result.ExcludingLinterDiagnostics().Diagnostics.Single().As<IFixable>().Fixes.Single().Should().HaveResult(templateWithNullablyTypedArg, templateWithNonNullAssertion);
-
-            CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-        }
-
-        [TestMethod]
-        public void Test_9720_multiple_nullability_violations()
-        {
-            var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), @"
-param input string[]
-
-output out array = split(first(input), last(input))
-");
-
-            result.Template.Should().NotBeNull();
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-            {
-                ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
-                ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""array | string"" but the provided value is of type ""null | string""."),
-            });
-        }
-
-        [TestMethod]
-        public void Test_9720_no_match_even_with_nullability_tweaks()
-        {
-            var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), @"
-param input string[]
-
-output out array = split(first(input), 21)
-");
-
-            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-            {
-                ("BCP070", DiagnosticLevel.Error, @"Argument of type ""21"" is not assignable to parameter of type ""array | string""."),
-            });
         }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Bicep.Core.CodeAction;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.IntegrationTests.Scenarios;
+
+[TestClass]
+public class NullabilityTests
+{
+    private static ServiceBuilder Services => new ServiceBuilder();
+
+    [DataTestMethod]
+    [DynamicData(nameof(GetTemplatesWithSingleUnexpectedlyNullableValue), DynamicDataSourceType.Method)]
+    public void Unexpectedly_nullable_types_raise_fixable_warning(string templateWithNullablyTypedValue, string templateWithNonNullAssertion, TypeSymbol expectedType, TypeSymbol actualType)
+    {
+        var result = CompilationHelper.Compile(templateWithNullablyTypedValue);
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, $@"Expected a value of type ""{expectedType}"" but the provided value is of type ""{actualType}""."),
+        });
+        result.Template.Should().NotBeNull();
+
+        result.ExcludingLinterDiagnostics().Diagnostics.Single().Should().BeAssignableTo<IFixable>();
+        result.ExcludingLinterDiagnostics().Diagnostics.Single().As<IFixable>().Fixes.Single().Should().HaveResult(templateWithNullablyTypedValue, templateWithNonNullAssertion);
+
+        CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    private static IEnumerable<object[]> GetTemplatesWithSingleUnexpectedlyNullableValue()
+    {
+        static object[] Case(string templateWithNullablyTypedValue, string templateWithNonNullAssertion, TypeSymbol expectedType, TypeSymbol actualType) => new object[]
+        {
+            templateWithNullablyTypedValue,
+            templateWithNonNullAssertion,
+            expectedType,
+            actualType,
+        };
+
+        return new[]
+        {
+            // nullably typed property assignment
+            Case(
+@"
+param input string
+
+resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: last(split(input, '/'))
+}
+",
+@"
+param input string
+
+resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: last(split(input, '/'))!
+}
+",
+                LanguageConstants.String,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.String)
+            ),
+
+            // nullably typed function argument
+            Case(
+@"
+param input string
+
+output out string = uniqueString(last(split(input, '/')))
+",
+@"
+param input string
+
+output out string = uniqueString(last(split(input, '/'))!)
+",
+                LanguageConstants.String,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.String)
+            ),
+
+            // nullably typed output value
+            Case(
+@"
+param csv string
+
+output firstPrefix string = first(split(csv, ','))
+",
+@"
+param csv string
+
+output firstPrefix string = first(split(csv, ','))!
+",
+                LanguageConstants.String,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.String)
+            ),
+
+            // nullably typed ternary condition
+            Case(
+@"
+param input array
+
+var nullableAtIndex = [for i in input: i != null]
+
+output eitherFooOrBar string = first(nullableAtIndex) ? 'foo' : 'bar'
+",
+@"
+param input array
+
+var nullableAtIndex = [for i in input: i != null]
+
+output eitherFooOrBar string = first(nullableAtIndex) ! ? 'foo' : 'bar'
+",
+                LanguageConstants.Bool,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.Bool)
+            ),
+
+            // nullably typed if condition
+            Case(
+@"
+param input array
+
+var nullableAtIndex = [for i in input: i != null]
+
+resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = if (first(nullableAtIndex)) {
+  name: 'sa'
+}
+",
+@"
+param input array
+
+var nullableAtIndex = [for i in input: i != null]
+
+resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' existing = if (first(nullableAtIndex)!) {
+  name: 'sa'
+}
+",
+                LanguageConstants.Bool,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.Bool)
+            ),
+
+            // nullably typed array indices
+            Case(
+@"
+param input array
+
+output something string = input[first(range(0, length(input)))]
+",
+@"
+param input array
+
+output something string = input[first(range(0, length(input)))!]
+",
+                LanguageConstants.Int,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.Int)
+            ),
+
+            // nullably typed object indices
+            Case(
+@"
+param input object
+param csv string
+
+output something string = input[first(split(csv, ','))]
+",
+@"
+param input object
+param csv string
+
+output something string = input[first(split(csv, ','))!]
+",
+                LanguageConstants.String,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.String)
+            ),
+
+            // nullably typed list comprehension target
+            Case(
+@"
+param input array
+
+var arrayOfArrays = [for i in input: range(0, 10)]
+var arrayOfOneBuzz = [for i in first(arrayOfArrays): 'buzz']
+",
+@"
+param input array
+
+var arrayOfArrays = [for i in input: range(0, 10)]
+var arrayOfOneBuzz = [for i in first(arrayOfArrays)!: 'buzz']
+",
+                LanguageConstants.Array,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, new TypedArrayType(LanguageConstants.Int, default))
+            ),
+
+            // nullably typed parameter defaults
+            Case(
+@"
+param csv string
+param anotherParam string = first(split(csv, ','))
+",
+@"
+param csv string
+param anotherParam string = first(split(csv, ','))!
+",
+                LanguageConstants.String,
+                TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.String)
+            ),
+        };
+    }
+
+    [TestMethod]
+    public void Function_overload_with_multiple_nullability_violations_still_finds_match_and_raises_no_errors()
+    {
+        var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), @"
+param input string[]
+
+output out array = split(first(input), last(input))
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""string"" but the provided value is of type ""null | string""."),
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""array | string"" but the provided value is of type ""null | string""."),
+        });
+    }
+
+    [TestMethod]
+    public void Function_overload_mismatch_even_with_nullability_tweaks_raises_no_nullability_warnings()
+    {
+        var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), @"
+param input string[]
+
+output out array = split(first(input), 21)
+");
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP070", DiagnosticLevel.Error, @"Argument of type ""21"" is not assignable to parameter of type ""array | string""."),
+        });
+    }
+}

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Azure.Deployments.Expression.Extensions;
@@ -345,6 +346,25 @@ namespace Bicep.Core.TypeSystem
                 sansNull.Length < union.Members.Length => CreateTypeUnion(sansNull),
             _ => null,
         };
+
+        /// <summary>
+        /// Determines if the provided candidate type would be assignable to the provided expected type if the former were stripped of its nullability.
+        /// </summary>
+        /// <remarks>
+        /// This function will return <code>false</code> if the provided candidate type is not nullable, even if it would be assignable to the provided expected
+        /// type without modification.
+        /// </remarks>
+        public static bool WouldBeAssignableIfNonNullable(TypeSymbol candidateType, TypeSymbol expectedType, [NotNullWhen(true)] out TypeSymbol? nonNullableCandidateType)
+        {
+            if (TryRemoveNullability(candidateType) is TypeSymbol nonNullable && TypeValidator.AreTypesAssignable(nonNullable, expectedType))
+            {
+                nonNullableCandidateType = nonNullable;
+                return true;
+            }
+
+            nonNullableCandidateType = null;
+            return false;
+        }
 
         private static ImmutableArray<ITypeReference> NormalizeTypeList(IEnumerable<ITypeReference> unionMembers)
         {

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -270,7 +270,7 @@ namespace Bicep.Core.TypeSystem
             // basic assignability check
             if (AreTypesAssignable(expressionType, targetType) == false)
             {
-                if (TypeHelper.TryRemoveNullability(expressionType) is TypeSymbol nonNullableExpressionType && AreTypesAssignable(nonNullableExpressionType, targetType))
+                if (TypeHelper.WouldBeAssignableIfNonNullable(expressionType, targetType, out var nonNullableExpressionType))
                 {
                     diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).PossibleNullReferenceAssignment(targetType, expressionType.Type, expression));
                     return NarrowType(config, expression, nonNullableExpressionType, targetType);


### PR DESCRIPTION
There are a number of Bicep constructs that perform their own assignment validity checking, including:

* Output values
* For expression targets
* If and ternary conditions
* Array access indices

Each of these special-purpose type checking guards has been updated to warn on nullable assignments iff the assigned value would otherwise be valid.

Resolves #9725 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9730)