### PR TITLE
Improve paste as bicep E2E tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
         working-directory: ./src/vscode-bicep
 
       - name: Show extension logs of E2E tests
-        run: cat ./bicep.log
+        run: cat ./bicep-e2e.log
         if: always()
         working-directory: ./src/vscode-bicep
 

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -9,7 +9,7 @@ namespace Bicep.Core.Syntax
     /// Visits an <see href="https://en.wikipedia.org/wiki/Abstract_syntax_tree">abstract syntax tree (AST)</see>.
     /// </summary>
     /// <remarks>
-    /// The Bicep syntax tree is always a <see href="https://en.wikipedia.org/wiki/Parse_tree">concret syntax tree</see>.
+    /// The Bicep syntax tree is always a <see href="https://en.wikipedia.org/wiki/Parse_tree">concrete syntax tree</see>.
     /// The visitor visits syntax nodes except for terminal symbols (tokens) so that the Bicep syntax tree is traversed as an AST.
     /// </remarks>
     public abstract class AstVisitor : SyntaxVisitor

--- a/src/Bicep.Tools.Benchmark/Visitors.cs
+++ b/src/Bicep.Tools.Benchmark/Visitors.cs
@@ -47,7 +47,7 @@ public class Visitors
         this.cstVisitor = new();
     }
 
-    [Benchmark(Description = "Visit concret syntax tree.", Baseline = true)]
+    [Benchmark(Description = "Visit concrete syntax tree.", Baseline = true)]
     public void Visit_cst()
     {
         foreach (var programSyntax in this.benchmarkData)

--- a/src/vscode-bicep/src/commands/pasteAsBicep.ts
+++ b/src/vscode-bicep/src/commands/pasteAsBicep.ts
@@ -69,7 +69,9 @@ export class PasteAsBicepCommand implements Command {
       clipboardText = await env.clipboard.readText();
 
       if (editor?.document.languageId !== bicepLanguageId) {
-        throw new Error("Cannot paste as Bicep into an editor not using the Bicep language");
+        throw new Error(
+          "Cannot paste as Bicep: Editor is not editing a Bicep document."
+        );
       }
 
       const result = await this.callDecompileForPaste(
@@ -194,6 +196,7 @@ export class PasteAsBicepCommand implements Command {
                 true // queryCanPaste
               );
               if (!canPasteResult.pasteType) {
+                // Nothing we know how to convert
                 getLogger().debug(`${logPrefix}: pasteType empty`);
                 return;
               }
@@ -217,7 +220,6 @@ export class PasteAsBicepCommand implements Command {
                 );
                 const msg = `Could not convert pasted text into Bicep: ${canPasteResult.errorMessage}`;
                 this.outputChannelManager.appendToOutputChannel(msg);
-
                 getLogger().debug(`${logPrefix}: ${msg}`);
 
                 // ... and register telemetry for the failure (don't show the error to the user again)
@@ -232,7 +234,7 @@ export class PasteAsBicepCommand implements Command {
 
               // While we were awaiting async calls, the pasted text may have been formatted in the editor, get the new version
               const formattedPastedText = getTextAfterFormattingChanges(
-                contentChange.text,     
+                contentChange.text,
                 e.document.getText(),
                 contentChange.rangeOffset
               );

--- a/src/vscode-bicep/src/commands/pasteAsBicep.ts
+++ b/src/vscode-bicep/src/commands/pasteAsBicep.ts
@@ -20,6 +20,7 @@ import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
 import {
   callWithTelemetryAndErrorHandling,
   IActionContext,
+  parseError,
 } from "@microsoft/vscode-azext-utils";
 import { areEqualIgnoringWhitespace } from "../utils/areEqualIgnoringWhitespace";
 import { getTextAfterFormattingChanges } from "../utils/getTextAfterFormattingChanges";
@@ -34,6 +35,7 @@ import { SuppressedWarningsManager } from "./SuppressedWarningsManager";
 import { Disposable } from "../utils/disposable";
 import { isEmptyOrWhitespace } from "../utils/isEmptyOrWhitespace";
 import { withProgressAfterDelay } from "../utils/withProgressAfterDelay";
+import { getLogger } from "../utils/logger";
 
 export class PasteAsBicepCommand implements Command {
   public readonly id = "bicep.pasteAsBicep";
@@ -51,41 +53,55 @@ export class PasteAsBicepCommand implements Command {
     context: IActionContext,
     documentUri?: Uri
   ): Promise<void> {
-    documentUri = await findOrCreateActiveBicepFile(
-      context,
-      documentUri,
-      "Choose which Bicep file to paste into"
-    );
+    const logPrefix = "PasteAsBicep (command)";
+    let clipboardText: string | undefined;
+    let finalPastedBicep: string | undefined;
 
-    const document = await workspace.openTextDocument(documentUri);
-    const editor = await window.showTextDocument(document);
-    const clipboardText = await env.clipboard.readText();
-
-    if (editor?.document.languageId !== bicepLanguageId) {
-      return;
-    }
-
-    const result = await this.callDecompileForPaste(
-      clipboardText,
-      false /* queryCanPaste */
-    );
-
-    if (!result.pasteType) {
-      throw new Error(
-        `The clipboard text does not appear to be valid JSON or is not in a format that can be pasted as Bicep.`
+    try {
+      documentUri = await findOrCreateActiveBicepFile(
+        context,
+        documentUri,
+        "Choose which Bicep file to paste into"
       );
-    }
 
-    if (result.errorMessage) {
-      context.errorHandling.issueProperties.clipboardText = clipboardText;
-      throw new Error(
-        `Could not paste clipboard text as Bicep: ${result.errorMessage}`
+      const document = await workspace.openTextDocument(documentUri);
+      const editor = await window.showTextDocument(document);
+      clipboardText = await env.clipboard.readText();
+
+      if (editor?.document.languageId !== bicepLanguageId) {
+        throw new Error("Cannot paste as Bicep into an editor not using the Bicep language");
+      }
+
+      const result = await this.callDecompileForPaste(
+        clipboardText,
+        false /* queryCanPaste */
       );
-    }
 
-    await editor.edit((builder) => {
-      builder.replace(editor.selection, result.bicep ?? "");
-    });
+      if (!result.pasteType) {
+        throw new Error(
+          `The clipboard text does not appear to be valid JSON or is not in a format that can be pasted as Bicep.`
+        );
+      }
+
+      if (result.errorMessage) {
+        context.errorHandling.issueProperties.clipboardText = clipboardText;
+        throw new Error(
+          `Could not paste clipboard text as Bicep: ${result.errorMessage}`
+        );
+      }
+
+      finalPastedBicep = result.bicep;
+      await editor.edit((builder) => {
+        builder.replace(editor.selection, result.bicep ?? "");
+      });
+    } catch (err) {
+      getLogger().debug(
+        `${logPrefix}: Exception occurred: ${parseError(err).message}"`
+      );
+      throw err;
+    } finally {
+      this.logPasteCompletion(logPrefix, clipboardText, finalPastedBicep);
+    }
   }
 
   public registerForPasteEvents(extension: Disposable) {
@@ -132,6 +148,8 @@ export class PasteAsBicepCommand implements Command {
   private async onDidChangeTextDocument(
     e: TextDocumentChangeEvent
   ): Promise<void> {
+    const logPrefix = "PasteAsBicep (copy/paste)";
+
     await callWithTelemetryAndErrorHandling(
       "autoPasteAsBicep",
       async (context) => {
@@ -141,10 +159,11 @@ export class PasteAsBicepCommand implements Command {
           return;
         }
 
+        const editor = window.activeTextEditor;
         if (
           e.reason !== TextDocumentChangeReason.Redo &&
           e.reason !== TextDocumentChangeReason.Undo &&
-          e.document === window.activeTextEditor?.document &&
+          e.document === editor?.document &&
           e.document.languageId === bicepLanguageId &&
           e.contentChanges.length === 1
         ) {
@@ -166,90 +185,108 @@ export class PasteAsBicepCommand implements Command {
             !isEmptyOrWhitespace(clipboardText) && // ... non-trivial changes only
             areEqualIgnoringWhitespace(clipboardText, contentChange.text)
           ) {
-            // See if we can paste this text as Bicep
-            const canPasteResult = await this.callDecompileForPaste(
-              clipboardText,
-              true // queryCanPaste
-            );
-            if (!canPasteResult.pasteType) {
-              // Nothing we know how to convert
-              return;
-            }
+            let finalPastedBicep: string | undefined;
 
-            context.telemetry.suppressIfSuccessful = false;
-            context.telemetry.properties.pasteType = canPasteResult.pasteType;
-            context.telemetry.properties.decompileId =
-              canPasteResult.decompileId;
-            context.telemetry.properties.jsonSize = String(
-              clipboardText.length
-            );
-
-            if (canPasteResult.pasteType === "bicepValue") {
-              // If the input was already a valid Bicep expression (i.e., the conversion looks the same as the original, once formatting
-              //   changes are ignored), then skip the conversion, otherwise the user will see formatting changes when copying Bicep values
-              //   to Bicep (e.g. [1] would get changed to a multi-line array).
-              // This will mainly happen with single-line arrays and objects, especially since the Newtonsoft parser accepts input that is
-              //   JavaScript but not technically JSON, such as '{ abc: 1, def: 'def' }, but which also happens to be valid Bicep.
-              return;
-            }
-
-            if (canPasteResult.errorMessage || !canPasteResult.bicep) {
-              // If we should be able to convert but there were errors in the JSON, show a message to the output window
-              this.outputChannelManager.appendToOutputChannel(
-                canPasteResult.output
+            try {
+              // See if we can paste this text as Bicep
+              const canPasteResult = await this.callDecompileForPaste(
+                clipboardText,
+                true // queryCanPaste
               );
-              this.outputChannelManager.appendToOutputChannel(
-                `Could not convert pasted text into Bicep: ${canPasteResult.errorMessage}`
+              if (!canPasteResult.pasteType) {
+                getLogger().debug(`${logPrefix}: pasteType empty`);
+                return;
+              }
+
+              context.telemetry.suppressIfSuccessful = false;
+
+              if (canPasteResult.pasteType === "bicepValue") {
+                // If the input was already a valid Bicep expression (i.e., the conversion looks the same as the original, once formatting
+                //   changes are ignored), then skip the conversion, otherwise the user will see formatting changes when copying Bicep values
+                //   to Bicep (e.g. [1] would get changed to a multi-line array).
+                // This will mainly happen with single-line arrays and objects, especially since the Newtonsoft parser accepts input that is
+                //   JavaScript but not technically JSON, such as '{ abc: 1, def: 'def' }, but which also happens to be valid Bicep.
+                getLogger().debug(`${logPrefix}: Already bicep`);
+                return;
+              }
+
+              if (canPasteResult.errorMessage || !canPasteResult.bicep) {
+                // If we should be able to convert but there were errors in the JSON, show a message to the output window
+                this.outputChannelManager.appendToOutputChannel(
+                  canPasteResult.output
+                );
+                const msg = `Could not convert pasted text into Bicep: ${canPasteResult.errorMessage}`;
+                this.outputChannelManager.appendToOutputChannel(msg);
+
+                getLogger().debug(`${logPrefix}: ${msg}`);
+
+                // ... and register telemetry for the failure (don't show the error to the user again)
+                context.telemetry.maskEntireErrorMessage = true;
+                context.errorHandling.suppressDisplay = true;
+                throw new Error("Decompile error");
+              }
+
+              context.telemetry.properties.bicepSize = String(
+                canPasteResult.bicep.length
               );
 
-              // ... and register telemetry for the failure (don't show the error to the user again)
-              context.telemetry.maskEntireErrorMessage = true;
-              context.errorHandling.suppressDisplay = true;
-              throw new Error("Decompile error");
-            }
+              // While we were awaiting async calls, the pasted text may have been formatted in the editor, get the new version
+              const formattedPastedText = getTextAfterFormattingChanges(
+                contentChange.text,     
+                e.document.getText(),
+                contentChange.rangeOffset
+              );
+              if (!formattedPastedText) {
+                getLogger().debug(
+                  `${logPrefix}: Couldn't get pasted text after editor formatted it`
+                );
+                return;
+              }
+              if (
+                !formattedPastedText ||
+                !areEqualIgnoringWhitespace(formattedPastedText, clipboardText)
+              ) {
+                // Some other editor change must have happened, abort the conversion to Bicep
+                context.errorHandling.suppressDisplay = true;
+                throw new Error("Editor changed");
+              }
 
-            context.telemetry.properties.bicepSize = String(
-              canPasteResult.bicep.length
-            );
+              // All systems go - replace pasted JSON with Bicep
+              const edit = new WorkspaceEdit();
+              const rangeOfFormattedPastedText = new Range(
+                e.document.positionAt(contentChange.rangeOffset),
+                e.document.positionAt(
+                  contentChange.rangeOffset + formattedPastedText.length
+                )
+              );
+              edit.replace(
+                e.document.uri,
+                rangeOfFormattedPastedText,
+                canPasteResult.bicep
+              );
+              const success = await workspace.applyEdit(edit);
+              if (!success) {
+                throw new Error(
+                  "Applying edit failed while converting pasted JSON to Bicep"
+                );
+              }
 
-            // While we were awaiting async calls, the pasted text may have been formatted in the editor.
-            // Need to figure out the length of the formatted text so we can properly replace it.
-            const formattedPastedText = getTextAfterFormattingChanges(
-              contentChange.text,
-              e.document.getText(),
-              contentChange.rangeOffset
-            );
-            if (
-              !formattedPastedText ||
-              !areEqualIgnoringWhitespace(formattedPastedText, clipboardText)
-            ) {
-              // Some other editor change must have happened, abort the conversion to Bicep
-              context.errorHandling.suppressDisplay = true;
-              throw new Error("Editor changed");
-            }
+              // Don't wait for disclaimer/warning because our telemetry won't fire until we return
+              void this.showWarning(context, canPasteResult);
 
-            // All systems go - replace pasted JSON with Bicep
-            const edit = new WorkspaceEdit();
-            const rangeOfFormattedPastedText = new Range(
-              e.document.positionAt(contentChange.rangeOffset),
-              e.document.positionAt(
-                contentChange.rangeOffset + formattedPastedText.length
-              )
-            );
-            edit.replace(
-              e.document.uri,
-              rangeOfFormattedPastedText,
-              canPasteResult.bicep
-            );
-            const success = await workspace.applyEdit(edit);
-            if (!success) {
-              throw new Error(
-                "Applying edit failed while converting pasted JSON to Bicep"
+              finalPastedBicep = canPasteResult.bicep;
+            } catch (err) {
+              getLogger().debug(
+                `${logPrefix}: Exception occurred: ${parseError(err).message}"`
+              );
+              throw err;
+            } finally {
+              this.logPasteCompletion(
+                logPrefix,
+                clipboardText,
+                finalPastedBicep
               );
             }
-
-            // Don't wait for disclaimer/warning because our telemetry won't fire until we return
-            void this.showWarning(context, canPasteResult);
           }
         }
       }
@@ -319,5 +356,20 @@ export class PasteAsBicepCommand implements Command {
         `Automatic decompile on paste has been disabled. You can turn it back on at any time from VS Code settings (${SuppressedWarningsManager.keys.decompileOnPasteWarning}). You can also still use the "Paste as Bicep" command from the command palette.`
       );
     }
+  }
+
+  // This allows our test code to know when a paste operation has been completed (in the case of handling CTRL+C/V)
+  private logPasteCompletion(
+    prefix: string,
+    clipboardText: string | undefined,
+    bicepText: string | undefined
+  ): void {
+    function format(s: string | undefined): string {
+      return typeof s === "string" ? `"${s}"` : "undefined";
+    }
+
+    getLogger().debug(
+      `${prefix}: Result: ${format(clipboardText)} -> ${format(bicepText)}`
+    );
   }
 }

--- a/src/vscode-bicep/src/test/e2e/commands.ts
+++ b/src/vscode-bicep/src/test/e2e/commands.ts
@@ -98,3 +98,18 @@ export async function executeForceModulesRestoreCommand(
     documentUri
   );
 }
+
+export async function executePasteAsBicepCommand(
+  documentUri: vscode.Uri
+): Promise<void> {
+  return await vscode.commands.executeCommand(
+    "bicep.pasteAsBicep",
+    documentUri
+  );
+}
+
+export async function executeEditorPaste(): Promise<void> {
+  return await vscode.commands.executeCommand(
+    "editor.action.clipboardPasteAction"
+  );
+}

--- a/src/vscode-bicep/src/test/e2e/commands.ts
+++ b/src/vscode-bicep/src/test/e2e/commands.ts
@@ -108,7 +108,7 @@ export async function executePasteAsBicepCommand(
   );
 }
 
-export async function executeEditorPaste(): Promise<void> {
+export async function executeEditorPasteCommand(): Promise<void> {
   return await vscode.commands.executeCommand(
     "editor.action.clipboardPasteAction"
   );

--- a/src/vscode-bicep/src/test/e2e/pasteAsBicep.test.ts
+++ b/src/vscode-bicep/src/test/e2e/pasteAsBicep.test.ts
@@ -1,13 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import vscode, { ConfigurationTarget } from "vscode";
-import { executeCloseAllEditors } from "./commands";
+/* eslint-disable jest/expect-expect */
+
+import vscode, { ConfigurationTarget, Selection, TextDocument } from "vscode";
+import {
+  executeCloseAllEditors,
+  executeEditorPaste,
+  executePasteAsBicepCommand,
+} from "./commands";
 import { getBicepConfiguration } from "../../language/getBicepConfiguration";
-import { until } from "../utils/time";
 import { normalizeMultilineString } from "../utils/normalizeMultilineString";
 import { SuppressedWarningsManager } from "../../commands/SuppressedWarningsManager";
 import { bicepConfigurationKeys } from "../../language/constants";
+import assert from "assert";
+import { until } from "../utils/time";
+import * as fse from "fs-extra";
+import * as path from "path";
+import { e2eLogName } from "../../utils/logger";
+
+const extensionLogPath = path.join(__dirname, `../../../${e2eLogName}`);
 
 describe("pasteAsBicep", (): void => {
   afterEach(async () => {
@@ -30,8 +42,225 @@ describe("pasteAsBicep", (): void => {
     );
   }
 
+  function getTextAndMarkers(
+    s: string
+  ): [text: string, markerOffset: number, markerLength: number] {
+    const offset = s.indexOf("|");
+    assert(offset >= 0, "Couldn't find marker in text");
+
+    s = s.slice(0, offset) + s.slice(offset + 1);
+
+    let length = 0;
+    const offset2 = s.indexOf("|");
+    if (offset2 >= 0) {
+      length = offset2 - offset;
+      s = s.slice(0, offset2) + s.slice(offset2 + 1);
+    }
+
+    expect(s).not.toContain("|");
+
+    return [s, offset, length];
+  }
+
+  function setSelection(
+    document: TextDocument,
+    offsetStart: number,
+    offsetLength: number
+  ): void {
+    const start = document.positionAt(offsetStart);
+    const end = document.positionAt(offsetStart + offsetLength);
+    const activeTextEditor = vscode.window.activeTextEditor;
+    assert(activeTextEditor, "No active text editor");
+    activeTextEditor.selection = new Selection(start, end);
+  }
+
+  async function runTest(
+    initialBicepWithMarker: string,
+    jsonToPaste: string,
+    action: "command" | "copy/paste",
+    expected: {
+      bicep?: string;
+      error?: string;
+    }
+  ): Promise<{ log: string }> {
+    const initialLogContentsLength = fse
+      .readFileSync(extensionLogPath)
+      .toString().length;
+
+    await configureSettings();
+
+    const [initialBicep, offsetStart, offsetLength] = getTextAndMarkers(
+      initialBicepWithMarker
+    );
+    const textDocument = await vscode.workspace.openTextDocument({
+      language: "bicep",
+      content: initialBicep,
+    });
+    const editor = await vscode.window.showTextDocument(textDocument);
+
+    setSelection(textDocument, offsetStart, offsetLength);
+
+    await vscode.env.clipboard.writeText(jsonToPaste);
+
+    if (action === "copy/paste") {
+      await executeEditorPaste();
+
+      const expected = `PasteAsBicep (command): Result: "${jsonToPaste}"`;
+      await waitForPasteAsBicep(expected);
+    } else {
+      await executePasteAsBicepCommand(editor.document.uri);
+
+      const expected = `PasteAsBicep (copy/paste): Result: "${jsonToPaste}"`;
+      await waitForPasteAsBicep(expected);
+    }
+    if (expected.error) {
+      const match = new RegExp(
+        `Exception occurred: .*${escapeRegexReplacement(expected.error)}`
+      );
+      expect(getRecentLogContents()).toMatch(match);
+    } else {
+      expect(getRecentLogContents()).not.toMatch(`Exception occurred`);
+    }
+
+    const buffer = textDocument.getText();
+
+    if (typeof expected.bicep === "string") {
+      expect(normalizeMultilineString(buffer)).toBe(
+        normalizeMultilineString(expected.bicep)
+      );
+    }
+
+    return { log: getRecentLogContents() };
+
+    function getRecentLogContents() {
+      const logContents = fse
+        .readFileSync(extensionLogPath)
+        .toString()
+        .substring(initialLogContentsLength);
+      return logContents;
+    }
+
+    async function waitForPasteAsBicep(
+      expectedSubstring: string
+    ): Promise<void> {
+      await until(() => isReady(), {
+        interval: 100,
+        timeoutMs: 4000,
+      });
+      if (!isReady()) {
+        throw new Error(
+          `Expected paste as bicep command to complete. Expected following string in log: "${expectedSubstring}".\nRecent log contents: ${getRecentLogContents()}`
+        );
+      }
+
+      function isReady(): boolean {
+        const readyMessage = jsonToPaste;
+        const logContents = getRecentLogContents();
+        return logContents.indexOf(readyMessage) >= 0;
+      }
+    }
+  }
+
+  function escapeRegexReplacement(s: string) {
+    return s.replace(/\$/g, "$$$$");
+  }
+
+  //////////////////////////////////////////////////
+
+  const fullTemplate1 = `
+  {
+      "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+          "location": {
+              "type": "string"
+          },
+          "existingVirtualMachineNames": {
+              "type": "array"
+          },
+          "sqlServerLicenseType": {
+              "type": "string"
+          },
+          "existingVmResourceGroup": {
+              "type": "string"
+          },
+          "groupResourceId": {
+              "type": "string"
+          },
+          "domainAccountPassword": {
+              "type": "securestring"
+          },
+          "sqlServicePassword": {
+              "type": "securestring"
+          }
+      },
+      "variables": {
+      },
+      "resources": [
+          {
+              "name": "[trim(parameters('existingVirtualMachineNames')[copyIndex()])]",
+              "type": "Microsoft.SqlVirtualMachine/SqlVirtualMachines",
+              "apiVersion": "2017-03-01-preview",
+              "location": "[parameters('location')]",
+              "copy": {
+                  "name": "vmToClusterLoop",
+                  "count": "[length(parameters('existingVirtualMachineNames'))]"
+              },
+              "properties": {
+                  "virtualMachineResourceId": "[resourceId(parameters('existingVmResourceGroup'),'Microsoft.Compute/virtualMachines', trim(parameters('existingVirtualMachineNames')[copyIndex()]))]",
+                  "sqlServerLicenseType": "[parameters('sqlServerLicenseType')]",
+                  "SqlVirtualMachineGroupResourceId": "[parameters('groupResourceId')]",
+                  "WSFCDomainCredentials": {
+                      "ClusterBootstrapAccountPassword": "[parameters('domainAccountPassword')]",
+                      "ClusterOperatorAccountPassword": "[parameters('domainAccountPassword')]",
+                      "SqlServiceAccountPassword": "[parameters('sqlServicePassword')]"
+                  }
+              }
+          }
+      ]
+  }`;
+
+  const fullTemplateExpectedBicep = `param location string
+param existingVirtualMachineNames array
+param sqlServerLicenseType string
+param existingVmResourceGroup string
+param groupResourceId string
+
+@secure()
+param domainAccountPassword string
+
+@secure()
+param sqlServicePassword string
+
+resource existingVirtualMachineNames_resource 'Microsoft.SqlVirtualMachine/SqlVirtualMachines@2017-03-01-preview' = [for item in existingVirtualMachineNames: {
+  name: trim(item)
+  location: location
+  properties: {
+    virtualMachineResourceId: resourceId(existingVmResourceGroup, 'Microsoft.Compute/virtualMachines', trim(item))
+    sqlServerLicenseType: sqlServerLicenseType
+    sqlVirtualMachineGroupResourceId: groupResourceId
+    wsfcDomainCredentials: {
+      clusterBootstrapAccountPassword: domainAccountPassword
+      clusterOperatorAccountPassword: domainAccountPassword
+      sqlServiceAccountPassword: sqlServicePassword
+    }
+  }
+}]`;
+
+  it("should convert pasted full ARM template - copy/paste", async () => {
+    await runTest(`|`, fullTemplate1, "copy/paste", {
+      bicep: fullTemplateExpectedBicep,
+    });
+  });
+
+  it("should convert pasted full ARM template - paste command", async () => {
+    await runTest(`|`, fullTemplate1, "command", {
+      bicep: fullTemplateExpectedBicep,
+    });
+  });
+
   it("should convert pasted list of resources", async () => {
-    const json = `
+    const jsonToPaste = `
 {
   "type": "Microsoft.Storage/storageAccounts",
   "apiVersion": "2021-02-01",
@@ -76,7 +305,6 @@ describe("pasteAsBicep", (): void => {
 }
 ,`;
 
-    const waitfor = "resource stg1";
     const expected = `resource stg1 'Microsoft.Storage/storageAccounts@2021-02-01' = {
   name: 'stg1'
   location: location2
@@ -120,28 +348,46 @@ resource aksCluster1 'Microsoft.ContainerService/managedClusters@2021-05-01' = {
 // My bicep file
 `;
 
-    await configureSettings();
-
-    const textDocument = await vscode.workspace.openTextDocument({
-      language: "bicep",
-      content: "// My bicep file\n",
+    await runTest(`|// My bicep file\n`, jsonToPaste, "copy/paste", {
+      bicep: expected,
     });
-    await vscode.window.showTextDocument(textDocument);
+  });
 
-    await vscode.env.clipboard.writeText(json);
-    await vscode.commands.executeCommand("editor.action.clipboardPasteAction");
+  //////////////////////////////////////////////////
 
-    try {
-      await until(() => textDocument.getText().includes(waitfor), {
-        timeoutMs: 10000,
-      });
-    } catch (err) {
-      throw "Timeout.  Editor text: " + textDocument.getText();
-    }
-    const buffer = textDocument.getText();
+  it("should decompile if copy/pasting outside string", async () => {
+    const bicep = `var v = |`;
+    const jsonToPaste = `"Mom says 'hi'"`;
+    const expected = `var v = 'Mom says \\'hi\\''`;
 
-    expect(normalizeMultilineString(buffer)).toBe(
-      normalizeMultilineString(expected)
-    );
+    await runTest(bicep, jsonToPaste, "copy/paste", { bicep: expected });
+  });
+
+  it("should handle non-empty selection inside and outside of a string (using context of first part of selection)", async () => {
+    const bicep = `resource loadBalancerPublicIPAddress 'Microsoft.Network/publicIPAddresses@2020-11-01' = {
+  name: 'loadBalancerName'
+  |location: 'location|'
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'static'
+  }
+}
+`;
+    const jsonToPaste = `"hello"`;
+    const expected = `resource loadBalancerPublicIPAddress 'Microsoft.Network/publicIPAddresses@2020-11-01' = {
+  name: 'loadBalancerName'
+  'hello''
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'static'
+  }
+}
+`;
+
+    await runTest(bicep, jsonToPaste, "command", { bicep: expected });
   });
 });

--- a/src/vscode-bicep/src/test/e2e/pasteAsBicep.test.ts
+++ b/src/vscode-bicep/src/test/e2e/pasteAsBicep.test.ts
@@ -6,7 +6,7 @@
 import vscode, { ConfigurationTarget, Selection, TextDocument } from "vscode";
 import {
   executeCloseAllEditors,
-  executeEditorPaste,
+  executeEditorPasteCommand,
   executePasteAsBicepCommand,
 } from "./commands";
 import { getBicepConfiguration } from "../../language/getBicepConfiguration";
@@ -103,7 +103,7 @@ describe("pasteAsBicep", (): void => {
     await vscode.env.clipboard.writeText(jsonToPaste);
 
     if (action === "copy/paste") {
-      await executeEditorPaste();
+      await executeEditorPasteCommand();
 
       const expected = `PasteAsBicep (command): Result: "${jsonToPaste}"`;
       await waitForPasteAsBicep(expected);

--- a/src/vscode-bicep/src/test/e2e/visualizer.test.ts
+++ b/src/vscode-bicep/src/test/e2e/visualizer.test.ts
@@ -4,6 +4,7 @@
 import fs from "fs";
 import path from "path";
 import vscode from "vscode";
+import { e2eLogName } from "../../utils/logger";
 import { sleep } from "../../utils/time";
 
 import { expectDefined } from "../utils/assert";
@@ -16,7 +17,7 @@ import {
 } from "./commands";
 import { resolveExamplePath } from "./examples";
 
-const extensionLogPath = path.join(__dirname, "../../../bicep.log");
+const extensionLogPath = path.join(__dirname, `../../../${e2eLogName}`);
 
 describe("visualizer", (): void => {
   afterEach(executeCloseAllEditors);

--- a/src/vscode-bicep/src/utils/logger.ts
+++ b/src/vscode-bicep/src/utils/logger.ts
@@ -6,6 +6,12 @@ import Transport from "winston-transport";
 import * as path from "path";
 import { MESSAGE } from "triple-beam";
 
+/**
+ * This logfile is written during to E2E tests. It serves as a way to watch for events from the code
+ * while running inside the tests, since simple in-memory sharing won't work.
+ */
+export const e2eLogName = "bicep-e2e.log";
+
 export interface Logger extends vscode.Disposable {
   debug(message: string): void;
   info(message: string): void;
@@ -40,7 +46,7 @@ export class WinstonLogger implements Logger {
           ? [
               new winston.transports.File({
                 dirname: path.resolve(__dirname, ".."),
-                filename: "bicep.log",
+                filename: e2eLogName,
                 options: { flags: "w" },
               }),
             ]


### PR DESCRIPTION
This code was necessary before adding the fix for #9996 

Before, there was no way to know when a copy/paste operation was done except by looking for some expected text in the buffer.  This version uses the e2e logfile to figure this out more definitively.  Plus adds a couple more tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10103)