### PR TITLE
Update TypeHelper.TryCollapseTypes to handle refinements

### DIFF
--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -622,6 +622,13 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 CreateRow(TypeFactory.CreateIntegerType(0, null), LanguageConstants.Int, TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(0), null, null)),
                 CreateRow(LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateArrayType(LanguageConstants.Int, 10, 10)),
                 CreateRow(LanguageConstants.Int, TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateArrayType(LanguageConstants.Int, 10, 20)),
+
+                CreateRow(TypeHelper.CreateTypeUnion(TypeFactory.CreateIntegerType(-100, 1), TypeFactory.CreateIntegerType(-1, 100), TypeFactory.CreateIntegerLiteralType(0)),
+                    TypeFactory.CreateIntegerLiteralType(10),
+                    TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(-100, 109), 10, 10)),
+                CreateRow(TypeFactory.CreateIntegerLiteralType(10),
+                    TypeHelper.CreateTypeUnion(TypeFactory.CreateIntegerType(0, 11), TypeFactory.CreateIntegerType(19, 30), TypeFactory.CreateIntegerType(9, 20), TypeFactory.CreateIntegerLiteralType(10)),
+                    TypeFactory.CreateArrayType(TypeFactory.CreateIntegerType(10, 39), 0, 30)),
             };
         }
 

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeHelperTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeHelperTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Extensions;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests.Assertions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.TypeSystem;
+
+[TestClass]
+public class TypeHelperTests
+{
+    [DataTestMethod]
+    [DynamicData(nameof(GetPrimitiveCollapsePositiveTestCases), DynamicDataSourceType.Method)]
+    public void Primitive_collapse_preserves_and_fuses_refinements(TypeSymbol expected, params TypeSymbol[] toCollapse)
+    {
+        var actual = TypeHelper.TryCollapseTypes(toCollapse);
+        actual.Should().Be(expected);
+    }
+
+    private static IEnumerable<object[]> GetPrimitiveCollapsePositiveTestCases()
+    {
+        static object[] Row(TypeSymbol expected, params TypeSymbol[] toCollapse)
+            => expected.AsEnumerable().Concat(toCollapse).ToArray();
+
+        // In the explanatory comments for test cases, the `{inclusiveMin,inclusiveMax}` suffix is used to denote length constraints
+        return new[]
+        {
+            // collapse(true, false) -> bool
+            Row(LanguageConstants.Bool, LanguageConstants.True, LanguageConstants.False),
+            // collapse(bool, false) -> bool
+            Row(LanguageConstants.Bool, LanguageConstants.Bool, LanguageConstants.False),
+            // collapse(true, bool) -> bool
+            Row(LanguageConstants.Bool, LanguageConstants.True, LanguageConstants.Bool),
+            // collapse(true, false, null) -> bool?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.Bool, LanguageConstants.Null), LanguageConstants.True, LanguageConstants.False, LanguageConstants.Null),
+            // collapse(null, true, false) -> bool?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.Bool, LanguageConstants.Null), LanguageConstants.Null, LanguageConstants.True, LanguageConstants.False),
+
+            // collapse(<= 10, >= 9) -> int
+            Row(LanguageConstants.Int, TypeFactory.CreateIntegerType(minValue: null, maxValue: 10), TypeFactory.CreateIntegerType(minValue: 9, maxValue: null)),
+            // collapse(<= 10, >= 9, null) -> int?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.Int, LanguageConstants.Null), TypeFactory.CreateIntegerType(minValue: null, maxValue: 10), TypeFactory.CreateIntegerType(minValue: 9, maxValue: null), LanguageConstants.Null),
+            // collapse(null, <= 10, >= 9) -> int?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.Int, LanguageConstants.Null), LanguageConstants.Null, TypeFactory.CreateIntegerType(minValue: null, maxValue: 10), TypeFactory.CreateIntegerType(minValue: 9, maxValue: null)),
+            // collapse(<= 10, >= 9, 10) -> int
+            Row(LanguageConstants.Int, TypeFactory.CreateIntegerType(minValue: null, maxValue: 10), TypeFactory.CreateIntegerType(minValue: 9, maxValue: null), TypeFactory.CreateIntegerLiteralType(10)),
+            // collapse(<= 10, 10) -> <= 10
+            Row(TypeFactory.CreateIntegerType(minValue: null, maxValue: 10), TypeFactory.CreateIntegerType(minValue: null, maxValue: 10), TypeFactory.CreateIntegerLiteralType(10)),
+            // collapse(>= 7 && <= 9, 8) -> >= 7 && <= 9
+            Row(TypeFactory.CreateIntegerType(minValue: 7, maxValue: 9), TypeFactory.CreateIntegerType(minValue: 7, maxValue: 9), TypeFactory.CreateIntegerLiteralType(8)),
+            // collapse(>= 7 && <= 8, >= 8 && <= 9) -> >= 7 && <= 9
+            Row(TypeFactory.CreateIntegerType(minValue: 7, maxValue: 9), TypeFactory.CreateIntegerType(minValue: 7, maxValue: 8), TypeFactory.CreateIntegerType(minValue: 8, maxValue: 9)),
+            // collapse(7, 8, 9) -> >= 7 && <= 9
+            Row(TypeFactory.CreateIntegerType(minValue: 7, maxValue: 9), TypeFactory.CreateIntegerLiteralType(7), TypeFactory.CreateIntegerLiteralType(8), TypeFactory.CreateIntegerLiteralType(9)),
+            // collapse(5, 7, >= 1 && <= 3, 8, >= 2 && <= 4, 9) -> union(>= 1 && <= 5, >= 7 && <= 9)
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateIntegerType(minValue: 1, maxValue: 5), TypeFactory.CreateIntegerType(minValue: 7, maxValue: 9)),
+                TypeFactory.CreateIntegerLiteralType(5),
+                TypeFactory.CreateIntegerLiteralType(7),
+                TypeFactory.CreateIntegerType(1, 3),
+                TypeFactory.CreateIntegerLiteralType(8),
+                TypeFactory.CreateIntegerType(2, 4),
+                TypeFactory.CreateIntegerLiteralType(9)),
+
+            // collapse(string{null,10}, string{9,null}) -> string
+            Row(LanguageConstants.String, TypeFactory.CreateStringType(minLength: null, maxLength: 10), TypeFactory.CreateStringType(minLength: 9, maxLength: null)),
+            // collapse(string{null,10}, string{9,null}, null) -> string?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Null), TypeFactory.CreateStringType(minLength: null, maxLength: 10), TypeFactory.CreateStringType(minLength: 9, maxLength: null), LanguageConstants.Null),
+            // collapse(null, string{null,10}, string{9,null}) -> string?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Null), LanguageConstants.Null, TypeFactory.CreateStringType(minLength: null, maxLength: 10), TypeFactory.CreateStringType(minLength: 9, maxLength: null)),
+            // collapse(string{null,10}, string{9,null}, '10 letters') -> string
+            Row(LanguageConstants.String, TypeFactory.CreateStringType(minLength: null, maxLength: 10), TypeFactory.CreateStringType(minLength: 9, maxLength: null), TypeFactory.CreateStringLiteralType("10 letters")),
+            // collapse(string{null,10}, '10 letters') -> string{null,10}
+            Row(TypeFactory.CreateStringType(minLength: null, maxLength: 10), TypeFactory.CreateStringType(minLength: null, maxLength: 10), TypeFactory.CreateStringLiteralType("10 letters")),
+            // collapse(string{9,11}, '10 letters') -> string{9,11}
+            Row(TypeFactory.CreateStringType(minLength: 9, maxLength: 11), TypeFactory.CreateStringType(minLength: 9, maxLength: 11), TypeFactory.CreateStringLiteralType("10 letters")),
+            // collapse(string{9,11}, '10 letters', '13 characters') -> union(string{9,11}, '13 characters')
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateStringType(minLength: 9, maxLength: 11), TypeFactory.CreateStringLiteralType("13 characters")),
+                TypeFactory.CreateStringType(minLength: 9, maxLength: 11),
+                TypeFactory.CreateStringLiteralType("10 letters"),
+                TypeFactory.CreateStringLiteralType("13 characters")),
+            // collapse(string{6,7}, string{8,9}) -> string{6,9}
+            Row(TypeFactory.CreateStringType(minLength: 6, maxLength: 9), TypeFactory.CreateStringType(minLength: 6, maxLength: 7), TypeFactory.CreateStringType(minLength: 8, maxLength: 9)),
+            // collapse(string{6,7}, string{11,15}, string{8,9}) -> union(string{6,9}, string{11,15})
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateStringType(minLength: 6, maxLength: 9), TypeFactory.CreateStringType(minLength: 11, maxLength: 15)),
+                TypeFactory.CreateStringType(minLength: 6, maxLength: 7),
+                TypeFactory.CreateStringType(minLength: 11, maxLength: 15),
+                TypeFactory.CreateStringType(minLength: 8, maxLength: 9)),
+
+            // collapse(array{null,10}, array{9,null}) -> array
+            Row(LanguageConstants.Array, TypeFactory.CreateArrayType(minLength: null, maxLength: 10), TypeFactory.CreateArrayType(minLength: 9, maxLength: null)),
+            // collapse(array{null,10}, array{9,null}, null) -> array?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.Array, LanguageConstants.Null), TypeFactory.CreateArrayType(minLength: null, maxLength: 10), TypeFactory.CreateArrayType(minLength: 9, maxLength: null), LanguageConstants.Null),
+            // collapse(null, array{null,10}, array{9,null}) -> array?
+            Row(TypeHelper.CreateTypeUnion(LanguageConstants.Array, LanguageConstants.Null), LanguageConstants.Null, TypeFactory.CreateArrayType(minLength: null, maxLength: 10), TypeFactory.CreateArrayType(minLength: 9, maxLength: null)),
+            // collapse(array{6,7}, array{8,9}) -> array{6,9}
+            Row(TypeFactory.CreateArrayType(minLength: 6, maxLength: 9), TypeFactory.CreateArrayType(minLength: 6, maxLength: 7), TypeFactory.CreateArrayType(minLength: 8, maxLength: 9)),
+            // collapse(array{6,7}, array{11,15}, array{8,9}) -> union(array{6,9}, array{11,15})
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateArrayType(minLength: 6, maxLength: 9), TypeFactory.CreateArrayType(minLength: 11, maxLength: 15)),
+                TypeFactory.CreateArrayType(minLength: 6, maxLength: 7),
+                TypeFactory.CreateArrayType(minLength: 11, maxLength: 15),
+                TypeFactory.CreateArrayType(minLength: 8, maxLength: 9)),
+            // collapse(string[]{null,3}, int[]{100,null}, string[]{4,6}, int[]{5,99}) -> union(string[]{null,6}, int[]{5,null})
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateArrayType(LanguageConstants.String, minLength: null, maxLength: 6), TypeFactory.CreateArrayType(LanguageConstants.Int, minLength: 5, maxLength: null)),
+                TypeFactory.CreateArrayType(LanguageConstants.String, minLength: null, maxLength: 3),
+                TypeFactory.CreateArrayType(LanguageConstants.Int, minLength: 100, maxLength: null),
+                TypeFactory.CreateArrayType(LanguageConstants.String, minLength: 4, maxLength: 6),
+                TypeFactory.CreateArrayType(LanguageConstants.Int, minLength: 5, maxLength: 99)),
+            // collapse(array{6,7}, [string, int], array{8,9}) -> union(array{6,9}, [string, int])
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateArrayType(minLength: 6, maxLength: 9), new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.Int), default)),
+                TypeFactory.CreateArrayType(minLength: 6, maxLength: 7),
+                new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.Int), default),
+                TypeFactory.CreateArrayType(minLength: 8, maxLength: 9)),
+            // collapse(string[], [string, string, string]) -> string[]
+            Row(TypeFactory.CreateArrayType(LanguageConstants.String),
+                TypeFactory.CreateArrayType(LanguageConstants.String),
+                new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.String, LanguageConstants.String), default)),
+            // collapse(string[], [string, int, string]) -> union(string[], [string, int, string])
+            Row(TypeHelper.CreateTypeUnion(TypeFactory.CreateArrayType(LanguageConstants.String), new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.String), default)),
+                TypeFactory.CreateArrayType(LanguageConstants.String),
+                new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.String), default)),
+            // collapse((string | int)[], [string, int, string]) -> (string | int)[]
+            Row(TypeFactory.CreateArrayType(TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Int)),
+                TypeFactory.CreateArrayType(TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Int)),
+                new TupleType(ImmutableArray.Create<ITypeReference>(LanguageConstants.String, LanguageConstants.Int, LanguageConstants.String), default)),
+        };
+    }
+}

--- a/src/Bicep.Core/TypeSystem/TupleType.cs
+++ b/src/Bicep.Core/TypeSystem/TupleType.cs
@@ -33,7 +33,19 @@ public class TupleType : ArrayType
 
     public override bool Equals(object? other) => other is TupleType otherTuple && ValidationFlags == otherTuple.ValidationFlags && Items.SequenceEqual(otherTuple.Items);
 
-    public override int GetHashCode() => HashCode.Combine(TypeKind, Items, ValidationFlags);
+    public override int GetHashCode()
+    {
+        HashCode hashCode = new();
+
+        hashCode.Add(TypeKind);
+        hashCode.Add(ValidationFlags);
+        foreach (var item in Items)
+        {
+            hashCode.Add(item);
+        }
+
+        return hashCode.ToHashCode();
+    }
 
     private static string DeriveTupleName(ImmutableArray<ITypeReference> items)
     {

--- a/src/Bicep.Core/TypeSystem/TypeCollapser.cs
+++ b/src/Bicep.Core/TypeSystem/TypeCollapser.cs
@@ -63,8 +63,8 @@ internal static class TypeCollapser
                 BooleanType @bool => new BoolCollapse(@bool, nullable),
                 TupleType tuple => new ArrayCollapse(tuple, nullable),
                 ArrayType array => new ArrayCollapse(array, nullable),
-                AnyType => new CollapsesToAny(),
-                _ => new Uncollapsable(),
+                AnyType => CollapsesToAny.Instance,
+                _ => Uncollapsable.Instance,
             };
 
             private UnionCollapseState WithNullability()
@@ -124,9 +124,9 @@ internal static class TypeCollapser
                         nullable = true;
                         return this;
                     case AnyType:
-                        return new CollapsesToAny();
+                        return CollapsesToAny.Instance;
                     default:
-                        return new Uncollapsable();
+                        return Uncollapsable.Instance;
                 }
             }
         }
@@ -179,9 +179,9 @@ internal static class TypeCollapser
                         nullable = true;
                         return this;
                     case AnyType:
-                        return new CollapsesToAny();
+                        return CollapsesToAny.Instance;
                     default:
-                        return new Uncollapsable();
+                        return Uncollapsable.Instance;
                 }
             }
         }
@@ -241,9 +241,9 @@ internal static class TypeCollapser
                         nullable = true;
                         return this;
                     case AnyType:
-                        return new CollapsesToAny();
+                        return CollapsesToAny.Instance;
                     default:
-                        return new Uncollapsable();
+                        return Uncollapsable.Instance;
                 }
             }
         }
@@ -307,9 +307,9 @@ internal static class TypeCollapser
                         nullable = true;
                         return this;
                     case AnyType:
-                        return new CollapsesToAny();
+                        return CollapsesToAny.Instance;
                     default:
-                        return new Uncollapsable();
+                        return Uncollapsable.Instance;
                 }
             }
 
@@ -331,6 +331,10 @@ internal static class TypeCollapser
 
         private class CollapsesToAny : UnionCollapseState
         {
+            private CollapsesToAny() {}
+
+            internal static readonly CollapsesToAny Instance = new();
+
             public TypeSymbol? Collapse() => LanguageConstants.Any;
 
             public UnionCollapseState Push(ITypeReference _) => this;
@@ -338,6 +342,10 @@ internal static class TypeCollapser
 
         private class Uncollapsable : UnionCollapseState
         {
+            private Uncollapsable() {}
+
+            internal static readonly Uncollapsable Instance = new();
+
             public TypeSymbol? Collapse() => null;
 
             public UnionCollapseState Push(ITypeReference _) => this;

--- a/src/Bicep.Core/TypeSystem/TypeCollapser.cs
+++ b/src/Bicep.Core/TypeSystem/TypeCollapser.cs
@@ -1,0 +1,391 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Bicep.Core.Extensions;
+
+namespace Bicep.Core.TypeSystem;
+
+internal static class TypeCollapser
+{
+    internal static TypeSymbol? TryCollapse(TypeSymbol type) => type switch
+    {
+        // it doesn't really make sense to collapse 'never' or 'any'
+        _ when type.TypeKind == TypeKind.Never => null,
+        AnyType => null,
+        UnionType unionType => TryCollapse(unionType),
+        _ => type,
+    };
+
+    /// <remarks>
+    /// How and whether multiple types can be collapsed varies by type, so a finite state machine is used so that each
+    /// type can define its collapsing rules separately and we can choose which ruleset to use based on the first 1-2
+    /// union members.
+    /// </remarks>
+    private static TypeSymbol? TryCollapse(UnionType unionType)
+    {
+        var collapseState = UnionCollapseState.Initialize();
+        foreach (var member in unionType.Members)
+        {
+            collapseState = collapseState.Push(member);
+        }
+
+        return collapseState.Collapse();
+    }
+
+    private interface UnionCollapseState
+    {
+        UnionCollapseState Push(ITypeReference memberType);
+
+        TypeSymbol? Collapse();
+
+        public static UnionCollapseState Initialize() => new InitialState();
+
+        private static TypeSymbol CreateTypeUnion(IEnumerable<TypeSymbol> toUnion, bool nullable)
+            => TypeHelper.CreateTypeUnion(nullable ? toUnion.Append(LanguageConstants.Null) : toUnion);
+
+        private class InitialState : UnionCollapseState
+        {
+            private bool nullable = false;
+
+            public TypeSymbol? Collapse() => LanguageConstants.Never;
+
+            public UnionCollapseState Push(ITypeReference memberType) => memberType.Type switch
+            {
+                NullType => WithNullability(),
+                StringLiteralType stringLiteral => new StringCollapse(stringLiteral, nullable),
+                StringType @string => new StringCollapse(@string, nullable),
+                IntegerLiteralType intLiteral => new IntCollapse(intLiteral, nullable),
+                IntegerType @int => new IntCollapse(@int, nullable),
+                BooleanLiteralType boolLiteral => new BoolCollapse(boolLiteral, nullable),
+                BooleanType @bool => new BoolCollapse(@bool, nullable),
+                TupleType tuple => new ArrayCollapse(tuple, nullable),
+                ArrayType array => new ArrayCollapse(array, nullable),
+                AnyType => new CollapsesToAny(),
+                _ => new Uncollapsable(),
+            };
+
+            private UnionCollapseState WithNullability()
+            {
+                nullable = true;
+                return this;
+            }
+        }
+
+        private class StringCollapse : UnionCollapseState
+        {
+            private readonly RefinementSpanCollapser spanCollapser = new();
+            private readonly HashSet<StringLiteralType> stringLiterals = new();
+            private bool nullable;
+
+            internal StringCollapse(StringLiteralType stringLiteral, bool nullable)
+            {
+                stringLiterals.Add(stringLiteral);
+                this.nullable = nullable;
+            }
+
+            internal StringCollapse(StringType @string, bool nullable)
+            {
+                spanCollapser.PushSpan(RefinementSpan.For(@string));
+                this.nullable = nullable;
+            }
+
+            public TypeSymbol? Collapse() => CreateTypeUnion(
+                // only keep string literals that are not valid in any of the discrete spans
+                stringLiterals.Where(literal => !spanCollapser.Spans.Any(s => s.Contains(literal.RawStringValue.Length)))
+                    // create a refined string type for each span
+                    .Concat(spanCollapser.Spans.Select(span => TypeFactory.CreateStringType(
+                        span.Min switch
+                        {
+                            <= 0 => null,
+                            long otherwise => otherwise,
+                        },
+                        span.Max switch
+                        {
+                            long.MaxValue => null,
+                            long otherwise => otherwise,
+                        },
+                        span.Flags))),
+                nullable);
+
+            public UnionCollapseState Push(ITypeReference memberType)
+            {
+                switch (memberType.Type)
+                {
+                    case StringLiteralType literal:
+                        stringLiterals.Add(literal);
+                        return this;
+                    case StringType @string:
+                        spanCollapser.PushSpan(RefinementSpan.For(@string));
+                        return this;
+                    case NullType:
+                        nullable = true;
+                        return this;
+                    case AnyType:
+                        return new CollapsesToAny();
+                    default:
+                        return new Uncollapsable();
+                }
+            }
+        }
+
+        private class IntCollapse : UnionCollapseState
+        {
+            private readonly RefinementSpanCollapser spanCollapser = new();
+            private bool nullable;
+
+            internal IntCollapse(IntegerLiteralType integerLiteral, bool nullable)
+            {
+                spanCollapser.PushSpan(RefinementSpan.For(integerLiteral));
+                this.nullable = nullable;
+            }
+
+            internal IntCollapse(IntegerType @int, bool nullable)
+            {
+                spanCollapser.PushSpan(RefinementSpan.For(@int));
+                this.nullable = nullable;
+            }
+
+            public TypeSymbol? Collapse() => CreateTypeUnion(
+                spanCollapser.Spans.Select(span => span.Min == span.Max
+                    ? TypeFactory.CreateIntegerLiteralType(span.Min, span.Flags)
+                    : TypeFactory.CreateIntegerType(
+                        span.Min switch
+                        {
+                            long.MinValue => null,
+                            long otherwise => otherwise,
+                        },
+                        span.Max switch
+                        {
+                            long.MaxValue => null,
+                            long otherwise => otherwise,
+                        },
+                        span.Flags)),
+                nullable);
+
+            public UnionCollapseState Push(ITypeReference memberType)
+            {
+                switch (memberType.Type)
+                {
+                    case IntegerLiteralType literal:
+                        spanCollapser.PushSpan(RefinementSpan.For(literal));
+                        return this;
+                    case IntegerType @int:
+                        spanCollapser.PushSpan(RefinementSpan.For(@int));
+                        return this;
+                    case NullType:
+                        nullable = true;
+                        return this;
+                    case AnyType:
+                        return new CollapsesToAny();
+                    default:
+                        return new Uncollapsable();
+                }
+            }
+        }
+
+        private class BoolCollapse : UnionCollapseState
+        {
+            private bool includesTrue;
+            private bool includesFalse;
+            private TypeSymbolValidationFlags flags;
+            private bool nullable;
+
+            internal BoolCollapse(BooleanLiteralType literal, bool nullable)
+            {
+                includesTrue = literal.Value;
+                includesFalse = !literal.Value;
+                flags = literal.ValidationFlags;
+                this.nullable = nullable;
+            }
+
+            internal BoolCollapse(BooleanType @bool, bool nullable)
+            {
+                includesTrue = includesFalse = true;
+                flags = @bool.ValidationFlags;
+                this.nullable = nullable;
+            }
+
+            public TypeSymbol? Collapse()
+            {
+                TypeSymbol collapsed = includesTrue ^ includesFalse
+                    ? TypeFactory.CreateBooleanLiteralType(includesTrue, flags)
+                    : TypeFactory.CreateBooleanType(flags);
+
+                return nullable ? TypeHelper.CreateTypeUnion(new[] { collapsed, LanguageConstants.Null }) : collapsed;
+            }
+
+            public UnionCollapseState Push(ITypeReference memberType)
+            {
+                switch (memberType.Type)
+                {
+                    case BooleanLiteralType literal:
+                        if (literal.Value)
+                        {
+                            includesTrue = true;
+                        }
+                        else
+                        {
+                            includesFalse = true;
+                        }
+                        flags |= literal.ValidationFlags;
+                        return this;
+                    case BooleanType @bool:
+                        includesTrue = true;
+                        includesFalse = true;
+                        flags |= @bool.ValidationFlags;
+                        return this;
+                    case NullType:
+                        nullable = true;
+                        return this;
+                    case AnyType:
+                        return new CollapsesToAny();
+                    default:
+                        return new Uncollapsable();
+                }
+            }
+        }
+
+        private class ArrayCollapse : UnionCollapseState
+        {
+            private readonly ConcurrentDictionary<TypeSymbol, RefinementSpanCollapser> spanCollapsersByItemType = new();
+            private readonly HashSet<TupleType> tuples = new();
+            private bool nullable;
+
+            internal ArrayCollapse(TupleType tuple, bool nullable)
+            {
+                PushTuple(tuple);
+                this.nullable = nullable;
+            }
+
+            internal ArrayCollapse(ArrayType array, bool nullable)
+            {
+                PushArraySpan(array);
+                this.nullable = nullable;
+            }
+
+            public TypeSymbol? Collapse()
+            {
+                foreach (var tuple in tuples.ToArray())
+                {
+                    if (spanCollapsersByItemType.Any(kvp => kvp.Value.Spans.Any(span => span.Min <= tuple.Items.Length && tuple.Items.Length <= span.Max) &&
+                        TypeValidator.AreTypesAssignable(tuple.Item.Type, kvp.Key)))
+                    {
+                        tuples.Remove(tuple);
+                    }
+                }
+
+                return CreateTypeUnion(
+                    tuples.Concat(spanCollapsersByItemType.SelectMany(kvp => kvp.Value.Spans.Select(span => TypeFactory.CreateArrayType(kvp.Key,
+                        span.Min switch
+                        {
+                            <= 0 => null,
+                            long otherwise => otherwise,
+                        },
+                        span.Max switch
+                        {
+                            long.MaxValue => null,
+                            long otherwise => otherwise,
+                        },
+                        span.Flags)))),
+                    nullable);
+            }
+
+            public UnionCollapseState Push(ITypeReference memberType)
+            {
+                switch (memberType.Type)
+                {
+                    case TupleType tuple:
+                        PushTuple(tuple);
+                        return this;
+                    case ArrayType array:
+                        PushArraySpan(array);
+                        return this;
+                    case NullType:
+                        nullable = true;
+                        return this;
+                    case AnyType:
+                        return new CollapsesToAny();
+                    default:
+                        return new Uncollapsable();
+                }
+            }
+
+            private void PushTuple(TupleType tuple)
+            {
+                if (tuple.Items.Select(i => i.Type).Distinct().Count() == 1)
+                {
+                    PushArraySpan(TypeFactory.CreateArrayType(tuple.Items[0], tuple.Items.Length, tuple.Items.Length, tuple.ValidationFlags));
+                }
+                else
+                {
+                    tuples.Add(tuple);
+                }
+            }
+
+            private void PushArraySpan(ArrayType array)
+                => spanCollapsersByItemType.GetOrAdd(array.Item.Type, _ => new RefinementSpanCollapser()).PushSpan(RefinementSpan.For(array));
+        }
+
+        private class CollapsesToAny : UnionCollapseState
+        {
+            public TypeSymbol? Collapse() => LanguageConstants.Any;
+
+            public UnionCollapseState Push(ITypeReference _) => this;
+        }
+
+        private class Uncollapsable : UnionCollapseState
+        {
+            public TypeSymbol? Collapse() => null;
+
+            public UnionCollapseState Push(ITypeReference _) => this;
+        }
+
+        private readonly record struct RefinementSpan(long Min, long Max, TypeSymbolValidationFlags Flags)
+        {
+            internal bool Contains(long number) => Min <= number && number <= Max;
+
+            internal bool OverlapsOrAbuts(RefinementSpan other) => Min <= (other.Max == long.MaxValue ? long.MaxValue : other.Max + 1) &&
+                Max >= (other.Min == long.MinValue ? long.MinValue : other.Min - 1);
+
+            internal RefinementSpan Fuse(RefinementSpan other) => new(Math.Min(Min, other.Min), Math.Max(Max, other.Max), Flags | other.Flags);
+
+            internal static RefinementSpan For(StringType @string) => new(@string.MinLength ?? 0, @string.MaxLength ?? long.MaxValue, @string.ValidationFlags);
+
+            internal static RefinementSpan For(IntegerType @int) => new(@int.MinValue ?? long.MinValue, @int.MaxValue ?? long.MaxValue, @int.ValidationFlags);
+
+            internal static RefinementSpan For(IntegerLiteralType literal) => new(literal.Value, literal.Value, literal.ValidationFlags);
+
+            internal static RefinementSpan For(ArrayType array) => new(array.MinLength ?? 0, array.MaxLength ?? long.MaxValue, array.ValidationFlags);
+        }
+
+        private class RefinementSpanCollapser
+        {
+            private readonly List<RefinementSpan> discreteSpans = new();
+
+            internal void PushSpan(RefinementSpan span)
+            {
+                for (int i = 0; i < discreteSpans.Count; i++)
+                {
+                    if (span.OverlapsOrAbuts(discreteSpans[i]))
+                    {
+                        discreteSpans[i] = discreteSpans[i].Fuse(span);
+                        if (discreteSpans.Count > 1)
+                        {
+                            var fused = discreteSpans[i];
+                            discreteSpans.RemoveAt(i);
+                            PushSpan(fused);
+                        }
+                        return;
+                    }
+                }
+
+                discreteSpans.Add(span);
+            }
+
+            internal IEnumerable<RefinementSpan> Spans => discreteSpans;
+        }
+    }
+}

--- a/src/Bicep.Core/TypeSystem/TypeComparer.cs
+++ b/src/Bicep.Core/TypeSystem/TypeComparer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+
+namespace Bicep.Core.TypeSystem;
+
+internal class TypeComparer : IComparer<TypeSymbol>
+{
+    public int Compare(TypeSymbol? a, TypeSymbol? b) => (a, b) switch
+    {
+        (ArrayType arrayA, ArrayType arrayB) when arrayA.Name == arrayB.Name => arrayA.MinLength == arrayB.MinLength
+            ? CompareRefinements(arrayA.MaxLength, arrayB.MaxLength)
+            : CompareRefinements(arrayA.MinLength, arrayB.MinLength),
+        (IntegerType intA, IntegerType intB) => intA.MinValue == intB.MinValue
+            ? CompareRefinements(intA.MaxValue, intB.MaxValue)
+            : CompareRefinements(intA.MinValue, intB.MinValue),
+        (StringType stringA, StringType stringB) => stringA.MinLength == stringB.MinLength
+            ? CompareRefinements(stringA.MaxLength, stringB.MaxLength)
+            : CompareRefinements(stringA.MinLength, stringB.MinLength),
+        _ => StringComparer.Ordinal.Compare(a?.Name, b?.Name),
+    };
+
+    private int CompareRefinements(long? a, long? b) => (a, b) switch
+    {
+        (long, null) => -1,
+        (null, long) => 1,
+        (long nonNullA, long nonNullB) => (nonNullA - nonNullB) switch
+        {
+            < 0 => -1,
+            > 0 => 1,
+            _ => 0,
+        },
+        _ => 0,
+    };
+}

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using Azure.Deployments.Expression.Extensions;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
@@ -18,48 +17,13 @@ namespace Bicep.Core.TypeSystem
 {
     public static class TypeHelper
     {
+        private static TypeComparer typeComparer = new();
+
         /// <summary>
         /// Try to collapse multiple types into a single (non-union) type. Returns null if this is not possible.
         /// </summary>
         public static TypeSymbol? TryCollapseTypes(IEnumerable<ITypeReference> itemTypes)
-        {
-            var aggregatedItemType = CreateTypeUnion(itemTypes);
-
-            if (aggregatedItemType.TypeKind == TypeKind.Never || aggregatedItemType.TypeKind == TypeKind.Any)
-            {
-                // it doesn't really make sense to collapse 'never' or 'any'
-                return null;
-            }
-
-            if (aggregatedItemType is UnionType unionType)
-            {
-                if (unionType.Members.All(x => x is StringLiteralType || x == LanguageConstants.String))
-                {
-                    return unionType.Members.Any(x => x == LanguageConstants.String) ?
-                        LanguageConstants.String :
-                        unionType;
-                }
-
-                if (unionType.Members.All(x => TypeValidator.AreTypesAssignable(x.Type, LanguageConstants.Bool)))
-                {
-                    return unionType.Members.Any(x => x == LanguageConstants.Bool)
-                        ? LanguageConstants.Bool
-                        : unionType;
-                }
-
-                if (unionType.Members.All(x => TypeValidator.AreTypesAssignable(x.Type, LanguageConstants.Int)))
-                {
-                    return unionType.Members.Any(x => x == LanguageConstants.Int)
-                        ? LanguageConstants.Bool
-                        : unionType;
-                }
-
-                // We have a mix of item types that cannot be collapsed
-                return null;
-            }
-
-            return aggregatedItemType;
-        }
+            => TypeCollapser.TryCollapse(CreateTypeUnion(itemTypes));
 
         /// <summary>
         /// Collapses multiple types into either:
@@ -415,31 +379,35 @@ namespace Bicep.Core.TypeSystem
 
         private static ImmutableArray<ITypeReference> NormalizeTypeList(IEnumerable<ITypeReference> unionMembers)
         {
-            // flatten and then de-duplicate members
-            var flattenedMembers = FlattenMembers(unionMembers)
-                .Distinct()
-                .OrderBy(m => m.Type.Name, StringComparer.Ordinal)
-                .ToImmutableArray();
-
-            if (flattenedMembers.Any(member => member is AnyType))
+            HashSet<TypeSymbol> distinctMembers = new();
+            bool hasUnrefinedUntypedArrayMember = false;
+            foreach (var member in FlattenMembers(unionMembers))
             {
-                // a union type with "| any" is the same as "any" type
-                return ImmutableArray.Create<ITypeReference>(LanguageConstants.Any);
+                if (member is AnyType)
+                {
+                    // a union type with "| any" is the same as "any" type
+                    return ImmutableArray.Create<ITypeReference>(LanguageConstants.Any);
+                }
+
+                if (hasUnrefinedUntypedArrayMember && member is ArrayType)
+                {
+                    continue;
+                }
+
+                if (member.Equals(LanguageConstants.Array))
+                {
+                    hasUnrefinedUntypedArrayMember = true;
+                    distinctMembers.RemoveWhere(t => t is ArrayType);
+                }
+
+                distinctMembers.Add(member);
             }
 
-            IEnumerable<ITypeReference> intermediateMembers = flattenedMembers;
-
-            if (flattenedMembers.Any(member => member.Type == LanguageConstants.Array))
-            {
-                // the union has the base "array" type, so we can drop any more specific array types
-                intermediateMembers = intermediateMembers.Where(member => member.Type is not ArrayType || member.Type == LanguageConstants.Array);
-            }
-
-            return intermediateMembers.ToImmutableArray();
+            return distinctMembers.Order(typeComparer).ToImmutableArray<ITypeReference>();
         }
 
-        private static IEnumerable<ITypeReference> FlattenMembers(IEnumerable<ITypeReference> members) =>
-            members.SelectMany(member => member.Type is UnionType union
+        private static IEnumerable<TypeSymbol> FlattenMembers(IEnumerable<ITypeReference> members) =>
+            members.Select(member => member.Type).SelectMany(member => member is UnionType union
                 ? FlattenMembers(union.Members)
                 : member.AsEnumerable());
 

--- a/src/Bicep.Core/TypeSystem/UnionType.cs
+++ b/src/Bicep.Core/TypeSystem/UnionType.cs
@@ -13,11 +13,25 @@ namespace Bicep.Core.TypeSystem
             this.Members = members;
         }
 
-        public override TypeKind TypeKind => this.Members.Any() ? TypeKind.Union : TypeKind.Never;
+        public override TypeKind TypeKind => this.Members.IsEmpty ? TypeKind.Never : TypeKind.Union;
 
         public ImmutableArray<ITypeReference> Members { get; }
 
         public override string FormatNameForCompoundTypes() => TypeKind == TypeKind.Never ? Name : WrapTypeName();
+
+        public override bool Equals(object? other) => other is UnionType otherUnion && Members.SequenceEqual(otherUnion.Members);
+
+        public override int GetHashCode()
+        {
+            int hashCode = TypeKind.GetHashCode();
+
+            // follow the Java algorithm (hashCode(<set>) == the sum of the hashcodes of set members) so that hash code is not dependent on set identity or iteration order
+            foreach (var member in Members)
+            {
+                hashCode = unchecked(hashCode + member.GetHashCode());
+            }
+
+            return hashCode;
+        }
     }
 }
-

--- a/src/Bicep.Core/TypeSystem/UnionType.cs
+++ b/src/Bicep.Core/TypeSystem/UnionType.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -23,15 +24,16 @@ namespace Bicep.Core.TypeSystem
 
         public override int GetHashCode()
         {
-            int hashCode = TypeKind.GetHashCode();
+            HashCode hashCode = new();
 
-            // follow the Java algorithm (hashCode(<set>) == the sum of the hashcodes of set members) so that hash code is not dependent on set identity or iteration order
+            hashCode.Add(Name);
+            hashCode.Add(TypeKind);
             foreach (var member in Members)
             {
-                hashCode = unchecked(hashCode + member.GetHashCode());
+                hashCode.Add(member);
             }
 
-            return hashCode;
+            return hashCode.ToHashCode();
         }
     }
 }


### PR DESCRIPTION
Resolves #10170 

As a follow-up to #9870, this PR updates `TypeHelper.TryCollapseTypes` to be aware of and to properly merge type refinements. The simple list of `if` conditions with early returns used in the previous version got really gnarly once refinement tracking was added, so I broke the logic off into a separate class. 

Collapsing now uses a finite state machine, which is probably overkill but allows a type union to be collapsed in a single pass and should make it easier to add more specialized collapsing logic (like collapsing objects into a discriminated union) in the future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10124)