### PR TITLE
Add survey debug flag for output window and move survey code to after langserver startup

### DIFF
--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -117,7 +117,7 @@ export async function activate(
         setGlobalStateKeysToSyncBetweenMachines(extensionContext.globalState);
 
         // Show appropriate surveys
-        surveys.showSurveys(extensionContext.globalState);
+        surveys.showSurveys(extensionContext.globalState, outputChannel);
 
         const viewManager = extension.register(
           new BicepVisualizerViewManager(extension.extensionUri, languageClient)

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -116,9 +116,6 @@ export async function activate(
 
         setGlobalStateKeysToSyncBetweenMachines(extensionContext.globalState);
 
-        // Show appropriate surveys
-        surveys.showSurveys(extensionContext.globalState, outputChannel);
-
         const viewManager = extension.register(
           new BicepVisualizerViewManager(extension.extensionUri, languageClient)
         );
@@ -212,6 +209,9 @@ export async function activate(
           window.activeTextEditor?.document,
           pasteAsBicepCommand
         );
+
+        // Show survey if appropriate
+        surveys.showSurveys(extensionContext.globalState, outputChannel);
       })
   );
 }

--- a/src/vscode-bicep/src/test/unit/surveys.unit.test.ts
+++ b/src/vscode-bicep/src/test/unit/surveys.unit.test.ts
@@ -45,7 +45,7 @@ describe("surveys-unittests", () => {
     const launchSurveyMock = options.launchSurveyMock ?? jest.fn();
     const workspaceConfigurationFake = new WorkspaceConfigurationFake();
 
-    const survey = new Survey(globalStorageFake, surveyInfo, {
+    const survey = new Survey(globalStorageFake, surveyInfo, undefined, {
       showInformationMessage: showInformationMessageMock,
       getIsSurveyAvailable: jest
         .fn()


### PR DESCRIPTION
Same as https://github.com/Azure/bicep/pull/9740 but moves the survey to after the language server has started up.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9779)