### PR TITLE
don't use cheap source map in main extension code

### DIFF
--- a/src/vscode-bicep/webpack.config.ts
+++ b/src/vscode-bicep/webpack.config.ts
@@ -120,8 +120,12 @@ module.exports = (env: unknown, argv: { mode: string }) => {
     // Note that any "eval" options cannot be used because it will be blocked by
     // the content security policy that we set in /visualizer/view.ts.
     const developmentDevtool = "cheap-module-source-map";
-    extensionConfig.devtool = developmentDevtool;
     visualizerConfig.devtool = developmentDevtool;
+
+    // I don't notice any difference in F5 time when using the cheap version, but using it
+    // causes many problems settings breakpoints in some code, especially tests, so don't use for
+    // the extension.
+    //extensionConfig.devtool = developmentDevtool;
   }
 
   return [extensionConfig, visualizerConfig];

--- a/src/vscode-bicep/webpack.config.ts
+++ b/src/vscode-bicep/webpack.config.ts
@@ -123,8 +123,8 @@ module.exports = (env: unknown, argv: { mode: string }) => {
     visualizerConfig.devtool = developmentDevtool;
 
     // I don't notice any difference in F5 time when using the cheap version, but using it
-    // causes many problems settings breakpoints in some code, especially tests, so don't use for
-    // the extension.
+    // causes many problems recognizing breakpoints in some code, especially tests, so don't use for
+    // the main extension code.
     //extensionConfig.devtool = developmentDevtool;
   }
 


### PR DESCRIPTION
I had thought the poor ability to hit breakpoints in test code was a vscode issue...

Still having problems with this change, but I think it's a little better now.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/9994)