### PR TITLE
Stop creating PR to update TPN files

### DIFF
--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -82,6 +82,7 @@ jobs:
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor }}@users.noreply.github.com
           commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          file_pattern: '*.txt'
           branch: update-local-tpn-files
           commit_options: '--no-verify --signoff'
           status_options: '--untracked-files=no'

--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -74,19 +74,17 @@ jobs:
 
       - name: Build BicepInVisualStudio.sln
         run: msbuild src/vs-bicep/BicepInVisualStudio.sln /restore -property:Configuration=Release /v:m
-      
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
-          add-paths: '**/local-tpn.txt'
+          commit_message: Update Local TPN Files
+          commit_user_name: ${{ github.actor }}
+          commit_user_email: ${{ github.actor }}@users.noreply.github.com
+          commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: update-local-tpn-files
-          delete-branch: true
-          title: |
-            Update Local TPN Files
-          commit-message: |
-            Update Local TPN Files
-          labels: dependencies
-          draft: false
+          commit_options: '--no-verify --signoff'
+          status_options: '--untracked-files=no'
+          push_options: '--force'
+          skip_fetch: true
+          skip_checkout: true
+          create_branch: true

--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Build BicepInVisualStudio.sln
         run: msbuild src/vs-bicep/BicepInVisualStudio.sln /restore -property:Configuration=Release /v:m
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Create branch and force push
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update Local TPN Files
           commit_user_name: ${{ github.actor }}


### PR DESCRIPTION
Since the permissions got locked down, we can no longer use workflows to automatically create PRs. Removed the PR creation step and replaced it with a force push step. The PR will be created manually from the branch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9989)