### PR TITLE
Fix (hopefully) setting breakpoints in vscode ext

### DIFF
--- a/src/vscode-bicep/.vscode/launch.json
+++ b/src/vscode-bicep/.vscode/launch.json
@@ -12,9 +12,6 @@
         "--extensionDevelopmentPath=${workspaceRoot}"
       ],
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/out/src/**/*.js"
-      ],
       "preLaunchTask": "${defaultBuildTask}",
       "env": {
         "BICEP_TRACING_ENABLED": "true",
@@ -33,9 +30,6 @@
         "--extensionDevelopmentPath=${workspaceRoot}"
       ],
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/out/src/**/*.js"
-      ],
       "preLaunchTask": "build:prod",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll"
@@ -51,9 +45,6 @@
         "--extensionDevelopmentPath=${workspaceRoot}"
       ],
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/out/src/**/*.js"
-      ],
       "preLaunchTask": "watch",
       "env": {
         "BICEP_LANGUAGE_SERVER_PATH": "${workspaceRoot}/../Bicep.LangServer/bin/Debug/net6.0/Bicep.LangServer.dll"
@@ -67,9 +58,6 @@
         "--enable-proposed-api=ms-azuretools.vscode-bicep",
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/e2e/index"
-      ],
-      "outFiles": [
-        "${workspaceRoot}/out/test/e2e/**/*.js"
       ],
       "preLaunchTask": "build:e2e",
       "env": {
@@ -85,9 +73,6 @@
         "--enable-proposed-api=ms-azuretools.vscode-bicep",
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/e2e/index"
-      ],
-      "outFiles": [
-        "${workspaceRoot}/out/test/e2e/**/*.js"
       ],
       "preLaunchTask": "build:e2e:dev",
       "env": {


### PR DESCRIPTION
I believe outFiles is no longer needed.  Also, it was incorrect.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9794)