### PR TITLE
Fix dependabot-update-dotnet-lockfiles.yml

### DIFF
--- a/.github/workflows/dependabot-update-dotnet-lockfiles.yml
+++ b/.github/workflows/dependabot-update-dotnet-lockfiles.yml
@@ -1,8 +1,7 @@
 name: 'Dependabot: Update Dotnet Lockfiles'
 on: 
   pull_request:
-    branches:
-      - 'dependabot/nuget/**'
+    branches: [main]
     types:
       - opened
       - reopened
@@ -13,7 +12,7 @@ on:
 jobs:
   update-dotnet-lockfiles:
     name: Update Dotnet Lockfiles
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, '.NET') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Fixed the target branch to be `main` and updated the `if` check to only run the action for `.NET` dependencies

Validated on my fork:
![image](https://user-images.githubusercontent.com/38542602/225056945-541953de-a26f-4f31-a6f4-d4ecb2eebf75.png)
