### PR TITLE
Fix run-away regex

### DIFF
--- a/src/vscode-bicep/src/test/unit/removePropertiesWithPossibleUserInfo.test.ts
+++ b/src/vscode-bicep/src/test/unit/removePropertiesWithPossibleUserInfo.test.ts
@@ -28,4 +28,42 @@ describe("removePropertiesWithPossibleUserInfoInDeployParams()", () => {
 
     expect(actual).toMatch(expected);
   });
+
+  it("should handle multiple replacements", () => {
+    let value =
+      'Params: {    "textDocument": {        "uri": "someUri"    }, "token": "eyJ0eXAi",    "expiresOnTimestamp": "1648143343698"}';
+    value = value.repeat(10) + "\n" + value.repeat(10);
+    const actual = removePropertiesWithPossibleUserInfoInDeployParams(value);
+    let expected =
+      'Params: {    "textDocument": {        "uri": "someUri"    }, "token": "<REDACTED: token>",    "expiresOnTimestamp": "1648143343698"}';
+    expected = expected.repeat(10) + "\n" + expected.repeat(10);
+
+    expect(actual).toMatch(expected);
+  });
+
+  it("should not blow up on large strings", () => {
+    const withToken =
+      'Params: {\n    "textDocument": {\n        "uri": "someUri"\n    }, "token": "eyJ0eXAi",\n    "expiresOnTimestamp": "1648143343698"\n}';
+
+    const string10K = Array(10000)
+      .fill(null)
+      .map(() =>
+        "    ======\"'{}()!@#$%^&*()_+][|;':,abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charAt(
+          Math.random() * 62
+        )
+      )
+      .join("");
+    const string10MB = (string10K + withToken).repeat(
+      Math.ceil(10000000 / (string10K.length + withToken.length))
+    );
+
+    const start = Date.now();
+    const actual =
+      removePropertiesWithPossibleUserInfoInDeployParams(string10MB);
+    const duration = Date.now() - start;
+
+    expect(actual).not.toContain("eyJ0eXAi");
+    console.log(duration);
+    expect(duration).toBeLessThan(1000); // I normally see < 20ms, but giving some buffer
+  });
 });

--- a/src/vscode-bicep/src/utils/removePropertiesWithPossibleUserInfo.ts
+++ b/src/vscode-bicep/src/utils/removePropertiesWithPossibleUserInfo.ts
@@ -1,22 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const deployParamsPattern = new RegExp('"token":\\s*"(?<token>[^"]+)"');
+const deployParamsPattern = new RegExp(
+  '(?<lhs>"token":\\s*")(?<token>[^"]+)"',
+  "g"
+);
 
 export function removePropertiesWithPossibleUserInfoInDeployParams(
   value: string
 ): string {
-  const matches = deployParamsPattern.exec(value);
-
-  if (matches) {
-    const groups = matches.groups;
-
-    if (groups) {
-      const token = groups["token"];
-
-      return value.replace(token, "<REDACTED: token>");
-    }
-  }
-
-  return value;
+  return value.replace(deployParamsPattern, '$<lhs><REDACTED: token>"');
 }

--- a/src/vscode-bicep/src/utils/removePropertiesWithPossibleUserInfo.ts
+++ b/src/vscode-bicep/src/utils/removePropertiesWithPossibleUserInfo.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const deployParamsPattern = new RegExp('.*"token":\\s*"(?<token>.*)"');
+
+const deployParamsPattern = new RegExp('"token":\\s*"(?<token>[^"]+)"');
+
 export function removePropertiesWithPossibleUserInfoInDeployParams(
   value: string
 ): string {


### PR DESCRIPTION
Fixes #9657 

With lang server verbose tracing, large strings can come through, including the entire contents of bicep files. This regex gets really slow with large strings.

The removal of ".*" was enough to fix my scenario (unnecessary since regex already matches anywhere in a string, and causes backtracking on every single character in the string). The second change is also a good idea unless there's a possibility of a double quote inside a token string, which seems unlikely.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9869)