### PR TITLE
Update literal return type deriver to take account of object additionalProperties

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4223,5 +4223,24 @@ output storageService string = storageServices[0]
 
             result.Should().NotHaveAnyDiagnostics();
         }
+
+        // https://github.com/Azure/bicep/issues/9734
+        [TestMethod]
+        public void Test_9734()
+        {
+            var result = CompilationHelper.Compile(@"
+param name string
+param appsettings object
+
+var defaultValues = {
+  '${name}': { }
+}
+var values = union(defaultValues, appsettings)
+
+output values object = values[name]
+");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/ArmFunctionReturnTypeEvaluator.cs
+++ b/src/Bicep.Core/TypeSystem/ArmFunctionReturnTypeEvaluator.cs
@@ -74,6 +74,12 @@ public static class ArmFunctionReturnTypeEvaluator
 
     private static JToken? ToJToken(ObjectType objectType)
     {
+        // If an object allows additional properties (and is not the implicit fallback of an unsealed type), then it cannot be cast to a literal
+        if (objectType.AdditionalPropertiesType is not null && !objectType.AdditionalPropertiesFlags.HasFlag(TypePropertyFlags.FallbackProperty))
+        {
+            return null;
+        }
+
         var target = new JObject();
         foreach (var (key, property) in objectType.Properties)
         {


### PR DESCRIPTION
Resolves #9734

The function return type deriver that uses the ARM expressions engine did not account for objects with unknown named properties when deciding whether an object type was a type literal. Consequently, given the following template:

```bicep
param key string

var objectWithNoKeys = {}
var objectWithOneUnknownKey = {
  '${key}': 'boo!'
}

var shouldBeFalse = contains(objectWithNoKeys, 'key')
var undecidableAtCompileTime = contains(objectWithOneUnknownKey , 'key')
```

both `shouldBeFalse` and `undecidableAtCompileTime` were assigned a type of `false`, even though `undecidableAtCompileTime` should have had a type of `bool`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9735)