### PR TITLE
VSCode: Show less obtrusive and more granular loading indicator

### DIFF
--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -17,7 +17,11 @@ import { CreateBicepConfigurationFile } from "./commands/createConfigurationFile
 import { DecompileCommand } from "./commands/decompile";
 import { ImportKubernetesManifestCommand } from "./commands/importKubernetesManifest";
 import { PasteAsBicepCommand } from "./commands/pasteAsBicep";
-import { BicepCacheContentProvider, createLanguageService } from "./language";
+import {
+  BicepCacheContentProvider,
+  createLanguageService,
+  ensureDotnetRuntimeInstalled,
+} from "./language";
 import { TreeManager } from "./tree/TreeManager";
 import { updateUiContext } from "./updateUiContext";
 import { createAzExtOutputChannel } from "./utils/AzExtOutputChannel";
@@ -63,18 +67,6 @@ class BicepExtension extends Disposable {
   }
 }
 
-export async function activateWithProgressReport(
-  activateFunc: () => Promise<void>
-): Promise<void> {
-  return await window.withProgress(
-    {
-      title: "Launching Bicep language service...",
-      location: ProgressLocation.Notification,
-    },
-    activateFunc
-  );
-}
-
 export async function activate(
   extensionContext: ExtensionContext
 ): Promise<void> {
@@ -95,15 +87,26 @@ export async function activate(
   });
 
   // Activate and launch language server
-  await activateWithTelemetryAndErrorHandling(
-    async (actionContext) =>
-      await activateWithProgressReport(async () => {
+  await activateWithTelemetryAndErrorHandling(async (actionContext) => {
+    await window.withProgress(
+      {
+        location: ProgressLocation.Window,
+      },
+      async (progress) => {
+        progress.report({ message: "Acquiring dotnet runtime" });
+        const dotnetCommandPath = await ensureDotnetRuntimeInstalled(
+          actionContext
+        );
+
+        progress.report({ message: "Launching language service" });
         languageClient = await createLanguageService(
           actionContext,
           extensionContext,
-          outputChannel
+          outputChannel,
+          dotnetCommandPath
         );
 
+        progress.report({ message: "Registering commands" });
         // go2def links that point to the bicep cache will have the bicep-cache scheme in their document URIs
         // this content provider will allow VS code to understand that scheme
         // and surface the content as a read-only file
@@ -204,8 +207,9 @@ export async function activate(
 
         // Set initial UI context
         await updateUiContext(window.activeTextEditor?.document);
-      })
-  );
+      }
+    );
+  });
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -69,12 +69,10 @@ function getServerStartupOptions(
 export async function createLanguageService(
   actionContext: IActionContext,
   context: vscode.ExtensionContext,
-  outputChannel: vscode.OutputChannel
+  outputChannel: vscode.OutputChannel,
+  dotnetCommandPath: string
 ): Promise<lsp.LanguageClient> {
   getLogger().info("Launching Bicep language service...");
-
-  const dotnetCommandPath = await ensureDotnetRuntimeInstalled(actionContext);
-  getLogger().debug(`Found dotnet command at '${dotnetCommandPath}'.`);
 
   const languageServerPath = ensureLanguageServerExists(context);
   getLogger().debug(`Found language server at '${languageServerPath}'.`);
@@ -157,7 +155,7 @@ function getCustomDotnetRuntimePathConfig() {
   return acquireConfig.filter((x) => x.extensionId === extensionId)[0];
 }
 
-async function ensureDotnetRuntimeInstalled(
+export async function ensureDotnetRuntimeInstalled(
   actionContext: IActionContext
 ): Promise<string> {
   getLogger().info("Acquiring dotnet runtime...");
@@ -203,6 +201,7 @@ async function ensureDotnetRuntimeInstalled(
     throw new Error(errorMessage);
   }
 
+  getLogger().debug(`Found dotnet command at '${dotnetPath}'.`);
   return dotnetPath;
 }
 


### PR DESCRIPTION
1. Moves the loading indicator to the window, rather than raising a notification:
    ![image](https://user-images.githubusercontent.com/38542602/221156753-c204d66a-7d28-4b75-b13c-419473c0dafe.png)
1. Adds an explanation of what's happening (`Acquiring dotnet runtime` / `Launching language service` / `Registering commands`) to help users better understand delays.