### PR TITLE
Refine return types for built-in functions

### DIFF
--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbols.bicep
@@ -65,7 +65,7 @@ resource extendSingleResourceInCollection 'Microsoft.Authorization/locks@2016-09
 
 // collection of extensions
 resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for (i, i2) in range(0,1): {
-//@[080:081) Local i. Type: int. Declaration start char: 80, length: 1
+//@[080:081) Local i. Type: 0. Declaration start char: 80, length: 1
 //@[083:085) Local i2. Type: int. Declaration start char: 83, length: 2
 //@[009:028) Resource extensionCollection. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 235
   name: 'lock-${i}-${i2}'
@@ -78,7 +78,7 @@ resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for (
 // cascade extend the extension
 @batchSize(1)
 resource lockTheLocks 'Microsoft.Authorization/locks@2016-09-01' = [for (i, i2) in range(0,1): {
-//@[073:074) Local i. Type: int. Declaration start char: 73, length: 1
+//@[073:074) Local i. Type: 0. Declaration start char: 73, length: 1
 //@[076:078) Local i2. Type: int. Declaration start char: 76, length: 2
 //@[009:021) Resource lockTheLocks. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 260
   name: 'lock-the-lock-${i}-${i2}'

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.symbols.bicep
@@ -64,7 +64,7 @@ resource extendSingleResourceInCollection 'Microsoft.Authorization/locks@2016-09
 
 // collection of extensions
 resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for i in range(0,1): {
-//@[79:080) Local i. Type: int. Declaration start char: 79, length: 1
+//@[79:080) Local i. Type: 0. Declaration start char: 79, length: 1
 //@[09:028) Resource extensionCollection. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 212
   name: 'lock-${i}'
   properties: {
@@ -76,7 +76,7 @@ resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for i
 // cascade extend the extension
 @batchSize(1)
 resource lockTheLocks 'Microsoft.Authorization/locks@2016-09-01' = [for i in range(0,1): {
-//@[72:073) Local i. Type: int. Declaration start char: 72, length: 1
+//@[72:073) Local i. Type: 0. Declaration start char: 72, length: 1
 //@[09:021) Resource lockTheLocks. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 236
   name: 'lock-the-lock-${i}'
   properties: {

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbols.bicep
@@ -314,7 +314,7 @@ module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
 }
 
 module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
-//@[79:84) Local thing. Type: int. Declaration start char: 79, length: 5
+//@[79:84) Local thing. Type: 0. Declaration start char: 79, length: 5
 //@[07:55) Module propertyLoopInsideParameterValueInsideModuleLoop. Type: module[]. Declaration start char: 0, length: 529
   name: 'propertyLoopInsideParameterValueInsideModuleLoop'
   params: {

--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
             var mockDiagnosticWriter = Repository.Create<IDiagnosticWriter>();
             mockDiagnosticWriter.Setup(writer => writer.Write(It.Is<IDiagnostic>(diag => diag.Code == "BCP234")));
 
-            matches.Single().ResultBuilder(Repository.Create<IBinder>().Object, Repository.Create<IFileResolver>().Object, mockDiagnosticWriter.Object, functionCall, argumentTypes.ToImmutableArray()).Type.Should().BeSameAs(expectedReturnType);
+            matches.Single().ResultBuilder(Repository.Create<IBinder>().Object, Repository.Create<IFileResolver>().Object, mockDiagnosticWriter.Object, functionCall, argumentTypes.ToImmutableArray()).Type.Should().Be(expectedReturnType);
         }
 
         [DataTestMethod]
@@ -174,6 +174,421 @@ namespace Bicep.Core.UnitTests.TypeSystem
             returnType.As<ArrayType>().MinLength.Should().BeGreaterThan(0);
         }
 
+        [TestMethod]
+        public void ConcatDerivesMinLengthOfReturnType()
+        {
+            var returnType = EvaluateFunction("concat",
+                new List<TypeSymbol> { TypeFactory.CreateArrayType(LanguageConstants.String, minLength: 10), LanguageConstants.Array, TypeFactory.CreateArrayType(LanguageConstants.String, minLength: 11) },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")), new(TestSyntaxFactory.CreateVariableAccess("baz")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<ArrayType>();
+            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
+            returnType.As<ArrayType>().MinLength.Should().Be(21);
+        }
+
+        [TestMethod]
+        public void ConcatDerivesMaxLengthOfReturnType()
+        {
+            var returnType = EvaluateFunction("concat",
+                new List<TypeSymbol> { TypeFactory.CreateArrayType(LanguageConstants.String, maxLength: 10), TypeFactory.CreateArrayType(LanguageConstants.String, maxLength: 11) },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<ArrayType>();
+            returnType.As<ArrayType>().MaxLength.Should().NotBeNull();
+            returnType.As<ArrayType>().MaxLength.Should().Be(21);
+        }
+
+        [TestMethod]
+        public void ConcatDoesNotDeriveMaxLengthOfReturnTypeIfAnyInputLacksAMaxLength()
+        {
+            var returnType = EvaluateFunction("concat",
+                new List<TypeSymbol> { TypeFactory.CreateArrayType(LanguageConstants.String, maxLength: 10), LanguageConstants.Array, TypeFactory.CreateArrayType(LanguageConstants.String, maxLength: 11) },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")), new(TestSyntaxFactory.CreateVariableAccess("baz")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<ArrayType>();
+            returnType.As<ArrayType>().MaxLength.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ConcatConcatenatesTuples()
+        {
+            var returnType = EvaluateFunction("concat",
+                new List<TypeSymbol>
+                {
+                    new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.Int), default),
+                    new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.Bool), default),
+                    new TupleType(ImmutableArray.Create<ITypeReference>(TypeFactory.CreateStringLiteralType("abc"), TypeFactory.CreateIntegerLiteralType(123)), default),
+                },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")), new(TestSyntaxFactory.CreateVariableAccess("baz")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<TupleType>();
+            returnType.As<TupleType>().Items.Should()
+                .ContainInOrder(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool, TypeFactory.CreateStringLiteralType("abc"), TypeFactory.CreateIntegerLiteralType(123));
+        }
+
+        [TestMethod]
+        public void SkipDerivesMinAndMaxLengthOfReturnType()
+        {
+            var returnType = EvaluateFunction("skip",
+                new List<TypeSymbol> { TypeFactory.CreateArrayType(LanguageConstants.String, minLength: 10, maxLength: 20), TypeFactory.CreateIntegerLiteralType(9) },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<ArrayType>();
+            returnType.As<ArrayType>().Item.Should().Be(LanguageConstants.String);
+            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
+            returnType.As<ArrayType>().MinLength.Should().Be(1);
+            returnType.As<ArrayType>().MaxLength.Should().NotBeNull();
+            returnType.As<ArrayType>().MaxLength.Should().Be(11);
+        }
+
+        [TestMethod]
+        public void TakeDerivesMinAndMaxLengthOfReturnType()
+        {
+            var returnType = EvaluateFunction("take",
+                new List<TypeSymbol> { TypeFactory.CreateArrayType(LanguageConstants.String, minLength: 5, maxLength: 20), TypeFactory.CreateIntegerLiteralType(9) },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<ArrayType>();
+            returnType.As<ArrayType>().Item.Should().Be(LanguageConstants.String);
+            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
+            returnType.As<ArrayType>().MinLength.Should().Be(5);
+            returnType.As<ArrayType>().MaxLength.Should().NotBeNull();
+            returnType.As<ArrayType>().MaxLength.Should().Be(9);
+        }
+
+        [TestMethod]
+        public void SplitReturnTypeIncludesNonZeroMinLength()
+        {
+            var returnType = EvaluateFunction("split",
+                new List<TypeSymbol> { LanguageConstants.Any, LanguageConstants.Any },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
+                .Type;
+
+            returnType.Should().BeAssignableTo<ArrayType>();
+            returnType.As<ArrayType>().Item.Should().Be(LanguageConstants.String);
+            returnType.As<ArrayType>().MinLength.Should().Be(1);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetPadLeftTestCases), DynamicDataSourceType.Method)]
+        public void PadLeftReturnsCorrectType(IList<TypeSymbol> argumentTypes, TypeSymbol expectedReturnType)
+        {
+            var returnType = EvaluateFunction("padLeft", argumentTypes, argumentTypes
+                .Select((_, idx) => new FunctionArgumentSyntax(TestSyntaxFactory.CreateVariableAccess(idx.ToString()))).ToArray());
+
+            returnType.Type.Should().Be(expectedReturnType);
+        }
+
+        private static IEnumerable<object[]> GetPadLeftTestCases()
+        {
+            static object[] CreateRow(TypeSymbol expectedReturnType, params TypeSymbol[] argumentTypes)
+                => new object[] { argumentTypes.ToList(), expectedReturnType };
+
+            return new[]
+            {
+                CreateRow(TypeFactory.CreateStringLiteralType("++++0"),
+                    TypeFactory.CreateIntegerLiteralType(0),
+                    TypeFactory.CreateIntegerLiteralType(5),
+                    TypeFactory.CreateStringLiteralType("+")),
+                CreateRow(TypeFactory.CreateStringType(3, 3),
+                    TypeFactory.CreateIntegerType(-99, 999),
+                    TypeFactory.CreateIntegerLiteralType(3)),
+                CreateRow(TypeFactory.CreateStringType(5, 10),
+                    TypeFactory.CreateStringType(1, 10),
+                    TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(20, 20),
+                    TypeFactory.CreateStringType(1, 10),
+                    TypeFactory.CreateIntegerLiteralType(20)),
+            };
+        }
+
+        [TestMethod]
+        public void ToLowerPreservesFlags()
+        {
+            var returnType = EvaluateFunction("toLower",
+                new List<TypeSymbol> { LanguageConstants.SecureString },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")) })
+                .Type;
+
+            returnType.ValidationFlags.Should().HaveFlag(TypeSymbolValidationFlags.AllowLooseAssignment);
+            returnType.ValidationFlags.Should().HaveFlag(TypeSymbolValidationFlags.IsSecure);
+        }
+
+        [TestMethod]
+        public void ToUpperPreservesFlags()
+        {
+            var returnType = EvaluateFunction("toUpper",
+                new List<TypeSymbol> { LanguageConstants.SecureString },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")) })
+                .Type;
+
+            returnType.ValidationFlags.Should().HaveFlag(TypeSymbolValidationFlags.AllowLooseAssignment);
+            returnType.ValidationFlags.Should().HaveFlag(TypeSymbolValidationFlags.IsSecure);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetLengthTestCases), DynamicDataSourceType.Method)]
+        public void LengthInfersPossibleRangesFromRefinementMetadata(TypeSymbol argumentType, TypeSymbol expectedReturn)
+        {
+            var returnType = EvaluateFunction("length",
+                new List<TypeSymbol> { argumentType },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")) });
+
+            returnType.Type.Should().Be(expectedReturn);
+        }
+
+        private static IEnumerable<object[]> GetLengthTestCases()
+        {
+            static object[] CreateRow(TypeSymbol argumentType, TypeSymbol returnType)
+                => new object[] { argumentType, returnType };
+
+            return new[]
+            {
+                CreateRow(TypeFactory.CreateStringLiteralType("boo!"),
+                    TypeFactory.CreateIntegerLiteralType(4)),
+                CreateRow(TypeFactory.CreateStringType(3, 3),
+                    TypeFactory.CreateIntegerLiteralType(3)),
+                CreateRow(TypeFactory.CreateStringType(5, 10),
+                    TypeFactory.CreateIntegerType(5, 10)),
+                CreateRow(TypeFactory.CreateStringType(20),
+                    TypeFactory.CreateIntegerType(20)),
+
+                CreateRow(LanguageConstants.Object,
+                    TypeFactory.CreateIntegerType(0)),
+                CreateRow(new ObjectType("object",
+                    default,
+                    new TypeProperty[] { new("prop", LanguageConstants.Any, TypePropertyFlags.Required) },
+                    null),
+                    TypeFactory.CreateIntegerLiteralType(1)),
+                CreateRow(new ObjectType("object",
+                    default,
+                    new TypeProperty[]
+                    {
+                        new("prop", LanguageConstants.Any, TypePropertyFlags.Required),
+                        new("prop2", LanguageConstants.Any),
+                    },
+                    null),
+                    TypeFactory.CreateIntegerType(1, 2)),
+                CreateRow(new ObjectType("object",
+                    default,
+                    new TypeProperty[]
+                    {
+                        new("prop", LanguageConstants.Any, TypePropertyFlags.Required),
+                        new("prop2", LanguageConstants.Any),
+                    },
+                    LanguageConstants.Any),
+                    TypeFactory.CreateIntegerType(1)),
+
+                CreateRow(new DiscriminatedObjectType("discriminated", default, "type", new[]
+                {
+                    new ObjectType("object",
+                        default,
+                        new TypeProperty[]
+                        {
+                            new("type", TypeFactory.CreateStringLiteralType("fizz"), TypePropertyFlags.Required),
+                            new("prop", LanguageConstants.Any, TypePropertyFlags.Required),
+                        },
+                        null),
+                    new ObjectType("object",
+                        default,
+                        new TypeProperty[]
+                        {
+                            new("type", TypeFactory.CreateStringLiteralType("buzz"), TypePropertyFlags.Required),
+                            new("prop", LanguageConstants.Any, TypePropertyFlags.Required),
+                            new("prop2", LanguageConstants.Any),
+                        },
+                        null),
+                }), TypeFactory.CreateIntegerType(2, 3)),
+
+                CreateRow(TypeFactory.CreateArrayType(1, 10, default),
+                    TypeFactory.CreateIntegerType(1, 10)),
+                CreateRow(new TupleType("tuple", ImmutableArray.Create<ITypeReference>(LanguageConstants.Object, LanguageConstants.String, LanguageConstants.Int), default),
+                    TypeFactory.CreateIntegerLiteralType(3)),
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetJoinTestCases), DynamicDataSourceType.Method)]
+        public void JoinInfersPossibleLengthRangesFromRefinementMetadata(TypeSymbol typeToJoin, TypeSymbol delimiterType, TypeSymbol expectedReturn)
+        {
+            var returnType = EvaluateFunction("join",
+                new List<TypeSymbol> { typeToJoin, delimiterType },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("foo")) });
+
+            returnType.Type.Should().Be(expectedReturn);
+        }
+
+        private static IEnumerable<object[]> GetJoinTestCases()
+        {
+            static object[] CreateRow(TypeSymbol typeToJoin, TypeSymbol delimiterType, TypeSymbol returnType)
+                => new object[] { typeToJoin, delimiterType, returnType };
+
+            return new[]
+            {
+                CreateRow(LanguageConstants.Array, LanguageConstants.String, LanguageConstants.String),
+                CreateRow(new TypedArrayType(TypeFactory.CreateStringType(1, 10), default, 1, 10),
+                    TypeFactory.CreateStringLiteralType("/"),
+                    TypeFactory.CreateStringType(1, 109)),
+                CreateRow(new TypedArrayType(TypeFactory.CreateStringType(1, 10), default, 1, 10),
+                    LanguageConstants.String,
+                    TypeFactory.CreateStringType(1)),
+                CreateRow(new TupleType("tuple", ImmutableArray.Create<ITypeReference>(LanguageConstants.Object, LanguageConstants.String, LanguageConstants.Int), default),
+                    TypeFactory.CreateStringLiteralType(", "),
+                    TypeFactory.CreateStringType(7)),
+                CreateRow(new TupleType("tuple", ImmutableArray.Create<ITypeReference>(TypeFactory.CreateIntegerType(0, 9)), default),
+                    TypeFactory.CreateStringLiteralType(", "),
+                    TypeFactory.CreateStringType(1, 1)),
+                CreateRow(new TupleType("tuple", ImmutableArray.Create<ITypeReference>(TypeFactory.CreateIntegerType(0, 9), TypeFactory.CreateIntegerType(0, 9)), default),
+                    TypeFactory.CreateStringLiteralType(", "),
+                    TypeFactory.CreateStringType(4, 4)),
+                CreateRow(new TupleType("tuple", ImmutableArray.Create<ITypeReference>(TypeFactory.CreateIntegerType(0, 9), TypeFactory.CreateIntegerType(0, 9)), default),
+                    TypeFactory.CreateStringType(),
+                    TypeFactory.CreateStringType(2)),
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetSubstringTestCases), DynamicDataSourceType.Method)]
+        public void SubstringInfersPossibleLengthRangesFromRefinementMetadata(IList<TypeSymbol> argumentTypes, TypeSymbol expectedReturn)
+        {
+            var returnType = EvaluateFunction("substring", argumentTypes, argumentTypes
+                .Select((_, idx) => new FunctionArgumentSyntax(TestSyntaxFactory.CreateVariableAccess(idx.ToString()))).ToArray());
+
+            returnType.Type.Should().Be(expectedReturn);
+        }
+
+        private static IEnumerable<object[]> GetSubstringTestCases()
+        {
+            static object[] CreateRow(TypeSymbol expectedReturnType, params TypeSymbol[] argumentTypes)
+                => new object[] { argumentTypes.ToList(), expectedReturnType };
+
+            return new[]
+            {
+                CreateRow(LanguageConstants.String, LanguageConstants.String, LanguageConstants.Int),
+                CreateRow(LanguageConstants.String, LanguageConstants.Any, LanguageConstants.Int),
+                CreateRow(LanguageConstants.String, LanguageConstants.String, LanguageConstants.Any),
+                CreateRow(LanguageConstants.String, LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Int),
+                CreateRow(LanguageConstants.SecureString, LanguageConstants.SecureString, LanguageConstants.Int),
+                CreateRow(TypeFactory.CreateStringType(null, 10), TypeFactory.CreateStringType(9, 10), LanguageConstants.Int),
+                CreateRow(TypeFactory.CreateStringType(4, 5), TypeFactory.CreateStringType(9, 10), TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(LanguageConstants.String, LanguageConstants.String, TypeFactory.CreateIntegerLiteralType(5)),
+
+                CreateRow(TypeFactory.CreateStringType(null, 5), LanguageConstants.String, LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(null, 5), LanguageConstants.Any, LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(null, 5), LanguageConstants.String, LanguageConstants.Any, TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(null, 5, LanguageConstants.SecureString.ValidationFlags), LanguageConstants.SecureString, LanguageConstants.Any, TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(null, 5), TypeFactory.CreateStringType(9, 10), LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(null, 10), TypeFactory.CreateStringType(9, 10), LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(50)),
+                CreateRow(TypeFactory.CreateStringType(4, 5), TypeFactory.CreateStringType(9, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateIntegerLiteralType(5)),
+                CreateRow(TypeFactory.CreateStringType(2, 2), TypeFactory.CreateStringType(9, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateIntegerLiteralType(2)),
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetSkipTestCases), DynamicDataSourceType.Method)]
+        public void SkipInfersPossibleLengthRangesFromRefinementMetadata(TypeSymbol originalValue, TypeSymbol numberToSkip, TypeSymbol expectedReturn)
+        {
+            var returnType = EvaluateFunction("skip",
+                new List<TypeSymbol> { originalValue, numberToSkip },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) });
+
+            returnType.Type.Should().Be(expectedReturn);
+        }
+
+        private static IEnumerable<object[]> GetSkipTestCases()
+        {
+            static object[] CreateRow(TypeSymbol originalValue, TypeSymbol numberToSkip, TypeSymbol expectedReturn)
+                => new object[] { originalValue, numberToSkip, expectedReturn };
+
+            return new[]
+            {
+                CreateRow(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.String),
+                CreateRow(LanguageConstants.String, LanguageConstants.Any, LanguageConstants.String),
+                CreateRow(LanguageConstants.SecureString, LanguageConstants.Int, LanguageConstants.SecureString),
+                CreateRow(TypeFactory.CreateStringType(1, 10), LanguageConstants.Int, TypeFactory.CreateStringType(null, 10)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateStringType(null, 5)),
+                CreateRow(TypeFactory.CreateStringType(7, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateStringType(2, 5)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(0), TypeFactory.CreateStringType(1, 10)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(-1), TypeFactory.CreateStringType(1, 10)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateStringType(null, 9)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(15), TypeFactory.CreateStringType(null, 0)),
+                CreateRow(TypeFactory.CreateStringType(5, 10), TypeFactory.CreateIntegerType(2, 3), TypeFactory.CreateStringType(2, 8)),
+
+                CreateRow(LanguageConstants.Array, LanguageConstants.Int, LanguageConstants.Array),
+                CreateRow(LanguageConstants.Array, LanguageConstants.Any, LanguageConstants.Array),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), LanguageConstants.Int, TypeFactory.CreateArrayType(minLength: null, 10)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateArrayType(minLength: null, 5)),
+                CreateRow(TypeFactory.CreateArrayType(7, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateArrayType(2, 5)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(0), TypeFactory.CreateArrayType(1, 10)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(-1), TypeFactory.CreateArrayType(1, 10)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateArrayType(minLength: null, 9)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(15), TypeFactory.CreateArrayType(minLength: null, 0)),
+                CreateRow(TypeFactory.CreateArrayType(5, 10), TypeFactory.CreateIntegerType(2, 3), TypeFactory.CreateArrayType(2, 8)),
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetTakeTestCases), DynamicDataSourceType.Method)]
+        public void TakeInfersPossibleLengthRangesFromRefinementMetadata(TypeSymbol originalValue, TypeSymbol numberToTake, TypeSymbol expectedReturn)
+        {
+            var returnType = EvaluateFunction("take",
+                new List<TypeSymbol> { originalValue, numberToTake },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) });
+
+            returnType.Type.Should().Be(expectedReturn);
+        }
+
+        private static IEnumerable<object[]> GetTakeTestCases()
+        {
+            static object[] CreateRow(TypeSymbol originalValue, TypeSymbol numberToTake, TypeSymbol expectedReturn)
+                => new object[] { originalValue, numberToTake, expectedReturn };
+
+            return new[]
+            {
+                CreateRow(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.String),
+                CreateRow(LanguageConstants.String, LanguageConstants.Any, LanguageConstants.String),
+                CreateRow(LanguageConstants.SecureString, LanguageConstants.Int, LanguageConstants.SecureString),
+                CreateRow(TypeFactory.CreateStringType(1, 10), LanguageConstants.Int, TypeFactory.CreateStringType(null, 10)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateStringType(1, 5)),
+                CreateRow(TypeFactory.CreateStringType(7, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateStringType(5, 5)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(0), TypeFactory.CreateStringType(null, 0)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(-1), TypeFactory.CreateStringType(null, 0)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateStringType(1, 1)),
+                CreateRow(TypeFactory.CreateStringType(1, 10), TypeFactory.CreateIntegerLiteralType(15), TypeFactory.CreateStringType(1, 10)),
+                CreateRow(TypeFactory.CreateStringType(5, 10), TypeFactory.CreateIntegerType(2, 3), TypeFactory.CreateStringType(2, 3)),
+                CreateRow(TypeFactory.CreateStringType(5, 8), TypeFactory.CreateIntegerType(2, 10), TypeFactory.CreateStringType(2, 8)),
+
+                CreateRow(LanguageConstants.Array, LanguageConstants.Int, LanguageConstants.Array),
+                CreateRow(LanguageConstants.Array, LanguageConstants.Any, LanguageConstants.Array),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), LanguageConstants.Int, TypeFactory.CreateArrayType(minLength: null, 10)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateArrayType(1, 5)),
+                CreateRow(TypeFactory.CreateArrayType(7, 10), TypeFactory.CreateIntegerLiteralType(5), TypeFactory.CreateArrayType(5, 5)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(0), TypeFactory.CreateArrayType(minLength: null, 0)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(-1), TypeFactory.CreateArrayType(minLength: null, 0)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateArrayType(1, 1)),
+                CreateRow(TypeFactory.CreateArrayType(1, 10), TypeFactory.CreateIntegerLiteralType(15), TypeFactory.CreateArrayType(1, 10)),
+                CreateRow(TypeFactory.CreateArrayType(5, 10), TypeFactory.CreateIntegerType(2, 3), TypeFactory.CreateArrayType(2, 3)),
+                CreateRow(TypeFactory.CreateArrayType(5, 8), TypeFactory.CreateIntegerType(2, 10), TypeFactory.CreateArrayType(2, 8)),
+            };
+        }
+
+        [TestMethod]
+        public void TrimDropsMinLengthButPreservesMaxLengthAndFlags()
+        {
+            var returnType = EvaluateFunction("trim",
+                new List<TypeSymbol> { TypeFactory.CreateStringType(10, 20, TypeSymbolValidationFlags.IsSecure) },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")) })
+                .Type;
+
+            returnType.Should().Be(TypeFactory.CreateStringType(minLength: null, 20, TypeSymbolValidationFlags.IsSecure));
+        }
+
         private FunctionResult EvaluateFunction(string functionName, IList<TypeSymbol> argumentTypes, FunctionArgumentSyntax[] arguments)
         {
             var matches = GetMatches(functionName, argumentTypes, out _, out _);
@@ -263,6 +678,12 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new TypedArrayType(LanguageConstants.CreateResourceScopeReference(ResourceScope.ResourceGroup), default),
                 TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.CreateResourceScopeReference(ResourceScope.ResourceGroup))
             },
+            // first(string[] {@minLength(1)}) -> string
+            new object[]
+            {
+                new TypedArrayType(LanguageConstants.String, default, minLength: 1),
+                LanguageConstants.String,
+            },
             // first(['test', 3]) -> 'test'
             new object[]
             {
@@ -285,6 +706,18 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 default),
                 LanguageConstants.CreateResourceScopeReference(ResourceScope.ResourceGroup)
             },
+            // first(string) => string {@minLength(0), @maxLength(1)}
+            new object[]
+            {
+                LanguageConstants.String,
+                TypeFactory.CreateStringType(0, 1),
+            },
+            // first(string {@minLength(> 0)}) => string {@minLength(1), @maxLength(1)}
+            new object[]
+            {
+                TypeFactory.CreateStringType(1),
+                TypeFactory.CreateStringType(1, 1),
+            },
         };
 
         private static IEnumerable<object[]> GetLastTestCases() => new[]
@@ -294,6 +727,12 @@ namespace Bicep.Core.UnitTests.TypeSystem
             {
                 new TypedArrayType(LanguageConstants.CreateResourceScopeReference(ResourceScope.ResourceGroup), default),
                 TypeHelper.CreateTypeUnion(LanguageConstants.Null, LanguageConstants.CreateResourceScopeReference(ResourceScope.ResourceGroup))
+            },
+            // last(string[] {@minLength(1)}) -> string
+            new object[]
+            {
+                new TypedArrayType(LanguageConstants.String, default, minLength: 1),
+                LanguageConstants.String,
             },
             // last(['test', 3]) -> 3
             new object[]
@@ -316,6 +755,18 @@ namespace Bicep.Core.UnitTests.TypeSystem
                     ),
                 default),
                 LanguageConstants.CreateResourceScopeReference(ResourceScope.Subscription)
+            },
+            // last(string) => string {@minLength(0), @maxLength(1)}
+            new object[]
+            {
+                LanguageConstants.String,
+                TypeFactory.CreateStringType(0, 1),
+            },
+            // last(string {@minLength(> 0)}) => string {@minLength(1), @maxLength(1)}
+            new object[]
+            {
+                TypeFactory.CreateStringType(1),
+                TypeFactory.CreateStringType(1, 1),
             },
         };
 
@@ -440,9 +891,9 @@ namespace Bicep.Core.UnitTests.TypeSystem
             //vararg function
             yield return CreateRow("union", LanguageConstants.Object, LanguageConstants.Object, LanguageConstants.Object, LanguageConstants.Object);
 
-            yield return CreateRow("length", LanguageConstants.Int, LanguageConstants.String);
-            yield return CreateRow("length", LanguageConstants.Int, LanguageConstants.Object);
-            yield return CreateRow("length", LanguageConstants.Int, LanguageConstants.Array);
+            yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.String);
+            yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.Object);
+            yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.Array);
             yield return CreateRow("length", LanguageConstants.Int, TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Object));
         }
 

--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -168,10 +168,10 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().Item.Type.Should().Be(LanguageConstants.String);
-            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MinLength.Should().BeGreaterThan(0);
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.Item.Type.Should().Be(LanguageConstants.String);
+            returnedArray.MinLength.Should().NotBeNull();
+            returnedArray.MinLength.Should().BeGreaterThan(0);
         }
 
         [TestMethod]
@@ -182,9 +182,9 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")), new(TestSyntaxFactory.CreateVariableAccess("baz")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MinLength.Should().Be(21);
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.MinLength.Should().NotBeNull();
+            returnedArray.MinLength.Should().Be(21);
         }
 
         [TestMethod]
@@ -195,9 +195,9 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().MaxLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MaxLength.Should().Be(21);
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.MaxLength.Should().NotBeNull();
+            returnedArray.MaxLength.Should().Be(21);
         }
 
         [TestMethod]
@@ -208,8 +208,8 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")), new(TestSyntaxFactory.CreateVariableAccess("baz")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().MaxLength.Should().BeNull();
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.MaxLength.Should().BeNull();
         }
 
         [TestMethod]
@@ -225,8 +225,8 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")), new(TestSyntaxFactory.CreateVariableAccess("baz")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<TupleType>();
-            returnType.As<TupleType>().Items.Should()
+            var returnedTuple = returnType.Should().BeAssignableTo<TupleType>().Subject;
+            returnedTuple.Items.Should()
                 .ContainInOrder(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool, TypeFactory.CreateStringLiteralType("abc"), TypeFactory.CreateIntegerLiteralType(123));
         }
 
@@ -238,12 +238,12 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().Item.Should().Be(LanguageConstants.String);
-            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MinLength.Should().Be(1);
-            returnType.As<ArrayType>().MaxLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MaxLength.Should().Be(11);
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.Item.Should().Be(LanguageConstants.String);
+            returnedArray.MinLength.Should().NotBeNull();
+            returnedArray.MinLength.Should().Be(1);
+            returnedArray.MaxLength.Should().NotBeNull();
+            returnedArray.MaxLength.Should().Be(11);
         }
 
         [TestMethod]
@@ -254,12 +254,12 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().Item.Should().Be(LanguageConstants.String);
-            returnType.As<ArrayType>().MinLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MinLength.Should().Be(5);
-            returnType.As<ArrayType>().MaxLength.Should().NotBeNull();
-            returnType.As<ArrayType>().MaxLength.Should().Be(9);
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.Item.Should().Be(LanguageConstants.String);
+            returnedArray.MinLength.Should().NotBeNull();
+            returnedArray.MinLength.Should().Be(5);
+            returnedArray.MaxLength.Should().NotBeNull();
+            returnedArray.MaxLength.Should().Be(9);
         }
 
         [TestMethod]
@@ -270,9 +270,9 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) })
                 .Type;
 
-            returnType.Should().BeAssignableTo<ArrayType>();
-            returnType.As<ArrayType>().Item.Should().Be(LanguageConstants.String);
-            returnType.As<ArrayType>().MinLength.Should().Be(1);
+            var returnedArray = returnType.Should().BeAssignableTo<ArrayType>().Subject;
+            returnedArray.Item.Should().Be(LanguageConstants.String);
+            returnedArray.MinLength.Should().Be(1);
         }
 
         [DataTestMethod]
@@ -587,6 +587,42 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 .Type;
 
             returnType.Should().Be(TypeFactory.CreateStringType(minLength: null, 20, TypeSymbolValidationFlags.IsSecure));
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetRangeTestCases), DynamicDataSourceType.Method)]
+        public void RangeInfersYieldRefinementsFromInputMetadata(TypeSymbol startIndex, TypeSymbol count, TypeSymbol expectedReturn)
+        {
+            var returnType = EvaluateFunction("range",
+                new List<TypeSymbol> { startIndex, count },
+                new FunctionArgumentSyntax[] { new(TestSyntaxFactory.CreateVariableAccess("foo")), new(TestSyntaxFactory.CreateVariableAccess("bar")) });
+
+            returnType.Type.Should().Be(expectedReturn);
+        }
+
+        private static IEnumerable<object[]> GetRangeTestCases()
+        {
+            static object[] CreateRow(TypeSymbol startIndex, TypeSymbol count, TypeSymbol expectedReturn)
+                => new object[] { startIndex, count, expectedReturn };
+
+            return new[]
+            {
+                CreateRow(LanguageConstants.Any, LanguageConstants.Int, TypeFactory.CreateArrayType(LanguageConstants.Int)),
+                CreateRow(LanguageConstants.Int, LanguageConstants.Any, TypeFactory.CreateArrayType(LanguageConstants.Int)),
+                CreateRow(LanguageConstants.Int, LanguageConstants.Int, TypeFactory.CreateArrayType(LanguageConstants.Int)),
+
+                CreateRow(TypeFactory.CreateIntegerLiteralType(-10), TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(-10, -1), 10, 10)),
+
+                CreateRow(TypeFactory.CreateIntegerType(0, 10), TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(0, 29), 10, 20)),
+                CreateRow(TypeFactory.CreateIntegerType(0, 10), TypeFactory.CreateIntegerType(null, 20), TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(0, 29), null, 20)),
+                CreateRow(TypeFactory.CreateIntegerType(null, 10), TypeFactory.CreateIntegerType(null, 20), TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(null, 29), null, 20)),
+                CreateRow(TypeFactory.CreateIntegerType(null, 10), TypeFactory.CreateIntegerType(10, null), TypeFactory.CreateArrayType(LanguageConstants.Int, 10, null)),
+                CreateRow(TypeFactory.CreateIntegerType(0, null), TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(0), 10, 10)),
+                CreateRow(TypeFactory.CreateIntegerType(0, null), TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(0), 10, 20)),
+                CreateRow(TypeFactory.CreateIntegerType(0, null), LanguageConstants.Int, TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(0), null, null)),
+                CreateRow(LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateArrayType(LanguageConstants.Int, 10, 10)),
+                CreateRow(LanguageConstants.Int, TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateArrayType(LanguageConstants.Int, 10, 20)),
+            };
         }
 
         private FunctionResult EvaluateFunction(string functionName, IList<TypeSymbol> argumentTypes, FunctionArgumentSyntax[] arguments)

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
@@ -56,7 +57,58 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("concat")
-                .WithReturnType(LanguageConstants.Array)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("concat", (_, _, _, _, argumentTypes) =>
+                {
+                    if (argumentTypes.All(t => t is TupleType))
+                    {
+                        return new(new TupleType(argumentTypes.OfType<TupleType>().SelectMany(tt => tt.Items).ToImmutableArray(), default));
+                    }
+
+                    BigInteger minLength = 0;
+                    BigInteger? maxLength = null;
+                    var itemTypes = new ITypeReference[argumentTypes.Length];
+
+                    for (int i = 0; i < argumentTypes.Length; i++)
+                    {
+                        if (argumentTypes[i] is not ArrayType arr)
+                        {
+                            return new(LanguageConstants.Array);
+                        }
+
+                        itemTypes[i] = arr.Item;
+
+                        minLength += arr.MinLength ?? 0;
+
+                        if (i == 0)
+                        {
+                            maxLength = arr.MaxLength;
+                        }
+                        else if (maxLength.HasValue && arr.MaxLength.HasValue)
+                        {
+                            maxLength = maxLength.Value + arr.MaxLength.Value;
+                        }
+                        else
+                        {
+                            maxLength = null;
+                        }
+                    }
+
+                    return new(TypeFactory.CreateArrayType(TypeHelper.CreateTypeUnion(itemTypes),
+                        minLength switch
+                        {
+                            var zero when zero <= 0 => null,
+                            var tooBig when tooBig > long.MaxValue => long.MaxValue,
+                            var otherwise => (long) otherwise,
+                        },
+                        maxLength switch
+                        {
+                            null => null,
+                            var tooBig when tooBig > long.MaxValue => long.MaxValue,
+                            var otherwise => (long) otherwise,
+                        },
+                        TypeSymbolValidationFlags.Default));
+                }),
+                LanguageConstants.Array)
                 .WithGenericDescription(ConcatDescription)
                 .WithDescription("Combines multiple arrays and returns the concatenated array.")
                 .WithVariableParameter("arg", LanguageConstants.Array, minimumCount: 1, "The array for concatenation")
@@ -83,7 +135,22 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("padLeft")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("padLeft", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(
+                    TryDeriveLiteralReturnType("padLeft", (_, _, _, _, argumentTypes) =>
+                    {
+                        (long? minLength, long? maxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[0]);
+
+                        if (argumentTypes[1] is not IntegerLiteralType literalLength)
+                        {
+                            return new(TypeFactory.CreateStringType(minLength: minLength, validationFlags: argumentTypes[0].ValidationFlags));
+                        }
+
+                        return new(TypeFactory.CreateStringType(
+                            minLength.HasValue ? Math.Max(minLength.Value, literalLength.Value) : null,
+                            maxLength.HasValue ? Math.Max(maxLength.Value, literalLength.Value) : null,
+                            argumentTypes[0].ValidationFlags));
+                    }),
+                    LanguageConstants.String)
                 .WithGenericDescription("Returns a right-aligned string by adding characters to the left until reaching the total specified length.")
                 .WithRequiredParameter("valueToPad", TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Int), "The value to right-align.")
                 .WithRequiredParameter("totalLength", LanguageConstants.Int, "The total number of characters in the returned string.")
@@ -99,27 +166,44 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("toLower")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toLower", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toLower", (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string ? @string : LanguageConstants.String)), LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to lower case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to lower case.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("toUpper")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toUpper", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toUpper", (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string ? @string : LanguageConstants.String)), LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to upper case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to upper case.")
                 .Build();
 
+
+            static int MinLength(ObjectType @object) =>
+                @object.Properties.Where(kvp => kvp.Value.Flags.HasFlag(TypePropertyFlags.Required) && TypeHelper.TryRemoveNullability(kvp.Value.TypeReference.Type) is null).Count();
+
+            static int? MaxLength(ObjectType @object) => @object.AdditionalPropertiesType is null ? @object.Properties.Count : null;
+
             yield return new FunctionOverloadBuilder("length")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("length", LanguageConstants.Int), LanguageConstants.Int)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("length", (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() switch
+                {
+                    StringType @string => TypeFactory.CreateIntegerType(@string.MinLength ?? 0, @string.MaxLength, @string.ValidationFlags),
+                    ObjectType @object => TypeFactory.CreateIntegerType(MinLength(@object), MaxLength(@object), @object.ValidationFlags),
+                    DiscriminatedObjectType discriminatedObject => TypeFactory.CreateIntegerType(
+                        minValue: discriminatedObject.UnionMembersByKey.Values.Min(MinLength),
+                        maxValue: discriminatedObject.UnionMembersByKey.Values
+                            .Aggregate((long?) 0, (acc, memberObject) => acc.HasValue && MaxLength(memberObject) is int maxLength
+                                ? Math.Max(acc.Value, maxLength) : null)),
+                    _ => LanguageConstants.Int,
+                })), LanguageConstants.Int)
                 .WithGenericDescription("Returns the number of characters in a string, elements in an array, or root-level properties in an object.")
                 .WithRequiredParameter("arg", TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Object), "The string to use for getting the number of characters or the object to use for getting the number of root-level properties.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("length")
                 .WithReturnResultBuilder(
-                    (binder, fileResolver, diagnostics, functionCall, argumentTypes) => (argumentTypes.IsEmpty ? null : argumentTypes[0]) switch {
+                    (_, _, _, _, argumentTypes) => (argumentTypes.IsEmpty ? null : argumentTypes[0]) switch {
                         TupleType tupleType => new(TypeFactory.CreateIntegerLiteralType(tupleType.Items.Length)),
+                        ArrayType arrayType => new(TypeFactory.CreateIntegerType(arrayType.MinLength ?? 0, arrayType.MaxLength)),
                         _ => new(LanguageConstants.Int),
                     },
                     LanguageConstants.Int)
@@ -135,7 +219,59 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("join")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("join", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("join", (_, _, _, _, argumentTypes) =>
+                {
+                    (long delimiterMinLength, long? delimiterMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[1]);
+
+                    long minLength = 0;
+                    long? maxLength = null;
+                    switch (argumentTypes.FirstOrDefault())
+                    {
+                        case TupleType inputTuple:
+                            maxLength = 0;
+                            foreach (var item in inputTuple.Items)
+                            {
+                                (long itemMinLength, long? itemMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(item.Type);
+
+                                minLength += itemMinLength;
+                                if (maxLength.HasValue)
+                                {
+                                    if (itemMaxLength.HasValue)
+                                    {
+                                        maxLength += itemMaxLength.Value;
+                                    }
+                                    else
+                                    {
+                                        maxLength = null;
+                                    }
+                                }
+                            }
+
+                            minLength += Math.Max(inputTuple.Items.Length - 1, 0) * delimiterMinLength;
+                            maxLength = maxLength.HasValue && delimiterMaxLength.HasValue
+                                ? maxLength.Value + (Math.Max(inputTuple.Items.Length - 1, 0) * delimiterMaxLength.Value)
+                                : null;
+                            break;
+
+                        case ArrayType inputArray:
+                            (long elementMinLength, long? elementMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(inputArray.Item.Type);
+                            minLength = (inputArray.MinLength ?? 0) * elementMinLength;
+                            minLength += Math.Max((inputArray.MinLength ?? 0) - 1, 0) * delimiterMinLength;
+
+                            if (elementMaxLength.HasValue && delimiterMaxLength.HasValue && inputArray.MaxLength.HasValue)
+                            {
+                                maxLength = elementMaxLength.Value * inputArray.MaxLength.Value;
+                                maxLength += Math.Max(inputArray.MaxLength.Value - 1, 0) * delimiterMaxLength.Value;
+                            }
+                            break;
+                    }
+
+                    return new(TypeFactory.CreateStringType(maxLength: maxLength, minLength: minLength switch
+                    {
+                        <= 0 => null,
+                        _ => minLength,
+                    }));
+                }), LanguageConstants.String)
                 .WithGenericDescription("Joins multiple strings into a single string, separated using a delimiter.")
                 .WithRequiredParameter("inputArray", new TypedArrayType(TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.Bool), TypeSymbolValidationFlags.Default), "An array of strings to join.")
                 .WithRequiredParameter("delimiter", LanguageConstants.String, "The delimiter to use to join the string.")
@@ -161,13 +297,19 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("guid")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("guid", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("guid", TypeFactory.CreateStringType(minLength: GuidLength, maxLength: GuidLength)),
+                    TypeFactory.CreateStringType(minLength: GuidLength, maxLength: GuidLength))
                 .WithGenericDescription("Creates a value in the format of a globally unique identifier based on the values provided as parameters.")
                 .WithVariableParameter("arg", LanguageConstants.String, minimumCount: 1, "The value used in the hash function to create the GUID.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("trim")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("trim", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(
+                    TryDeriveLiteralReturnType("trim",
+                        (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
+                            ? TypeFactory.CreateStringType(minLength: null, @string.MaxLength, @string.ValidationFlags)
+                            : LanguageConstants.String)),
+                    LanguageConstants.String)
                 .WithGenericDescription("Removes all leading and trailing white-space characters from the specified string.")
                 .WithRequiredParameter("stringToTrim", LanguageConstants.String, "The value to trim.")
                 .Build();
@@ -181,7 +323,52 @@ namespace Bicep.Core.Semantics.Namespaces
 
             // TODO: Docs deviation
             yield return new FunctionOverloadBuilder("substring")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("substring", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(
+                    TryDeriveLiteralReturnType("substring", (_, _, _, _, argumentTypes) =>
+                    {
+                        var originalString = argumentTypes[0] as StringType;
+                        var literalStartIndex = argumentTypes[1] as IntegerLiteralType;
+                        var literalLength = argumentTypes.Skip(2).FirstOrDefault() as IntegerLiteralType;
+
+                        if (literalLength is null)
+                        {
+                            long? minLength = literalStartIndex is null ? null : ((originalString?.MinLength ?? 0) - literalStartIndex.Value) switch
+                            {
+                                <= 0 => null,
+                                long otherwise => otherwise,
+                            };
+                            long? maxLength = literalStartIndex is null ? originalString?.MaxLength : originalString?.MaxLength.HasValue == true
+                                ? Math.Max(0, originalString.MaxLength.Value - literalStartIndex.Value)
+                                : null;
+
+                            return new(TypeFactory.CreateStringType(minLength, maxLength, argumentTypes[0].ValidationFlags));
+                        }
+
+                        if (literalStartIndex is null || originalString is null)
+                        {
+                            return new(TypeFactory.CreateStringType(minLength: null,
+                                maxLength: originalString?.MaxLength.HasValue == true
+                                    ? Math.Min(literalLength.Value, originalString.MaxLength.Value)
+                                    : literalLength.Value,
+                                argumentTypes[0].ValidationFlags));
+                        }
+
+                        long derivedMaxLength = originalString.MaxLength.HasValue
+                            ? Math.Min(Math.Max(0, originalString.MaxLength.Value - literalStartIndex.Value), literalLength.Value)
+                            : literalLength.Value;
+                        long? derivedMinLength = ((originalString.MinLength ?? 0) - literalStartIndex.Value) switch
+                        {
+                            <= 0 => null,
+                            long otherwise => otherwise,
+                        };
+                        if (derivedMinLength.HasValue && derivedMinLength.Value > derivedMaxLength)
+                        {
+                            derivedMinLength = derivedMaxLength;
+                        }
+
+                        return new(TypeFactory.CreateStringType(derivedMinLength, derivedMaxLength, originalString.ValidationFlags));
+                    }),
+                    LanguageConstants.String)
                 .WithGenericDescription("Returns a substring that starts at the specified character position and contains the specified number of characters.")
                 .WithRequiredParameter("stringToParse", LanguageConstants.String, "The original string from which the substring is extracted.")
                 .WithRequiredParameter("startIndex", LanguageConstants.Int, "The zero-based starting character position for the substring.")
@@ -189,7 +376,41 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("take")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", LanguageConstants.Array), LanguageConstants.Array)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", (_, _, _, functionCall, argumentTypes) =>
+                {
+                    (long? originalMinLength, long? originalMaxLength) = argumentTypes[0] switch
+                    {
+                        ArrayType array => (array.MinLength, array.MaxLength),
+                        _ => (null, null),
+                    };
+                    (long minToTake, long maxToTake) = argumentTypes[1] switch
+                    {
+                        IntegerLiteralType integerLiteral => (integerLiteral.Value, integerLiteral.Value),
+                        IntegerType integer => (integer.MinValue ?? long.MinValue, integer.MaxValue ?? long.MaxValue),
+                        _ => (long.MinValue, long.MaxValue),
+                    };
+
+                    return new(argumentTypes[0] switch
+                    {
+                        TupleType tupleType when minToTake == maxToTake && minToTake >= tupleType.Items.Length => tupleType,
+                        TupleType tupleType when minToTake == maxToTake && minToTake <= 0 => new TupleType(ImmutableArray<ITypeReference>.Empty, tupleType.ValidationFlags),
+                        TupleType tupleType when minToTake == maxToTake && minToTake <= int.MaxValue => new TupleType(tupleType.Items.Take((int) minToTake).ToImmutableArray(), tupleType.ValidationFlags),
+                        ArrayType array => TypeFactory.CreateArrayType(array.Item,
+                            !array.MinLength.HasValue ? null : minToTake switch
+                            {
+                                <= 0 => null,
+                                _ => Math.Min(array.MinLength.Value, minToTake),
+                            },
+                            Math.Min(array.MaxLength ?? long.MaxValue, maxToTake) switch
+                            {
+                                long.MaxValue => null,
+                                < 0 => 0,
+                                long otherwise => otherwise,
+                            },
+                            array.ValidationFlags),
+                        _ => TypeFactory.CreateArrayType(null, maxToTake, argumentTypes[0].ValidationFlags),
+                    });
+                }), LanguageConstants.Array)
                 .WithGenericDescription(TakeDescription)
                 .WithDescription("Returns an array with the specified number of elements from the start of the array.")
                 .WithRequiredParameter("originalValue", LanguageConstants.Array, "The array to take the elements from.")
@@ -197,7 +418,30 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("take")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", (_, _, _, functionCall, argumentTypes) =>
+                {
+                    (long? originalMinLength, long? originalMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[0]);
+                    (long minToTake, long maxToTake) = argumentTypes[1] switch
+                    {
+                        IntegerLiteralType integerLiteral => (integerLiteral.Value, integerLiteral.Value),
+                        IntegerType integer => (integer.MinValue ?? long.MinValue, integer.MaxValue ?? long.MaxValue),
+                        _ => (long.MinValue, long.MaxValue),
+                    };
+
+                    return new(TypeFactory.CreateStringType(
+                        !originalMinLength.HasValue ? null : minToTake switch
+                        {
+                            <= 0 => null,
+                            _ => Math.Min(originalMinLength.Value, minToTake),
+                        },
+                        Math.Min(originalMaxLength ?? long.MaxValue, maxToTake) switch
+                        {
+                            long.MaxValue => null,
+                            < 0 => 0,
+                            long otherwise => otherwise,
+                        },
+                        argumentTypes[0].ValidationFlags));
+                }), LanguageConstants.String)
                 .WithGenericDescription(TakeDescription)
                 .WithDescription("Returns a string with the specified number of characters from the start of the string.")
                 .WithRequiredParameter("originalValue", LanguageConstants.String, "The string to take the elements from.")
@@ -205,7 +449,34 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("skip")
-                .WithReturnType(LanguageConstants.Array)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", (_, _, _, functionCall, argumentTypes) =>
+                {
+                    (long minToSkip, long maxToSkip) = argumentTypes[1] switch
+                    {
+                        IntegerLiteralType integerLiteral => (integerLiteral.Value, integerLiteral.Value),
+                        IntegerType integer => (integer.MinValue ?? long.MinValue, integer.MaxValue ?? long.MaxValue),
+                        _ => (long.MinValue, long.MaxValue),
+                    };
+
+                    return new(argumentTypes[0] switch
+                    {
+                        TypeSymbol original when maxToSkip <= 0 => original,
+                        TupleType tupleType when minToSkip == maxToSkip && minToSkip <= int.MaxValue => new TupleType(tupleType.Items.Skip((int) minToSkip).ToImmutableArray(), tupleType.ValidationFlags),
+                        ArrayType array => TypeFactory.CreateArrayType(array.Item,
+                            ((array.MinLength ?? 0) - maxToSkip) switch
+                            {
+                                <= 0 => null,
+                                var otherwise => otherwise,
+                            },
+                            !array.MaxLength.HasValue ? null : (array.MaxLength.Value - Math.Max(0, minToSkip)) switch
+                            {
+                                < 0 => 0,
+                                long otherwise => otherwise,
+                            },
+                            array.ValidationFlags),
+                        _ => TypeFactory.CreateArrayType(validationFlags: argumentTypes[0].ValidationFlags),
+                    });
+                }), LanguageConstants.Array)
                 .WithGenericDescription(SkipDescription)
                 .WithDescription("Returns an array with all the elements after the specified number in the array.")
                 .WithRequiredParameter("originalValue", LanguageConstants.Array, "The array to use for skipping.")
@@ -213,7 +484,34 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("skip")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", (_, _, _, functionCall, argumentTypes) =>
+                {
+                    (long? originalMinLength, long? originalMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[0]);
+                    (long minToSkip, long maxToSkip) = argumentTypes[1] switch
+                    {
+                        IntegerLiteralType integerLiteral => (integerLiteral.Value, integerLiteral.Value),
+                        IntegerType integer => (integer.MinValue ?? long.MinValue, integer.MaxValue ?? long.MaxValue),
+                        _ => (long.MinValue, long.MaxValue),
+                    };
+
+                    if (maxToSkip <= 0)
+                    {
+                        return new(argumentTypes[0]);
+                    }
+
+                    return new(TypeFactory.CreateStringType(
+                        ((originalMinLength ?? 0) - maxToSkip) switch
+                        {
+                            <= 0 => null,
+                            var otherwise => otherwise,
+                        },
+                        !originalMaxLength.HasValue ? null : (originalMaxLength.Value - Math.Max(0, minToSkip)) switch
+                        {
+                            < 0 => 0,
+                            long otherwise => otherwise,
+                        },
+                        argumentTypes[0].ValidationFlags));
+                }), LanguageConstants.String)
                 .WithGenericDescription(SkipDescription)
                 .WithDescription("Returns a string with all the characters after the specified number in the string.")
                 .WithRequiredParameter("originalValue", LanguageConstants.String, "The string to use for skipping.")
@@ -283,44 +581,50 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("first")
-                .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) =>
+                .WithReturnResultBuilder((_, _, _, _, argumentTypes) =>  new(argumentTypes[0] switch
                 {
-                    return new(argumentTypes[0] switch
-                    {
-                        TupleType tupleType => tupleType.Items.FirstOrDefault()?.Type ?? LanguageConstants.Null,
-                        ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
-                        _ => LanguageConstants.Any
-                    });
-                }, LanguageConstants.Any)
+                    TupleType tupleType => tupleType.Items.FirstOrDefault()?.Type ?? LanguageConstants.Null,
+                    ArrayType arrayType when arrayType.MinLength.HasValue && arrayType.MinLength.Value > 0 => arrayType.Item.Type,
+                    ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
+                    _ => LanguageConstants.Any
+                }), LanguageConstants.Any)
                 .WithGenericDescription(FirstDescription)
                 .WithDescription("Returns the first element of the array.")
                 .WithRequiredParameter("array", LanguageConstants.Array, "The value to retrieve the first element.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("first")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("first", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(
+                    TryDeriveLiteralReturnType("first",
+                        (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
+                            ? TypeFactory.CreateStringType(@string.MinLength.HasValue ? Math.Min(@string.MinLength.Value, 1) : null, 1, @string.ValidationFlags)
+                            : TypeFactory.CreateStringType(minLength: null, 1, argumentTypes[0].ValidationFlags))),
+                    LanguageConstants.String)
                 .WithGenericDescription(FirstDescription)
                 .WithDescription("Returns the first character of the string.")
                 .WithRequiredParameter("string", LanguageConstants.String, "The value to retrieve the first character.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("last")
-                .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) =>
+                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
                 {
-                    return new(argumentTypes[0] switch
-                    {
-                        TupleType tupleType => tupleType.Items.LastOrDefault()?.Type ?? LanguageConstants.Null,
-                        ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
-                        _ => LanguageConstants.Any
-                    });
-                }, LanguageConstants.Any)
+                    TupleType tupleType => tupleType.Items.LastOrDefault()?.Type ?? LanguageConstants.Null,
+                    ArrayType arrayType when arrayType.MinLength.HasValue && arrayType.MinLength.Value > 0 => arrayType.Item.Type,
+                    ArrayType arrayType => TypeHelper.CreateTypeUnion(LanguageConstants.Null, arrayType.Item.Type),
+                    _ => LanguageConstants.Any,
+                }), LanguageConstants.Any)
                 .WithGenericDescription(LastDescription)
                 .WithDescription("Returns the last element of the array.")
                 .WithRequiredParameter("array", LanguageConstants.Array, "The value to retrieve the last element.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("last")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("last", LanguageConstants.String), LanguageConstants.String)
+                .WithReturnResultBuilder(
+                    TryDeriveLiteralReturnType("last",
+                        (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
+                            ? TypeFactory.CreateStringType(@string.MinLength.HasValue ? Math.Min(@string.MinLength.Value, 1) : null, 1, @string.ValidationFlags)
+                            : TypeFactory.CreateStringType(minLength: null, 1, argumentTypes[0].ValidationFlags))),
+                    LanguageConstants.String)
                 .WithGenericDescription(LastDescription)
                 .WithDescription("Returns the last character of the string.")
                 .WithRequiredParameter("string", LanguageConstants.String, "The value to retrieve the last character.")
@@ -403,7 +707,15 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("range")
-                .WithReturnType(new TypedArrayType(LanguageConstants.Int, TypeSymbolValidationFlags.Default))
+                .WithReturnResultBuilder(
+                    (_, _, _, _, argumentTypes) => new(new TypedArrayType(
+                        argumentTypes.Length == 2 &&
+                            argumentTypes[0] is IntegerLiteralType startIndexLiteral &&
+                            argumentTypes[1] is IntegerLiteralType countLiteral
+                                ? TypeFactory.CreateIntegerType(startIndexLiteral.Value, startIndexLiteral.Value + countLiteral.Value)
+                                : LanguageConstants.Int,
+                        TypeSymbolValidationFlags.Default)),
+                    new TypedArrayType(LanguageConstants.Int, default))
                 .WithGenericDescription("Creates an array of integers from a starting integer and containing a number of items.")
                 .WithRequiredParameter("startIndex", LanguageConstants.Int, "The first integer in the array. The sum of startIndex and count must be no greater than 2147483647.")
                 .WithRequiredParameter("count", LanguageConstants.Int, "The number of integers in the array. Must be non-negative integer up to 10000.")
@@ -539,16 +851,15 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("array", LanguageConstants.Array, "The array to filter.")
                 .WithRequiredParameter("predicate", OneParamLambda(LanguageConstants.Any, LanguageConstants.Bool), "The predicate applied to each input array element. If false, the item will be filtered out of the output array.",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => OneParamLambda(t, LanguageConstants.Bool)))
-                .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) => {
-                    return new(argumentTypes[0] switch
-                    {
-                        // If a tuple is filtered, each member of the resulting array will be assignable to <input tuple>.Item, but information about specific indices and tuple length is no longer reliable.
-                        // For example, given a symbol `a` of type `[0, 1, 2, 3, 4]`, the expression `filter(a, x => x % 2 == 0)` returns an array in which each member is assignable to `0 | 1 | 2 | 3 | 4`,
-                        // but the returned array (which has a concrete value of `[0, 2, 4]`) will not be assignable to the input tuple type of `[0, 1, 2, 3, 4]`
-                        TupleType tuple => tuple.ToTypedArray(),
-                        var otherwise => otherwise,
-                    });
-                }, LanguageConstants.Array)
+                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
+                {
+                    // If a tuple is filtered, each member of the resulting array will be assignable to <input tuple>.Item, but information about specific indices and tuple length is no longer reliable.
+                    // For example, given a symbol `a` of type `[0, 1, 2, 3, 4]`, the expression `filter(a, x => x % 2 == 0)` returns an array in which each member is assignable to `0 | 1 | 2 | 3 | 4`,
+                    // but the returned array (which has a concrete value of `[0, 2, 4]`) will not be assignable to the input tuple type of `[0, 1, 2, 3, 4]`
+                    TupleType tuple => tuple.ToTypedArray(minLength: null, maxLength: tuple.MaxLength),
+                    ArrayType arrayType => TypeFactory.CreateArrayType(arrayType.Item, minLength: null, maxLength: arrayType.MaxLength, arrayType.ValidationFlags),
+                    var otherwise => otherwise,
+                }), LanguageConstants.Array)
                 .Build();
 
             yield return new FunctionOverloadBuilder("map")
@@ -568,14 +879,12 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("array", LanguageConstants.Array, "The array to sort.")
                 .WithRequiredParameter("predicate", TwoParamLambda(LanguageConstants.Any, LanguageConstants.Any, LanguageConstants.Bool), "The predicate used to compare two array elements for ordering. If true, the second element will be ordered after the first in the output array.",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => TwoParamLambda(t, t, LanguageConstants.Bool)))
-                .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) => {
-                    return new(argumentTypes[0] switch
-                    {
-                        // When a tuple is sorted, the resultant array will be of the same length as the input tuple, but the information about which member resides at which index can no longer be relied upon.
-                        TupleType tuple => tuple.ToTypedArray(),
-                        var otherwise => otherwise,
-                    });
-                }, LanguageConstants.Array)
+                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
+                {
+                    // When a tuple is sorted, the resultant array will be of the same length as the input tuple, but the information about which member resides at which index can no longer be relied upon.
+                    TupleType tuple => tuple.ToTypedArray(),
+                    var otherwise => otherwise,
+                }), LanguageConstants.Array)
                 .Build();
 
             yield return new FunctionOverloadBuilder("reduce")
@@ -639,11 +948,14 @@ namespace Bicep.Core.Semantics.Namespaces
         }
 
         private static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, TypeSymbol nonLiteralReturnType) =>
+            TryDeriveLiteralReturnType(armFunctionName, (_, _, _, _, _) => new(nonLiteralReturnType));
+
+        private static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, FunctionOverload.ResultBuilderDelegate nonLiteralReturnResultBuilder) =>
             (binder, fileResolver, diagnostics, functionCall, argumentTypes) =>
             {
                 FunctionResult returnType = ArmFunctionReturnTypeEvaluator.TryEvaluate(armFunctionName, out var diagnosticBuilders, argumentTypes) is { } literalReturnType
                     ? new(literalReturnType)
-                    : new(nonLiteralReturnType);
+                    : nonLiteralReturnResultBuilder.Invoke(binder, fileResolver, diagnostics, functionCall, argumentTypes);
 
                 var diagnosticTarget = functionCall.Arguments.Any()
                     ? TextSpan.Between(functionCall.Arguments.First(), functionCall.Arguments.Last())
@@ -807,7 +1119,7 @@ namespace Bicep.Core.Semantics.Namespaces
             }
 
             return new(
-                new StringLiteralType(binder.FileSymbol.FileUri.MakeRelativeUri(fileUri).ToString(), fileContent, default),
+                new StringLiteralType(binder.FileSymbol.FileUri.MakeRelativeUri(fileUri).ToString(), fileContent, TypeSymbolValidationFlags.Default),
                 new StringLiteralExpression(functionCall, fileContent));
         }
 

--- a/src/Bicep.Core/TypeSystem/ArrayType.cs
+++ b/src/Bicep.Core/TypeSystem/ArrayType.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.TypeSystem
             MinLength == otherArray.MinLength &&
             MaxLength == otherArray.MaxLength &&
             Name == otherArray.Name &&
-            Item == otherArray.Item;
+            Item.Equals(otherArray.Item);
 
         public override int GetHashCode() => HashCode.Combine(TypeKind, ValidationFlags, MinLength, MaxLength, Name, Item);
     }


### PR DESCRIPTION
This PR updates the ReturnResultBuilder of several built-in functions that return strings, ints, or arrays so that the return type reflects inferences we can make based on the supplied arguments. For example, the return type of `length` is currently `LanguageConstants.Int`, but we can infer that the return should have a minimum value of 0 (because lengths cannot be negative) and, if the input is a string with a `MaxLength` refinement, we can infer the maximum value, too.

Similar inference was added for `concat`, `padLeft`, `join`, `trim`, `substring`, `take`, `skip`, `first`, `last`, and `range`.

This PR was spun off of #9870 because the refinement derivation logic seemed a bit intricate. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10102)