### PR TITLE
Fix 9958

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepDeploymentGraphHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentGraphHandler.cs
@@ -73,7 +73,7 @@ namespace Bicep.LanguageServer.Handlers
             {
                 var (semanticModel, filePath, parentId) = queue.Dequeue();
                 var nodesBySymbol = new Dictionary<DeclaredSymbol, BicepDeploymentGraphNode>();
-                var dependenciesBySymbol = ResourceDependencyVisitor.GetResourceDependencies(semanticModel)
+                var dependenciesBySymbol = ResourceDependencyVisitor.GetResourceDependencies(semanticModel, new ResourceDependencyVisitor.Options() { IncludeExisting = true })
                     .Where(x => x.Key.Name != LanguageConstants.MissingName && x.Key.Name != LanguageConstants.ErrorName)
                     .ToImmutableDictionary(x => x.Key, x => x.Value);
 


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

This PR attempts to fix #9958. 

Currently, `VisitResourceDeclarationSyntax` ignores existing resources while building the dependency tree, this PR adds a flag to the options struct to include existing resources. Doing so allows the existing resources to be included for the visualization.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10096)