### PR TITLE
Requiring `using` declaration in params file

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -110,9 +110,7 @@ namespace Bicep.Cli.IntegrationTests
             result.Should().Be(1);
             output.Should().BeEmpty();
             error.Should().Contain($"Bicep file {otherBicepPath} provided with --bicep-file option doesn't match the Bicep file {bicepPath} referenced by the using declaration in the parameters file");
-            // error
         }
-
 
         [TestMethod]
         public async Task Build_Params_Bicep_File_Reference_Mismatch_And_Other_Diagnostics_ShouldFail_WithAllExpectedErrorMessages()
@@ -135,14 +133,11 @@ namespace Bicep.Cli.IntegrationTests
 
             var diagnostics = await GetAllParamDiagnostics(bicepparamsPath, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
 
-
             result.Should().Be(1);
             output.Should().BeEmpty();
             error.Should().Contain($"Bicep file {otherBicepPath} provided with --bicep-file option doesn't match the Bicep file {bicepPath} referenced by the using declaration in the parameters file");
             error.Should().ContainAll(diagnostics);
         }
-
-
 
         [DataTestMethod]
         [BaselineData_Bicepparam.TestData(Filter = BaselineData_Bicepparam.TestDataFilterType.ValidOnly)]
@@ -150,10 +145,8 @@ namespace Bicep.Cli.IntegrationTests
         public async Task Build_Valid_Params_File_Should_Succeed(BaselineData_Bicepparam baselineData)
         {
             var data = baselineData.GetData(TestContext);
-
             var features = new FeatureProviderOverrides(TestContext, ParamsFilesEnabled: true);
             var settings = new InvocationSettings(features, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
-
             var (output, error, result) = await Bicep(settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath);
 
             using (new AssertionScope())

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -34,7 +34,7 @@ namespace Bicep.Cli.IntegrationTests
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();
-            var(output, error, result) = await Bicep("build-params", bicepparamsPath,"--outfile-params", outputFilePath);
+            var(output, error, result) = await Bicep("build-params", bicepparamsPath,"--outfile", outputFilePath);
 
             result.Should().Be(1);
             output.Should().BeEmpty();
@@ -52,7 +52,7 @@ namespace Bicep.Cli.IntegrationTests
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();
-            var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--outfile-params", outputFilePath);
+            var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--outfile", outputFilePath);
 
             File.Exists(outputFilePath).Should().BeTrue();
             result.Should().Be(0);
@@ -70,27 +70,11 @@ namespace Bicep.Cli.IntegrationTests
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();
-            var(output, error, result) = await Bicep("build-params", bicepparamsPath,"--bicep-file", bicepPath, "--outfile-params", outputFilePath);
+            var(output, error, result) = await Bicep("build-params", bicepparamsPath,"--bicep-file", bicepPath, "--outfile", outputFilePath);
 
             result.Should().Be(1);
             output.Should().BeEmpty();
             error.Should().Contain($"{bicepPath} is not a bicep file");
-        }
-
-        [TestMethod]
-        public async Task Build_Params_With_Same_Params_And_Bicep_Output_Path_ShouldFail_WithExpectedErrorMessage()
-        {
-            var bicepparamsPath = FileHelper.SaveResultFile(TestContext, "input.bicepparam", "using './main.bicep'");
-            var bicepPath = FileHelper.SaveResultFile(TestContext, "main.bicep", "", Path.GetDirectoryName(bicepparamsPath));
-
-            var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
-
-            File.Exists(outputFilePath).Should().BeFalse();
-            var(output, error, result) = await Bicep("build-params", bicepparamsPath,"--bicep-file", bicepPath, "--outfile-params", outputFilePath, "--outfile-bicep", outputFilePath);
-
-            result.Should().Be(1);
-            output.Should().BeEmpty();
-            error.Should().Contain($"The path for --outfile-params and --outfile-bicep can not be the same");
         }
 
         [TestMethod]
@@ -105,7 +89,7 @@ namespace Bicep.Cli.IntegrationTests
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();
-            var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile-params", outputFilePath);
+            var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile", outputFilePath);
 
             result.Should().Be(1);
             output.Should().BeEmpty();
@@ -128,7 +112,7 @@ namespace Bicep.Cli.IntegrationTests
             var settings = new InvocationSettings(new(TestContext, ParamsFilesEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
-            var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile-params", outputFilePath);
+            var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile", outputFilePath);
 
             var diagnostics = await GetAllParamDiagnostics(bicepparamsPath, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
 

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -128,7 +128,6 @@ namespace Bicep.Cli.IntegrationTests
             var settings = new InvocationSettings(new(TestContext, ParamsFilesEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
-            File.Exists(outputFilePath).Should().BeFalse();
             var(output, error, result) = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile-params", outputFilePath);
 
             var diagnostics = await GetAllParamDiagnostics(bicepparamsPath, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
@@ -137,6 +136,7 @@ namespace Bicep.Cli.IntegrationTests
             output.Should().BeEmpty();
             error.Should().Contain($"Bicep file {otherBicepPath} provided with --bicep-file option doesn't match the Bicep file {bicepPath} referenced by the using declaration in the parameters file");
             error.Should().ContainAll(diagnostics);
+            File.Exists(outputFilePath).Should().BeFalse();
         }
 
         [DataTestMethod]

--- a/src/Bicep.Cli/Arguments/BuildParamsArguments.cs
+++ b/src/Bicep.Cli/Arguments/BuildParamsArguments.cs
@@ -64,9 +64,9 @@ namespace Bicep.Cli.Arguments
                 throw new CommandLineException($"The parameters file path was not specified");
             }
 
-            if ((OutputFile is not null) && OutputToStdOut)
+            if (OutputFile is not null && OutputToStdOut)
             {
-                throw new CommandLineException($"The --stdout can not be use when --outfile is specified");
+                throw new CommandLineException($"The --stdout can not be used when --outfile is specified");
             }
         }
 

--- a/src/Bicep.Cli/Arguments/BuildParamsArguments.cs
+++ b/src/Bicep.Cli/Arguments/BuildParamsArguments.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.FileSystem;
-using System.IO;
-
 namespace Bicep.Cli.Arguments
 {
     public class BuildParamsArguments : ArgumentsBase
@@ -27,29 +24,16 @@ namespace Bicep.Cli.Arguments
                         i++;
                         break;
 
-                    case "--outfile-params":
+                    case "--outfile":
                         if (args.Length == i + 1)
                         {
-                            throw new CommandLineException($"The --outfile-params parameter expects an argument");
+                            throw new CommandLineException($"The --outfile parameter expects an argument");
                         }
-                        if (OutputParamsFile is not null)
+                        if (OutputFile is not null)
                         {
-                            throw new CommandLineException($"The --outfile-params parameter cannot be specified twice");
+                            throw new CommandLineException($"The --outfile parameter cannot be specified twice");
                         }
-                        OutputParamsFile = args[i + 1];
-                        i++;
-                        break;
-
-                    case "--outfile-bicep":
-                        if (args.Length == i + 1)
-                        {
-                            throw new CommandLineException($"The --outfile-bicep parameter expects an argument");
-                        }
-                        if (OutputBicepFile is not null)
-                        {
-                            throw new CommandLineException($"The --outfile-bicep parameter cannot be specified twice");
-                        }
-                        OutputBicepFile = args[i + 1];
+                        OutputFile = args[i + 1];
                         i++;
                         break;
 
@@ -80,14 +64,9 @@ namespace Bicep.Cli.Arguments
                 throw new CommandLineException($"The parameters file path was not specified");
             }
 
-            if (OutputParamsFile is not null && OutputBicepFile is not null && OutputParamsFile == OutputBicepFile)
+            if ((OutputFile is not null) && OutputToStdOut)
             {
-                throw new CommandLineException($"The path for --outfile-params and --outfile-bicep can not be the same");
-            }
-
-            if ((OutputParamsFile is not null || OutputBicepFile is not null) && OutputToStdOut)
-            {
-                throw new CommandLineException($"The --stdout can not be use when either --outfile-param or --outfile-bicep is specified");
+                throw new CommandLineException($"The --stdout can not be use when --outfile is specified");
             }
         }
 
@@ -99,8 +78,6 @@ namespace Bicep.Cli.Arguments
 
         public string? BicepFile { get; }
 
-        public string? OutputParamsFile { get; }
-
-        public string? OutputBicepFile { get; }
+        public string? OutputFile { get; }
     }
 }

--- a/src/Bicep.Cli/Commands/BuildParamsCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildParamsCommand.cs
@@ -97,7 +97,6 @@ namespace Bicep.Cli.Commands
                             var bicepOutputPath = PathHelper.ResolveDefaultOutputPath(bicepFileUsingPathUri.AbsolutePath, null, args.OutputParamsFile, DefaultOutputPath);
 
                             writer.ToFile(paramsCompilation, paramsOutputPath);
-
                             writer.ToFile(bicepSemanticModel, bicepOutputPath);
                         }
                     }

--- a/src/Bicep.Cli/Commands/BuildParamsCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildParamsCommand.cs
@@ -69,6 +69,7 @@ namespace Bicep.Cli.Commands
 
                 var paramsSemanticModel = paramsCompilation.GetEntrypointSemanticModel();
 
+            
                 if(paramsSemanticModel.Root.TryGetBicepFileSemanticModelViaUsing(out var bicepSemanticModel, out _))
                 {
                     var bicepFileUsingPathUri = bicepSemanticModel.Root.FileUri;

--- a/src/Bicep.Cli/Commands/BuildParamsCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildParamsCommand.cs
@@ -93,19 +93,14 @@ namespace Bicep.Cli.Commands
                 { 
                     if (args.OutputToStdOut)
                     {   
-                        if(bicepSemanticModel != null) 
-                        {
-                            writer.ToStdout(bicepSemanticModel, paramsSemanticModel);
-                        }
+                        writer.ToStdout(bicepSemanticModel, paramsSemanticModel);
                     }
                     else
                     {
                         static string DefaultOutputPath(string path) => PathHelper.GetDefaultBuildOutputPath(path);
-                        var paramsOutputPath = PathHelper.ResolveDefaultOutputPath(paramsInputPath, null, args.OutputParamsFile, DefaultOutputPath);
-                        var bicepOutputPath = PathHelper.ResolveDefaultOutputPath(bicepFileUsingPathUri.AbsolutePath, null, args.OutputParamsFile, DefaultOutputPath);
+                        var paramsOutputPath = PathHelper.ResolveDefaultOutputPath(paramsInputPath, null, args.OutputFile, DefaultOutputPath);
 
                         writer.ToFile(paramsCompilation, paramsOutputPath);
-                        // writer.ToFile(bicepSemanticModel, bicepOutputPath); //TODO: remove after decision on producing bicep file output is reached
                     }
                 }
             }

--- a/src/Bicep.Core.IntegrationTests/Emit/ParamsFileWriterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/ParamsFileWriterTests.cs
@@ -207,7 +207,7 @@ param myInt = 1", @"
                 result.Parameters.Should().BeNull();
                 result.Diagnostics.Should().HaveDiagnostics(new[]
                 {
-                    ("BCP261", DiagnosticLevel.Warning, "No using declaration is present in this parameters file. Parameter validation/completions will not be available"),
+                    ("BCP261", DiagnosticLevel.Error, "A using declaration must be present in this parameters file."),
                     ("BCP252", DiagnosticLevel.Error, "Binary operator is not allowed in Bicep parameter file.")
                 });
             }

--- a/src/Bicep.Core.IntegrationTests/Emit/ParamsFileWriterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/ParamsFileWriterTests.cs
@@ -17,6 +17,8 @@ namespace Bicep.Core.IntegrationTests.Emit
 
         [DataTestMethod]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = 'test value'", @"
 {
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
@@ -26,8 +28,12 @@ param myParam = 'test value'", @"
       ""value"": ""test value""
     }
   }
-}")]
+}", @"
+param myParam string
+")]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = 1", @"
 {
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
@@ -37,8 +43,12 @@ param myParam = 1", @"
       ""value"": 1
     }
   }
-}")]
+}", @"
+param myParam int
+")]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = true", @"
 {
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
@@ -48,8 +58,12 @@ param myParam = true", @"
       ""value"": true
     }
   }
-}")]
+}", @"
+param myParam bool
+")]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = [
   1
   2
@@ -65,8 +79,12 @@ param myParam = [
         ]
     }
   }
-}")]
+}", @"
+param myParam array
+")]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = {
   property1 : 'value1'
   property2 : 'value2'
@@ -82,8 +100,12 @@ param myParam = {
       }
     }
   }
-}")]
+}", @"
+param myParam object
+")]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = {
   property1 : null
 }", @"
@@ -97,8 +119,12 @@ param myParam = {
       }
     }
   }
-}")]
+}", @"
+param myParam object
+")]
         [DataRow(@"
+using 'main.bicep'
+
 param myParam = {
   // basic case
   'foo': 'val1'
@@ -116,8 +142,12 @@ param myParam = {
       }
     }
   }
-}")]
+}", @"
+param myParam object
+")]
         [DataRow(@"
+using 'main.bicep'
+
 // involves all syntax
 param myParam = {
   arr: [
@@ -166,9 +196,13 @@ param myParam = {
       }
     }
   }
-}")]
+}", @"
+param myParam object
+")]
 
         [DataRow(@"
+using 'main.bicep'
+
 //multiple parameters
 param myStr = 'foo'
 param myBool = false
@@ -187,30 +221,18 @@ param myInt = 1", @"
       ""value"": 1
     }
   }
-}")]
-        public void Params_file_with_no_errors_should_compile_correctly(string paramsText, string jsonText)
+}", @"
+param myStr string
+param myBool bool
+param myInt int
+")]
+        public void Params_file_with_no_errors_should_compile_correctly(string paramsText, string paramsJsonText, string bicepText)
         {
-            var result = CompilationHelper.CompileParams(paramsText);
+            var result = CompilationHelper.CompileParams(("parameters.bicepparam", paramsText), ("main.bicep", bicepText));
 
             // Exclude the "No using declaration is present in this parameters file" diagnostic
             result.ExcludingLinterDiagnostics().WithFilteredDiagnostics(x => x.Code != "BCP261").Should().NotHaveAnyDiagnostics();
-            result.Parameters.Should().DeepEqual(JToken.Parse(jsonText));
-        }
-
-        [TestMethod]
-        public void Params_file_with_not_implemented_syntax_should_log_diagnostic()
-        {
-            var result = CompilationHelper.CompileParams("param foo = 1 + 2");
-
-            using(new AssertionScope())
-            {
-                result.Parameters.Should().BeNull();
-                result.Diagnostics.Should().HaveDiagnostics(new[]
-                {
-                    ("BCP261", DiagnosticLevel.Error, "A using declaration must be present in this parameters file."),
-                    ("BCP252", DiagnosticLevel.Error, "Binary operator is not allowed in Bicep parameter file.")
-                });
-            }
+            result.Parameters.Should().DeepEqual(JToken.Parse(paramsJsonText));
         }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/EvaluationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/EvaluationTests.cs
@@ -86,12 +86,14 @@ output multiline string = multiline
         [TestMethod]
         public void ResourceId_expressions_are_evaluated_successfully()
         {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
+          var bicepparamText = @"
+using 'main.bicep'
+
 param parentName = 'myParent'
 param childName = 'myChild'
-");
+";
 
-            var (template, _, _) = CompilationHelper.Compile(@"
+          var bicepTemplateText =  @"
 param parentName string
 param childName string
 
@@ -146,7 +148,11 @@ output resource8Id string = existing8.id
 output resource1Name string = existing1.name
 output resource1ApiVersion string = existing1.apiVersion
 output resource1Type string = existing1.type
-");
+";
+
+            var (parameters, _, _) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var (template, _, _) = CompilationHelper.Compile(bicepTemplateText);
 
             using (new AssertionScope())
             {
@@ -207,11 +213,13 @@ output coalesce int = null ?? 123
         [TestMethod]
         public void Resource_property_access_works()
         {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
-param abcVal = 'test!!!'
-");
+            var bicepparamText = @"
+using 'main.bicep'
 
-            var (template, _, _) = CompilationHelper.Compile(@"
+param abcVal = 'test!!!'
+";
+
+            var bicepTemplateText = @"
 param abcVal string
 
 resource testRes 'My.Rp/res1@2020-01-01' = {
@@ -222,7 +230,11 @@ resource testRes 'My.Rp/res1@2020-01-01' = {
 }
 
 output abcVal string = testRes.properties.abc
-");
+";
+
+            var (parameters, _, _) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var (template, _, _) = CompilationHelper.Compile(bicepTemplateText);
 
             using (new AssertionScope())
             {
@@ -268,7 +280,9 @@ output abcVal string = testRes.properties.abc
         [TestMethod]
         public void Items_function_evaluation_works()
         {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
+            var bicepparamText = @"
+using 'main.bicep'
+
 param inputObj = {
   'ghiKey': 'ghiValue'
   'defKey': 'defValue'
@@ -279,13 +293,18 @@ param inputObj = {
   'ABCKey': 'ABCValue'
   '456Key': '456Value'
 }
-");
-            var result = CompilationHelper.Compile(@"
+";
+
+            var bicepTemplateText = @"
 param inputObj object
 
 output inputObjKeys array = [for item in items(inputObj): item.key]
 output inputObjValues array = [for item in items(inputObj): item.value]
-");
+";
+
+            var (parameters, _, _) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var result = CompilationHelper.Compile(bicepTemplateText);
 
             var evaluated = TemplateEvaluator.Evaluate(result.Template, parameters);
 
@@ -343,16 +362,18 @@ output joined3 string = join([
 
         [TestMethod]
         public void indexof_contains_function_evaluation_works()
-        {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
+        {            
+            var bicepparamText = @"
+using 'main.bicep'
+
 param inputString = 'FOOBAR'
 param inputArray = [
   'FOO'
   'BAR'
 ]
-");
+";
 
-            var (template, _, _) = CompilationHelper.Compile(@"
+            var bicepTemplateText = @"
 param inputString string
 param inputArray array
 
@@ -377,7 +398,12 @@ output containsArrBarLC bool = contains(inputArray, 'bar')
 output containsArrBarUC bool = contains(inputArray, 'BAR')
 output containsArrfalse bool = contains(inputArray, false)
 output containsArr123 bool = contains(inputArray, 123)
-");
+";
+
+            var (parameters, _, _) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var (template, _, _) = CompilationHelper.Compile(bicepTemplateText);
+
 
             using (new AssertionScope())
             {
@@ -411,8 +437,10 @@ output containsArr123 bool = contains(inputArray, 123)
 
         [TestMethod]
         public void List_comprehension_function_evaluation_works()
-        {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
+        {            
+            var bicepparamText = @"
+using 'main.bicep'
+
 param doggos = [
   'Evie'
   'Casper'
@@ -420,9 +448,9 @@ param doggos = [
   'Kira'
 ]
 param numbers = [0, 1, 2, 3]
-");
+";
 
-            var (template, _, _) = CompilationHelper.Compile(@"
+            var bicepTemplateText = @"
 param doggos array
 param numbers array
 
@@ -478,7 +506,12 @@ var objectMap2 = toObject(numbers, i => '${i}', i => {
   isGreaterThan2: (i > 2)
 })
 var objectMap3 = toObject(sortByObjectKey, x => x.name)
-");
+";
+
+            var (parameters, _, _) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var (template, _, _) = CompilationHelper.Compile(bicepTemplateText);
+
 
             using (new AssertionScope())
             {
@@ -730,14 +763,17 @@ output testFor array = [for record in testArray: {
         /// </summary>
         [TestMethod]
         public void Issue8782_2()
-        {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
+        {            
+            var bicepparamText = @"
+using 'main.bicep'
+
 param testObject = {
   a: true
   b: false
 }
-");
-            var result = CompilationHelper.Compile(@"
+";
+
+            var bicepTemplateText = @"
 param testObject object
 output output1 array = map(
   items(testObject),
@@ -746,7 +782,12 @@ output output1 array = map(
 output output2 array = map(
   items(testObject),
   subObject => subObject.key == 'a' ? [ 'yes' ] : [ 'no' ]
-)");
+)";
+
+            var (parameters, diag, comp) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var result = CompilationHelper.Compile(bicepTemplateText);
+
 
             var evaluated = TemplateEvaluator.Evaluate(result.Template, parameters);
             evaluated.Should().HaveValueAtPath("$.outputs['output1'].value", JToken.Parse(@"[
@@ -831,13 +872,14 @@ output iDogs array = filter(dogs, dog =>  (contains(dog.name, 'C') || contains(d
 
         [TestMethod]
         public void Module_with_unknown_resourcetype_as_parameter_and_output_has_diagnostics()
-        {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
-param useMod1 = true
-");
+        {            
+            var bicepparamText = @"
+using 'main.bicep'
 
-            var result = CompilationHelper.Compile(
-("main.bicep", @"
+param useMod1 = true
+"; 
+
+            var bicepTemplateText = @"
 param useMod1 bool
 
 module mod1 'module.bicep' = {
@@ -862,14 +904,18 @@ output test2 string = mod2.outputs.foo.bar
 output test3 string = (useMod1 ? mod1 : mod2).outputs.foo.bar
 output test4 string = selectedMod.outputs.foo.bar
 output test5 string = selectedMod2.outputs.foo.bar
-"),
-("module.bicep", @"
+";
+            var bicepModuleText = @"
 param bar string
 
 output foo object = {
   bar: bar
 }
-"));
+";
+
+            var (parameters, diag, comp) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var result = CompilationHelper.Compile(("main.bicep", bicepTemplateText), ("module.bicep", bicepModuleText));
 
             var evaluated = TemplateEvaluator.Evaluate(result.Template, parameters, config => config with {
                 OnReferenceFunc = (resourceId, apiVersion, fullBody) =>

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4295,7 +4295,9 @@ output firstCertEnabled bool = Certificate[0].properties.attributes.enabled
         [TestMethod]
         public void Test_Issue9467()
         {
-            var (parameters, _, _) = CompilationHelper.CompileParams(@"
+            var bicepparamText = @"
+using 'main.bicep'
+
 param CertificateSubjects = [{
   subject: 'blah'
   secretName: 'blah'
@@ -4306,9 +4308,9 @@ param CertificateSubjects = [{
     resourceGroupName: 'myRg'
   }
 }]
-");
+";
 
-            var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), @"
+            var bicepTemplateText = @"
 @description('Used to identify a Key Vault and where it\'s deployed to')
 type keyVaultIdentifier = {
   @description('The name of the Key Vault')
@@ -4341,7 +4343,11 @@ resource CertificateVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
 }
 
 output vaultId string = CertificateVault.id
-");
+";
+
+            var (parameters, diag, comp) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), bicepTemplateText);
 
             result.Should().GenerateATemplate();
 

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4345,7 +4345,9 @@ resource CertificateVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
 output vaultId string = CertificateVault.id
 ";
 
-            var (parameters, diag, comp) = CompilationHelper.CompileParams(("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+            var (parameters, diag, comp) = CompilationHelper.CompileParams(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), ("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
+
+            var allDiag = comp.GetAllDiagnosticsByBicepFile();
 
             var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), bicepTemplateText);
 

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4345,9 +4345,7 @@ resource CertificateVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
 output vaultId string = CertificateVault.id
 ";
 
-            var (parameters, diag, comp) = CompilationHelper.CompileParams(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), ("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
-
-            var allDiag = comp.GetAllDiagnosticsByBicepFile();
+            var (parameters, _, _) = CompilationHelper.CompileParams(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), ("parameters.bicepparam", bicepparamText), ("main.bicep", bicepTemplateText));
 
             var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), bicepTemplateText);
 

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -74,11 +74,18 @@ namespace Bicep.Core.UnitTests.Utils
         public static CompilationResult Compile(ServiceBuilder services, string fileContents)
             => Compile(services, ("main.bicep", fileContents));
 
+
         public static ParamsCompilationResult CompileParams(params (string fileName, string fileContents)[] files)
         {
             var features = BicepTestConstants.FeatureOverrides;
+            var services = new ServiceBuilder().WithFeatureOverrides(features);
+            return CompileParams(services, files);
+        }
+
+        public static ParamsCompilationResult CompileParams(ServiceBuilder services, params (string fileName, string fileContents)[] files)
+        {
             var configuration = BicepTestConstants.BuiltInConfiguration;
-            var services = new ServiceBuilder().WithFeatureOverrides(features).WithConfigurationPatch(c => configuration);
+            services = services.WithConfigurationPatch(c => configuration);
 
             files.Select(x => x.fileName).Should().Contain("parameters.bicepparam");
 
@@ -89,7 +96,7 @@ namespace Bicep.Core.UnitTests.Utils
                 .Where(x => PathHelper.HasBicepparamsExension(x.Key) || PathHelper.HasBicepExtension(x.Key) || PathHelper.HasArmTemplateLikeExtension(x.Key))
                 .ToDictionary(x => x.Key, x => x.Value);
 
-            var compilation = services.WithFeatureOverrides(features).BuildCompilation(sourceFiles, entryUri);
+            var compilation = services.BuildCompilation(sourceFiles, entryUri);
 
             return CompileParams(compilation);
         }

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -94,8 +94,8 @@ namespace Bicep.Core.UnitTests.Utils
             return CompileParams(compilation);
         }
 
-        public static ParamsCompilationResult CompileParams(string fileContents)
-            => CompileParams(("parameters.bicepparam", fileContents));
+        // public static ParamsCompilationResult CompileParams(string fileContents)
+        //     => CompileParams(("parameters.bicepparam", fileContents));
 
         private static (IReadOnlyDictionary<Uri, string> files, Uri entryFileUri) CreateFileDictionary(IEnumerable<(string fileName, string fileContents)> files, string entryFileName)
         {

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -101,9 +101,6 @@ namespace Bicep.Core.UnitTests.Utils
             return CompileParams(compilation);
         }
 
-        // public static ParamsCompilationResult CompileParams(string fileContents)
-        //     => CompileParams(("parameters.bicepparam", fileContents));
-
         private static (IReadOnlyDictionary<Uri, string> files, Uri entryFileUri) CreateFileDictionary(IEnumerable<(string fileName, string fileContents)> files, string entryFileName)
         {
             var uriDictionary = files.ToDictionary(

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1520,11 +1520,10 @@ namespace Bicep.Core.Diagnostics
                 "BCP260",
                 $"The parameter \"{identifier}\" expects a value of type \"{expectedType}\" but the provided value is of type \"{actualType}\".");
 
-            public Diagnostic UsingDeclarationNotSpecified() => new(
+            public ErrorDiagnostic UsingDeclarationNotSpecified() => new(
                 TextSpan,
-                DiagnosticLevel.Warning,
                 "BCP261",
-                "No using declaration is present in this parameters file. Parameter validation/completions will not be available");
+                "A using declaration must be present in this parameters file.");
 
             public ErrorDiagnostic MoreThanOneUsingDeclarationSpecified() => new(
                 TextSpan,


### PR DESCRIPTION
Users must provide a `using` declaration (pointing to a valid bicep file) before compiling a params files.

Reasons for this change:
- starting with a more restricted scenario for first release of bicep parameters (allowing for a none breaking change if we relax the requirement later)
- lowering the number of edge cases we have to deal with when ensuring that `using` declaration bicep file reference matches the one provided with `--bicep-file` in `build-params` command

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10050)