### PR TITLE
Increment nested deployment API version to 2022-09-01

### DIFF
--- a/src/Bicep.Core.Samples/Files/Lambdas_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Lambdas_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15080970933865602671"
+      "templateHash": "4686158236210752139"
     }
   },
   "variables": {
@@ -53,7 +53,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "asdfsadf",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/Lambdas_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Lambdas_LF/main.sourcemap.bicep
@@ -107,7 +107,7 @@ var mappedResProps = map(items(storageAcc.properties.secondaryEndpoints), item =
 module myMod './test.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"

--- a/src/Bicep.Core.Samples/Files/Lambdas_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Lambdas_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4809667844323283520"
+      "templateHash": "7333326022903475769"
     }
   },
   "variables": {
@@ -61,7 +61,7 @@
     },
     "myMod": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "asdfsadf",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18079976022670592837"
+      "templateHash": "12490339809850339782"
     }
   },
   "variables": {
@@ -116,7 +116,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "module1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -149,7 +149,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "module2",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.sourcemap.bicep
@@ -98,7 +98,7 @@ var loadedTextArrayInObjectFunctions = {
 module module1 'modulea.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -139,7 +139,7 @@ module module1 'modulea.bicep' = {
 module module2 'modulea.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"

--- a/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoadFunctions_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6209668087666326528"
+      "templateHash": "10973414352775753606"
     }
   },
   "variables": {
@@ -118,7 +118,7 @@
   "resources": {
     "module1": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "module1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -153,7 +153,7 @@
     },
     "module2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "module2",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "762037461916539674"
+      "templateHash": "9214004969162784388"
     }
   },
   "parameters": {
@@ -284,8 +284,8 @@
                   "name": "backends",
                   "count": "[length(range(0, length(variables('regions'))))]",
                   "input": {
-                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2020-10-01').outputs.myOutput.value]",
-                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2020-10-01').outputs.myOutput.value]",
+                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2022-09-01').outputs.myOutput.value]",
+                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2022-09-01').outputs.myOutput.value]",
                     "httpPort": 80,
                     "httpsPort": 443,
                     "priority": 1,
@@ -317,8 +317,8 @@
             "properties": {
               "backends": [
                 {
-                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2020-10-01').outputs.myOutput.value]",
-                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2020-10-01').outputs.myOutput.value]",
+                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2022-09-01').outputs.myOutput.value]",
+                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2022-09-01').outputs.myOutput.value]",
                   "httpPort": 80,
                   "httpsPort": 443,
                   "priority": 1,
@@ -401,7 +401,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "test",
       "properties": {
         "expressionEvaluationOptions": {
@@ -446,7 +446,7 @@
         "batchSize": 3
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[concat(variables('moduleSetup')[copyIndex()], copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -493,7 +493,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[concat(variables('moduleSetup')[copyIndex()], copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -536,7 +536,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hello",
       "properties": {
         "expressionEvaluationOptions": {
@@ -545,7 +545,7 @@
         "mode": "Incremental",
         "parameters": {
           "myInput": {
-            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier)]"
+            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier)]"
           }
         },
         "template": {
@@ -584,7 +584,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[concat(variables('moduleSetup')[copyIndex()], copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -593,7 +593,7 @@
         "mode": "Incremental",
         "parameters": {
           "myInput": {
-            "value": "[format('{0} - {1} - {2} - {3}', reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()], copyIndex())]"
+            "value": "[format('{0} - {1} - {2} - {3}', reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()], copyIndex())]"
           }
         },
         "template": {
@@ -632,7 +632,7 @@
         "count": "[length(variables('regions'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('apim-{0}-{1}-{2}', variables('regions')[copyIndex()], parameters('name'), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -712,7 +712,7 @@
     },
     "indexedModuleOutput": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[mul(parameters('index'), 1)], mul(parameters('index'), 1))), '2020-10-01').outputs.myOutput.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[mul(parameters('index'), 1)], mul(parameters('index'), 1))), '2022-09-01').outputs.myOutput.value]"
     },
     "existingIndexedResourceName": {
       "type": "string",

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.sourcemap.bicep
@@ -452,7 +452,7 @@ resource combinedDependencies 'Microsoft.Network/dnsZones@2018-05-01' = {
 module singleModule 'passthrough.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -517,7 +517,7 @@ module moduleCollectionWithSingleDependency 'passthrough.bicep' = [for (moduleNa
 //@        "batchSize": 3
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -576,7 +576,7 @@ module moduleCollectionWithCollectionDependencies 'passthrough.bicep' = [for (mo
 //@        "count": "[length(variables('moduleSetup'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -630,7 +630,7 @@ module moduleCollectionWithCollectionDependencies 'passthrough.bicep' = [for (mo
 module singleModuleWithIndexedDependencies 'passthrough.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -673,7 +673,7 @@ module singleModuleWithIndexedDependencies 'passthrough.bicep' = {
 //@        },
     myInput: concat(moduleCollectionWithCollectionDependencies[index].outputs.myOutput, storageAccounts[index * 3].properties.accessTier)
 //@          "myInput": {
-//@            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier)]"
+//@            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier)]"
 //@          }
   }
   dependsOn: [
@@ -688,7 +688,7 @@ module moduleCollectionWithIndexedDependencies 'passthrough.bicep' = [for (modul
 //@        "count": "[length(variables('moduleSetup'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -731,7 +731,7 @@ module moduleCollectionWithIndexedDependencies 'passthrough.bicep' = [for (modul
 //@        },
     myInput: '${moduleCollectionWithCollectionDependencies[index].outputs.myOutput} - ${storageAccounts[index * 3].properties.accessTier} - ${moduleName} - ${moduleIndex}'
 //@          "myInput": {
-//@            "value": "[format('{0} - {1} - {2} - {3}', reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()], copyIndex())]"
+//@            "value": "[format('{0} - {1} - {2} - {3}', reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[parameters('index')], parameters('index'))), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}-{2}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name, mul(parameters('index'), 3))), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()], copyIndex())]"
 //@          }
   }
   dependsOn: [
@@ -747,7 +747,7 @@ output indexedModulesName string = moduleCollectionWithSingleDependency[index].n
 output indexedModuleOutput string = moduleCollectionWithSingleDependency[index * 1].outputs.myOutput
 //@    "indexedModuleOutput": {
 //@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[mul(parameters('index'), 1)], mul(parameters('index'), 1))), '2020-10-01').outputs.myOutput.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', concat(variables('moduleSetup')[mul(parameters('index'), 1)], mul(parameters('index'), 1))), '2022-09-01').outputs.myOutput.value]"
 //@    },
 
 // resource collection
@@ -839,7 +839,7 @@ module apim 'passthrough.bicep' = [for (region, i) in regions: {
 //@        "count": "[length(variables('regions'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -921,9 +921,9 @@ resource propertyLoopDependencyOnModuleCollection 'Microsoft.Network/frontDoors@
             // would be outside of the scope of the property loop
             // as a result, this will generate a dependency on the entire collection
             address: apim[index + i].outputs.myOutput
-//@                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2020-10-01').outputs.myOutput.value]",
+//@                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2022-09-01').outputs.myOutput.value]",
             backendHostHeader: apim[index + i].outputs.myOutput
-//@                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2020-10-01').outputs.myOutput.value]",
+//@                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends'))], parameters('name'), add(range(0, length(variables('regions')))[copyIndex('backends')], copyIndex('backends')))), '2022-09-01').outputs.myOutput.value]",
             httpPort: 80
 //@                    "httpPort": 80,
             httpsPort: 443
@@ -979,9 +979,9 @@ resource indexedModuleCollectionDependency 'Microsoft.Network/frontDoors@2020-05
               // this indexed dependency on a module collection will be generated correctly because
               // copyIndex() can be invoked in the generated dependsOn
               address: apim[index+i].outputs.myOutput
-//@                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2020-10-01').outputs.myOutput.value]",
+//@                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2022-09-01').outputs.myOutput.value]",
               backendHostHeader: apim[index+i].outputs.myOutput
-//@                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2020-10-01').outputs.myOutput.value]",
+//@                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}-{2}', variables('regions')[add(range(0, length(variables('regions')))[copyIndex()], copyIndex())], parameters('name'), add(range(0, length(variables('regions')))[copyIndex()], copyIndex()))), '2022-09-01').outputs.myOutput.value]",
               httpPort: 80
 //@                  "httpPort": 80,
               httpsPort: 443

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1616169273528351593"
+      "templateHash": "14301333999021087992"
     }
   },
   "parameters": {
@@ -413,7 +413,7 @@
     },
     "singleModule": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "test",
       "properties": {
         "expressionEvaluationOptions": {
@@ -460,7 +460,7 @@
         "batchSize": 3
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[concat(variables('moduleSetup')[copyIndex()], copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -509,7 +509,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[concat(variables('moduleSetup')[copyIndex()], copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -554,7 +554,7 @@
     },
     "singleModuleWithIndexedDependencies": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hello",
       "properties": {
         "expressionEvaluationOptions": {
@@ -604,7 +604,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[concat(variables('moduleSetup')[copyIndex()], copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -654,7 +654,7 @@
         "count": "[length(variables('regions'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('apim-{0}-{1}-{2}', variables('regions')[copyIndex()], parameters('name'), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10092926960028975712"
+      "templateHash": "14105561933124692307"
     }
   },
   "parameters": {
@@ -284,8 +284,8 @@
                   "name": "backends",
                   "count": "[length(range(0, length(variables('regions'))))]",
                   "input": {
-                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
-                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
+                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
+                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
                     "httpPort": 80,
                     "httpsPort": 443,
                     "priority": 1,
@@ -317,8 +317,8 @@
             "properties": {
               "backends": [
                 {
-                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
-                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
+                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
+                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
                   "httpPort": 80,
                   "httpsPort": 443,
                   "priority": 1,
@@ -400,22 +400,22 @@
       ]
     },
     {
-      "condition": "[equals(mod(range(0, 10)[copyIndex()], 3), 0)]",
       "copy": {
         "name": "filteredZones",
         "count": "[length(range(0, 10))]"
       },
+      "condition": "[equals(mod(range(0, 10)[copyIndex()], 3), 0)]",
       "type": "Microsoft.Network/dnsZones",
       "apiVersion": "2018-05-01",
       "name": "[format('zone{0}', range(0, 10)[copyIndex()])]",
       "location": "[resourceGroup().location]"
     },
     {
-      "condition": "[parameters('accounts')[copyIndex()].enabled]",
       "copy": {
         "name": "filteredIndexedZones",
         "count": "[length(parameters('accounts'))]"
       },
+      "condition": "[parameters('accounts')[copyIndex()].enabled]",
       "type": "Microsoft.Network/dnsZones",
       "apiVersion": "2018-05-01",
       "name": "[format('indexedZone-{0}-{1}', parameters('accounts')[copyIndex()].name, copyIndex())]",
@@ -423,7 +423,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "test",
       "properties": {
         "expressionEvaluationOptions": {
@@ -468,7 +468,7 @@
         "batchSize": 3
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('moduleSetup')[copyIndex()]]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -515,7 +515,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('moduleSetup')[copyIndex()]]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -558,7 +558,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hello",
       "properties": {
         "expressionEvaluationOptions": {
@@ -567,7 +567,7 @@
         "mode": "Incremental",
         "parameters": {
           "myInput": {
-            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier)]"
+            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier)]"
           }
         },
         "template": {
@@ -606,7 +606,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('moduleSetup')[copyIndex()]]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -615,7 +615,7 @@
         "mode": "Incremental",
         "parameters": {
           "myInput": {
-            "value": "[format('{0} - {1} - {2}', reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()])]"
+            "value": "[format('{0} - {1} - {2}', reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()])]"
           }
         },
         "template": {
@@ -654,7 +654,7 @@
         "count": "[length(variables('regions'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('apim-{0}-{1}', variables('regions')[copyIndex()], parameters('name'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -692,13 +692,13 @@
       }
     },
     {
-      "condition": "[equals(mod(range(0, 6)[copyIndex()], 2), 0)]",
       "copy": {
         "name": "filteredModules",
         "count": "[length(range(0, 6))]"
       },
+      "condition": "[equals(mod(range(0, 6)[copyIndex()], 2), 0)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('stuff{0}', range(0, 6)[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -736,13 +736,13 @@
       }
     },
     {
-      "condition": "[parameters('accounts')[copyIndex()].enabled]",
       "copy": {
         "name": "filteredIndexedModules",
         "count": "[length(parameters('accounts'))]"
       },
+      "condition": "[parameters('accounts')[copyIndex()].enabled]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('stuff-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -822,7 +822,7 @@
     },
     "indexedModuleOutput": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[mul(parameters('index'), 1)]), '2020-10-01').outputs.myOutput.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[mul(parameters('index'), 1)]), '2022-09-01').outputs.myOutput.value]"
     },
     "existingIndexedResourceName": {
       "type": "string",
@@ -854,7 +854,7 @@
     },
     "lastModuleOutput": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('stuff-{0}', sub(length(parameters('accounts')), 1))), '2020-10-01').outputs.myOutput.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('stuff-{0}', sub(length(parameters('accounts')), 1))), '2022-09-01').outputs.myOutput.value]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.sourcemap.bicep
@@ -452,7 +452,7 @@ resource combinedDependencies 'Microsoft.Network/dnsZones@2018-05-01' = {
 module singleModule 'passthrough.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -517,7 +517,7 @@ module moduleCollectionWithSingleDependency 'passthrough.bicep' = [for moduleNam
 //@        "batchSize": 3
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -576,7 +576,7 @@ module moduleCollectionWithCollectionDependencies 'passthrough.bicep' = [for mod
 //@        "count": "[length(variables('moduleSetup'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -630,7 +630,7 @@ module moduleCollectionWithCollectionDependencies 'passthrough.bicep' = [for mod
 module singleModuleWithIndexedDependencies 'passthrough.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -673,7 +673,7 @@ module singleModuleWithIndexedDependencies 'passthrough.bicep' = {
 //@        },
     myInput: concat(moduleCollectionWithCollectionDependencies[index].outputs.myOutput, storageAccounts[index * 3].properties.accessTier)
 //@          "myInput": {
-//@            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier)]"
+//@            "value": "[concat(reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier)]"
 //@          }
   }
   dependsOn: [
@@ -688,7 +688,7 @@ module moduleCollectionWithIndexedDependencies 'passthrough.bicep' = [for module
 //@        "count": "[length(variables('moduleSetup'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -731,7 +731,7 @@ module moduleCollectionWithIndexedDependencies 'passthrough.bicep' = [for module
 //@        },
     myInput: '${moduleCollectionWithCollectionDependencies[index].outputs.myOutput} - ${storageAccounts[index * 3].properties.accessTier} - ${moduleName}'
 //@          "myInput": {
-//@            "value": "[format('{0} - {1} - {2}', reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2020-10-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()])]"
+//@            "value": "[format('{0} - {1} - {2}', reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[parameters('index')]), '2022-09-01').outputs.myOutput.value, reference(resourceId('Microsoft.Storage/storageAccounts', format('{0}-collection-{1}', parameters('name'), parameters('accounts')[mul(parameters('index'), 3)].name)), '2019-06-01').accessTier, variables('moduleSetup')[copyIndex()])]"
 //@          }
   }
   dependsOn: [
@@ -747,7 +747,7 @@ output indexedModulesName string = moduleCollectionWithSingleDependency[index].n
 output indexedModuleOutput string = moduleCollectionWithSingleDependency[index * 1].outputs.myOutput
 //@    "indexedModuleOutput": {
 //@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[mul(parameters('index'), 1)]), '2020-10-01').outputs.myOutput.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', variables('moduleSetup')[mul(parameters('index'), 1)]), '2022-09-01').outputs.myOutput.value]"
 //@    },
 
 // resource collection
@@ -839,7 +839,7 @@ module apim 'passthrough.bicep' = [for region in regions: {
 //@        "count": "[length(variables('regions'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -921,9 +921,9 @@ resource propertyLoopDependencyOnModuleCollection 'Microsoft.Network/frontDoors@
             // would be outside of the scope of the property loop
             // as a result, this will generate a dependency on the entire collection
             address: apim[index].outputs.myOutput
-//@                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
+//@                    "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
             backendHostHeader: apim[index].outputs.myOutput
-//@                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
+//@                    "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex('backends')]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
             httpPort: 80
 //@                    "httpPort": 80,
             httpsPort: 443
@@ -979,9 +979,9 @@ resource indexedModuleCollectionDependency 'Microsoft.Network/frontDoors@2020-05
               // this indexed dependency on a module collection will be generated correctly because
               // copyIndex() can be invoked in the generated dependsOn
               address: apim[index].outputs.myOutput
-//@                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
+//@                  "address": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
               backendHostHeader: apim[index].outputs.myOutput
-//@                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2020-10-01').outputs.myOutput.value]",
+//@                  "backendHostHeader": "[reference(resourceId('Microsoft.Resources/deployments', format('apim-{0}-{1}', variables('regions')[range(0, length(variables('regions')))[copyIndex()]], parameters('name'))), '2022-09-01').outputs.myOutput.value]",
               httpPort: 80
 //@                  "httpPort": 80,
               httpsPort: 443
@@ -1138,7 +1138,7 @@ module filteredModules 'passthrough.bicep' = [for i in range(0,6): if(i % 2 == 0
 //@      },
 //@      "condition": "[equals(mod(range(0, 6)[copyIndex()], 2), 0)]",
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1211,7 +1211,7 @@ module filteredIndexedModules 'passthrough.bicep' = [for (account, i) in account
 //@      },
 //@      "condition": "[parameters('accounts')[copyIndex()].enabled]",
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1257,6 +1257,6 @@ module filteredIndexedModules 'passthrough.bicep' = [for (account, i) in account
 output lastModuleOutput string = filteredIndexedModules[length(accounts) - 1].outputs.myOutput
 //@    "lastModuleOutput": {
 //@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('stuff-{0}', sub(length(parameters('accounts')), 1))), '2020-10-01').outputs.myOutput.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('stuff-{0}', sub(length(parameters('accounts')), 1))), '2022-09-01').outputs.myOutput.value]"
 //@    }
 

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4898420799794864272"
+      "templateHash": "2600527470758129305"
     }
   },
   "parameters": {
@@ -435,7 +435,7 @@
     },
     "singleModule": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "test",
       "properties": {
         "expressionEvaluationOptions": {
@@ -482,7 +482,7 @@
         "batchSize": 3
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('moduleSetup')[copyIndex()]]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -531,7 +531,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('moduleSetup')[copyIndex()]]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -576,7 +576,7 @@
     },
     "singleModuleWithIndexedDependencies": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hello",
       "properties": {
         "expressionEvaluationOptions": {
@@ -626,7 +626,7 @@
         "count": "[length(variables('moduleSetup'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('moduleSetup')[copyIndex()]]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -676,7 +676,7 @@
         "count": "[length(variables('regions'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('apim-{0}-{1}', variables('regions')[copyIndex()], parameters('name'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -722,7 +722,7 @@
       },
       "condition": "[equals(mod(range(0, 6)[copyIndex()], 2), 0)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('stuff{0}', range(0, 6)[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -768,7 +768,7 @@
       },
       "condition": "[parameters('accounts')[copyIndex()].enabled]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('stuff-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11368937387853847504"
+      "templateHash": "17971436525139166022"
     }
   },
   "parameters": {
@@ -40,7 +40,7 @@
         "count": "[length(variables('scripts'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-dep-{1}', parameters('prefix'), copyIndex())]",
       "resourceGroup": "[format('{0}-{1}', parameters('prefix'), variables('groups')[copyIndex()])]",
       "properties": {
@@ -100,7 +100,7 @@
         "count": "[length(variables('scripts'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-dep-{1}', parameters('prefix'), copyIndex())]",
       "resourceGroup": "[concat(variables('scripts')[copyIndex()], '-extra')]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.sourcemap.bicep
@@ -43,7 +43,7 @@ module scopedToSymbolicName 'hello.bicep' = [for (name, i) in scripts: {
 //@        "count": "[length(variables('scripts'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "[format('{0}-{1}', parameters('prefix'), variables('groups')[copyIndex()])]",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -111,7 +111,7 @@ module scopedToResourceGroupFunction 'hello.bicep' = [for (name, i) in scripts: 
 //@        "count": "[length(variables('scripts'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "[concat(variables('scripts')[copyIndex()], '-extra')]",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ModulesSubscription_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "858669054638275980"
+      "templateHash": "2423042858174630533"
     }
   },
   "parameters": {
@@ -42,7 +42,7 @@
         "count": "[length(variables('scripts'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-dep-{1}', parameters('prefix'), copyIndex())]",
       "resourceGroup": "[format('{0}-{1}', parameters('prefix'), variables('groups')[copyIndex()])]",
       "properties": {
@@ -104,7 +104,7 @@
         "count": "[length(variables('scripts'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-dep-{1}', parameters('prefix'), copyIndex())]",
       "resourceGroup": "[concat(variables('scripts')[copyIndex()], '-extra')]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.json
@@ -5,13 +5,13 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7686813142851057718"
+      "templateHash": "1588556337067815130"
     }
   },
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "myManagementGroupMod",
       "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup')]",
       "location": "[deployment().location]",
@@ -27,13 +27,13 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6066236114936137763"
+              "templateHash": "13668708128840728545"
             }
           },
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myTenantMod",
               "scope": "/",
               "location": "[deployment().location]",
@@ -64,7 +64,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myManagementGroupMod",
               "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
               "location": "[deployment().location]",
@@ -89,7 +89,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "mySubscriptionMod",
               "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
               "location": "[deployment().location]",
@@ -116,7 +116,7 @@
           "outputs": {
             "myOutput": {
               "type": "string",
-              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
             }
           }
         }
@@ -124,7 +124,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "myManagementGroupMod",
       "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
       "location": "[deployment().location]",
@@ -149,7 +149,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "mySubscriptionMod",
       "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
       "location": "[deployment().location]",
@@ -165,13 +165,13 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12301588538908463385"
+              "templateHash": "15454708585237868866"
             }
           },
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod",
               "resourceGroup": "myRg",
               "properties": {
@@ -186,13 +186,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "3773512362905547979"
+                      "templateHash": "3707936864441531265"
                     }
                   },
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -223,7 +223,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -254,7 +254,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -279,7 +279,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -306,11 +306,11 @@
                   "outputs": {
                     "myOutput": {
                       "type": "string",
-                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
                     },
                     "myOutputResourceGroup": {
                       "type": "string",
-                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
                     }
                   }
                 }
@@ -318,7 +318,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod2",
               "resourceGroup": "myRg",
               "properties": {
@@ -333,13 +333,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "3773512362905547979"
+                      "templateHash": "3707936864441531265"
                     }
                   },
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -370,7 +370,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -401,7 +401,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -426,7 +426,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -453,11 +453,11 @@
                   "outputs": {
                     "myOutput": {
                       "type": "string",
-                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
                     },
                     "myOutputResourceGroup": {
                       "type": "string",
-                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
                     }
                   }
                 }
@@ -465,7 +465,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod3",
               "subscriptionId": "subId",
               "resourceGroup": "myRg",
@@ -481,13 +481,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "3773512362905547979"
+                      "templateHash": "3707936864441531265"
                     }
                   },
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -518,7 +518,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -549,7 +549,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -574,7 +574,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -601,11 +601,11 @@
                   "outputs": {
                     "myOutput": {
                       "type": "string",
-                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
                     },
                     "myOutputResourceGroup": {
                       "type": "string",
-                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
                     }
                   }
                 }
@@ -613,7 +613,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myTenantMod",
               "scope": "/",
               "location": "[deployment().location]",
@@ -646,15 +646,15 @@
           "outputs": {
             "myOutput": {
               "type": "string",
-              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
             },
             "myOutputRgMod": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2022-09-01').outputs.myOutput.value]"
             },
             "myOutputRgMod2": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2022-09-01').outputs.myOutput.value]"
             }
           }
         }
@@ -663,7 +663,7 @@
     {
       "condition": "[equals(length('foo'), 3)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "mySubscriptionModWithCondition",
       "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
       "location": "[deployment().location]",
@@ -679,13 +679,13 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12301588538908463385"
+              "templateHash": "15454708585237868866"
             }
           },
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod",
               "resourceGroup": "myRg",
               "properties": {
@@ -700,13 +700,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "3773512362905547979"
+                      "templateHash": "3707936864441531265"
                     }
                   },
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -737,7 +737,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -768,7 +768,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -793,7 +793,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -820,11 +820,11 @@
                   "outputs": {
                     "myOutput": {
                       "type": "string",
-                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
                     },
                     "myOutputResourceGroup": {
                       "type": "string",
-                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
                     }
                   }
                 }
@@ -832,7 +832,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod2",
               "resourceGroup": "myRg",
               "properties": {
@@ -847,13 +847,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "3773512362905547979"
+                      "templateHash": "3707936864441531265"
                     }
                   },
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -884,7 +884,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -915,7 +915,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -940,7 +940,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -967,11 +967,11 @@
                   "outputs": {
                     "myOutput": {
                       "type": "string",
-                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
                     },
                     "myOutputResourceGroup": {
                       "type": "string",
-                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
                     }
                   }
                 }
@@ -979,7 +979,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod3",
               "subscriptionId": "subId",
               "resourceGroup": "myRg",
@@ -995,13 +995,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "3773512362905547979"
+                      "templateHash": "3707936864441531265"
                     }
                   },
                   "resources": [
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -1032,7 +1032,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -1063,7 +1063,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -1088,7 +1088,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -1115,11 +1115,11 @@
                   "outputs": {
                     "myOutput": {
                       "type": "string",
-                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
                     },
                     "myOutputResourceGroup": {
                       "type": "string",
-                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
                     }
                   }
                 }
@@ -1127,7 +1127,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myTenantMod",
               "scope": "/",
               "location": "[deployment().location]",
@@ -1160,15 +1160,15 @@
           "outputs": {
             "myOutput": {
               "type": "string",
-              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
             },
             "myOutputRgMod": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2022-09-01').outputs.myOutput.value]"
             },
             "myOutputRgMod2": {
               "type": "string",
-              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2020-10-01').outputs.myOutput.value]"
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2022-09-01').outputs.myOutput.value]"
             }
           }
         }
@@ -1176,7 +1176,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "mySubscriptionMod",
       "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
       "location": "[deployment().location]",
@@ -1203,11 +1203,11 @@
   "outputs": {
     "myManagementGroupOutput": {
       "type": "string",
-      "value": "[reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', 'myManagementGroup'), 'Microsoft.Resources/deployments', 'myManagementGroupMod'), '2020-10-01').outputs.myOutput.value]"
+      "value": "[reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', 'myManagementGroup'), 'Microsoft.Resources/deployments', 'myManagementGroupMod'), '2022-09-01').outputs.myOutput.value]"
     },
     "mySubscriptionOutput": {
       "type": "string",
-      "value": "[reference(subscriptionResourceId('ee44cd78-68c6-43d9-874e-e684ec8d1191', 'Microsoft.Resources/deployments', 'mySubscriptionMod'), '2020-10-01').outputs.myOutput.value]"
+      "value": "[reference(subscriptionResourceId('ee44cd78-68c6-43d9-874e-e684ec8d1191', 'Microsoft.Resources/deployments', 'mySubscriptionMod'), '2022-09-01').outputs.myOutput.value]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.sourcemap.bicep
@@ -3,7 +3,7 @@ targetScope = 'tenant'
 module myManagementGroupMod 'modules/managementgroup.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup')]",
 //@      "location": "[deployment().location]",
 //@      "properties": {
@@ -18,13 +18,13 @@ module myManagementGroupMod 'modules/managementgroup.bicep' = {
 //@            "_generator": {
 //@              "name": "bicep",
 //@              "version": "dev",
-//@              "templateHash": "6066236114936137763"
+//@              "templateHash": "13668708128840728545"
 //@            }
 //@          },
 //@          "resources": [
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myTenantMod",
 //@              "scope": "/",
 //@              "location": "[deployment().location]",
@@ -55,7 +55,7 @@ module myManagementGroupMod 'modules/managementgroup.bicep' = {
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myManagementGroupMod",
 //@              "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
 //@              "location": "[deployment().location]",
@@ -80,7 +80,7 @@ module myManagementGroupMod 'modules/managementgroup.bicep' = {
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "mySubscriptionMod",
 //@              "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
 //@              "location": "[deployment().location]",
@@ -107,7 +107,7 @@ module myManagementGroupMod 'modules/managementgroup.bicep' = {
 //@          "outputs": {
 //@            "myOutput": {
 //@              "type": "string",
-//@              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@            }
 //@          }
 //@        }
@@ -120,7 +120,7 @@ module myManagementGroupMod 'modules/managementgroup.bicep' = {
 module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
 //@      "location": "[deployment().location]",
 //@      "properties": {
@@ -149,7 +149,7 @@ module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/manageme
 module mySubscriptionMod 'modules/subscription.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "location": "[deployment().location]",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -163,13 +163,13 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@            "_generator": {
 //@              "name": "bicep",
 //@              "version": "dev",
-//@              "templateHash": "12301588538908463385"
+//@              "templateHash": "15454708585237868866"
 //@            }
 //@          },
 //@          "resources": [
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myResourceGroupMod",
 //@              "resourceGroup": "myRg",
 //@              "properties": {
@@ -184,13 +184,13 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    "_generator": {
 //@                      "name": "bicep",
 //@                      "version": "dev",
-//@                      "templateHash": "3773512362905547979"
+//@                      "templateHash": "3707936864441531265"
 //@                    }
 //@                  },
 //@                  "resources": [
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myTenantMod",
 //@                      "scope": "/",
 //@                      "location": "[resourceGroup().location]",
@@ -221,7 +221,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myOtherResourceGroup",
 //@                      "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
 //@                      "resourceGroup": "myOtherRg",
@@ -252,7 +252,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "mySubscription",
 //@                      "subscriptionId": "[subscription().subscriptionId]",
 //@                      "location": "[resourceGroup().location]",
@@ -277,7 +277,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "otherSubscription",
 //@                      "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
 //@                      "location": "[resourceGroup().location]",
@@ -304,11 +304,11 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                  "outputs": {
 //@                    "myOutput": {
 //@                      "type": "string",
-//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@                    },
 //@                    "myOutputResourceGroup": {
 //@                      "type": "string",
-//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
 //@                    }
 //@                  }
 //@                }
@@ -316,7 +316,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myResourceGroupMod2",
 //@              "resourceGroup": "myRg",
 //@              "properties": {
@@ -331,13 +331,13 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    "_generator": {
 //@                      "name": "bicep",
 //@                      "version": "dev",
-//@                      "templateHash": "3773512362905547979"
+//@                      "templateHash": "3707936864441531265"
 //@                    }
 //@                  },
 //@                  "resources": [
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myTenantMod",
 //@                      "scope": "/",
 //@                      "location": "[resourceGroup().location]",
@@ -368,7 +368,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myOtherResourceGroup",
 //@                      "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
 //@                      "resourceGroup": "myOtherRg",
@@ -399,7 +399,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "mySubscription",
 //@                      "subscriptionId": "[subscription().subscriptionId]",
 //@                      "location": "[resourceGroup().location]",
@@ -424,7 +424,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "otherSubscription",
 //@                      "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
 //@                      "location": "[resourceGroup().location]",
@@ -451,11 +451,11 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                  "outputs": {
 //@                    "myOutput": {
 //@                      "type": "string",
-//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@                    },
 //@                    "myOutputResourceGroup": {
 //@                      "type": "string",
-//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
 //@                    }
 //@                  }
 //@                }
@@ -463,7 +463,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myResourceGroupMod3",
 //@              "subscriptionId": "subId",
 //@              "resourceGroup": "myRg",
@@ -479,13 +479,13 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    "_generator": {
 //@                      "name": "bicep",
 //@                      "version": "dev",
-//@                      "templateHash": "3773512362905547979"
+//@                      "templateHash": "3707936864441531265"
 //@                    }
 //@                  },
 //@                  "resources": [
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myTenantMod",
 //@                      "scope": "/",
 //@                      "location": "[resourceGroup().location]",
@@ -516,7 +516,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myOtherResourceGroup",
 //@                      "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
 //@                      "resourceGroup": "myOtherRg",
@@ -547,7 +547,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "mySubscription",
 //@                      "subscriptionId": "[subscription().subscriptionId]",
 //@                      "location": "[resourceGroup().location]",
@@ -572,7 +572,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "otherSubscription",
 //@                      "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
 //@                      "location": "[resourceGroup().location]",
@@ -599,11 +599,11 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@                  "outputs": {
 //@                    "myOutput": {
 //@                      "type": "string",
-//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@                    },
 //@                    "myOutputResourceGroup": {
 //@                      "type": "string",
-//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
 //@                    }
 //@                  }
 //@                }
@@ -611,7 +611,7 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myTenantMod",
 //@              "scope": "/",
 //@              "location": "[deployment().location]",
@@ -644,15 +644,15 @@ module mySubscriptionMod 'modules/subscription.bicep' = {
 //@          "outputs": {
 //@            "myOutput": {
 //@              "type": "string",
-//@              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@            },
 //@            "myOutputRgMod": {
 //@              "type": "string",
-//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2022-09-01').outputs.myOutput.value]"
 //@            },
 //@            "myOutputRgMod2": {
 //@              "type": "string",
-//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2022-09-01').outputs.myOutput.value]"
 //@            }
 //@          }
 //@        }
@@ -668,7 +668,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@    {
 //@      "condition": "[equals(length('foo'), 3)]",
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "location": "[deployment().location]",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -682,13 +682,13 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@            "_generator": {
 //@              "name": "bicep",
 //@              "version": "dev",
-//@              "templateHash": "12301588538908463385"
+//@              "templateHash": "15454708585237868866"
 //@            }
 //@          },
 //@          "resources": [
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myResourceGroupMod",
 //@              "resourceGroup": "myRg",
 //@              "properties": {
@@ -703,13 +703,13 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    "_generator": {
 //@                      "name": "bicep",
 //@                      "version": "dev",
-//@                      "templateHash": "3773512362905547979"
+//@                      "templateHash": "3707936864441531265"
 //@                    }
 //@                  },
 //@                  "resources": [
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myTenantMod",
 //@                      "scope": "/",
 //@                      "location": "[resourceGroup().location]",
@@ -740,7 +740,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myOtherResourceGroup",
 //@                      "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
 //@                      "resourceGroup": "myOtherRg",
@@ -771,7 +771,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "mySubscription",
 //@                      "subscriptionId": "[subscription().subscriptionId]",
 //@                      "location": "[resourceGroup().location]",
@@ -796,7 +796,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "otherSubscription",
 //@                      "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
 //@                      "location": "[resourceGroup().location]",
@@ -823,11 +823,11 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                  "outputs": {
 //@                    "myOutput": {
 //@                      "type": "string",
-//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@                    },
 //@                    "myOutputResourceGroup": {
 //@                      "type": "string",
-//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
 //@                    }
 //@                  }
 //@                }
@@ -835,7 +835,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myResourceGroupMod2",
 //@              "resourceGroup": "myRg",
 //@              "properties": {
@@ -850,13 +850,13 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    "_generator": {
 //@                      "name": "bicep",
 //@                      "version": "dev",
-//@                      "templateHash": "3773512362905547979"
+//@                      "templateHash": "3707936864441531265"
 //@                    }
 //@                  },
 //@                  "resources": [
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myTenantMod",
 //@                      "scope": "/",
 //@                      "location": "[resourceGroup().location]",
@@ -887,7 +887,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myOtherResourceGroup",
 //@                      "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
 //@                      "resourceGroup": "myOtherRg",
@@ -918,7 +918,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "mySubscription",
 //@                      "subscriptionId": "[subscription().subscriptionId]",
 //@                      "location": "[resourceGroup().location]",
@@ -943,7 +943,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "otherSubscription",
 //@                      "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
 //@                      "location": "[resourceGroup().location]",
@@ -970,11 +970,11 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                  "outputs": {
 //@                    "myOutput": {
 //@                      "type": "string",
-//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@                    },
 //@                    "myOutputResourceGroup": {
 //@                      "type": "string",
-//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
 //@                    }
 //@                  }
 //@                }
@@ -982,7 +982,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myResourceGroupMod3",
 //@              "subscriptionId": "subId",
 //@              "resourceGroup": "myRg",
@@ -998,13 +998,13 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    "_generator": {
 //@                      "name": "bicep",
 //@                      "version": "dev",
-//@                      "templateHash": "3773512362905547979"
+//@                      "templateHash": "3707936864441531265"
 //@                    }
 //@                  },
 //@                  "resources": [
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myTenantMod",
 //@                      "scope": "/",
 //@                      "location": "[resourceGroup().location]",
@@ -1035,7 +1035,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "myOtherResourceGroup",
 //@                      "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
 //@                      "resourceGroup": "myOtherRg",
@@ -1066,7 +1066,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "mySubscription",
 //@                      "subscriptionId": "[subscription().subscriptionId]",
 //@                      "location": "[resourceGroup().location]",
@@ -1091,7 +1091,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                    },
 //@                    {
 //@                      "type": "Microsoft.Resources/deployments",
-//@                      "apiVersion": "2020-10-01",
+//@                      "apiVersion": "2022-09-01",
 //@                      "name": "otherSubscription",
 //@                      "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
 //@                      "location": "[resourceGroup().location]",
@@ -1118,11 +1118,11 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@                  "outputs": {
 //@                    "myOutput": {
 //@                      "type": "string",
-//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@                    },
 //@                    "myOutputResourceGroup": {
 //@                      "type": "string",
-//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2020-10-01').outputs.myOutput.value]"
+//@                      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', 'db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg'), 'Microsoft.Resources/deployments', 'myOtherResourceGroup'), '2022-09-01').outputs.myOutput.value]"
 //@                    }
 //@                  }
 //@                }
@@ -1130,7 +1130,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@            },
 //@            {
 //@              "type": "Microsoft.Resources/deployments",
-//@              "apiVersion": "2020-10-01",
+//@              "apiVersion": "2022-09-01",
 //@              "name": "myTenantMod",
 //@              "scope": "/",
 //@              "location": "[deployment().location]",
@@ -1163,15 +1163,15 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 //@          "outputs": {
 //@            "myOutput": {
 //@              "type": "string",
-//@              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(tenantResourceId('Microsoft.Resources/deployments', 'myTenantMod'), '2022-09-01').outputs.myOutput.value]"
 //@            },
 //@            "myOutputRgMod": {
 //@              "type": "string",
-//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod'), '2022-09-01').outputs.myOutput.value]"
 //@            },
 //@            "myOutputRgMod2": {
 //@              "type": "string",
-//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2020-10-01').outputs.myOutput.value]"
+//@              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'myRg'), 'Microsoft.Resources/deployments', 'myResourceGroupMod2'), '2022-09-01').outputs.myOutput.value]"
 //@            }
 //@          }
 //@        }
@@ -1186,7 +1186,7 @@ module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length(
 module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "location": "[deployment().location]",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -1217,11 +1217,11 @@ module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscriptio
 output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
 //@    "myManagementGroupOutput": {
 //@      "type": "string",
-//@      "value": "[reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', 'myManagementGroup'), 'Microsoft.Resources/deployments', 'myManagementGroupMod'), '2020-10-01').outputs.myOutput.value]"
+//@      "value": "[reference(extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', 'myManagementGroup'), 'Microsoft.Resources/deployments', 'myManagementGroupMod'), '2022-09-01').outputs.myOutput.value]"
 //@    },
 output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
 //@    "mySubscriptionOutput": {
 //@      "type": "string",
-//@      "value": "[reference(subscriptionResourceId('ee44cd78-68c6-43d9-874e-e684ec8d1191', 'Microsoft.Resources/deployments', 'mySubscriptionMod'), '2020-10-01').outputs.myOutput.value]"
+//@      "value": "[reference(subscriptionResourceId('ee44cd78-68c6-43d9-874e-e684ec8d1191', 'Microsoft.Resources/deployments', 'mySubscriptionMod'), '2022-09-01').outputs.myOutput.value]"
 //@    }
 

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.symbolicnames.json
@@ -7,13 +7,13 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "580921280783000990"
+      "templateHash": "12236945830777629559"
     }
   },
   "resources": {
     "myManagementGroupMod": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "myManagementGroupMod",
       "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup')]",
       "location": "[deployment().location]",
@@ -31,13 +31,13 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "7510144797364921650"
+              "templateHash": "7177244996826003837"
             }
           },
           "resources": {
             "myTenantMod": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myTenantMod",
               "scope": "/",
               "location": "[deployment().location]",
@@ -70,7 +70,7 @@
             },
             "myManagementGroupModWithDuplicatedNameButInSeparateModule": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myManagementGroupMod",
               "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
               "location": "[deployment().location]",
@@ -97,7 +97,7 @@
             },
             "mySubscriptionModWithDuplicatedNameButInSeparateModule": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "mySubscriptionMod",
               "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
               "location": "[deployment().location]",
@@ -134,7 +134,7 @@
     },
     "myManagementGroupModWithDuplicatedNameButDifferentScope": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "myManagementGroupMod",
       "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
       "location": "[deployment().location]",
@@ -161,7 +161,7 @@
     },
     "mySubscriptionMod": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "mySubscriptionMod",
       "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
       "location": "[deployment().location]",
@@ -179,13 +179,13 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16327556457495361115"
+              "templateHash": "14776429649509126253"
             }
           },
           "resources": {
             "myResourceGroupMod": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod",
               "resourceGroup": "myRg",
               "properties": {
@@ -202,13 +202,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7638849290223758923"
+                      "templateHash": "17548142436964263187"
                     }
                   },
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -241,7 +241,7 @@
                     },
                     "myOtherResourceGroup": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -274,7 +274,7 @@
                     },
                     "mySubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -301,7 +301,7 @@
                     },
                     "otherSubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -342,7 +342,7 @@
             },
             "myResourceGroupMod2": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod2",
               "resourceGroup": "myRg",
               "properties": {
@@ -359,13 +359,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7638849290223758923"
+                      "templateHash": "17548142436964263187"
                     }
                   },
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -398,7 +398,7 @@
                     },
                     "myOtherResourceGroup": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -431,7 +431,7 @@
                     },
                     "mySubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -458,7 +458,7 @@
                     },
                     "otherSubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -499,7 +499,7 @@
             },
             "myResourceGroupMod3": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod3",
               "subscriptionId": "subId",
               "resourceGroup": "myRg",
@@ -517,13 +517,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7638849290223758923"
+                      "templateHash": "17548142436964263187"
                     }
                   },
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -556,7 +556,7 @@
                     },
                     "myOtherResourceGroup": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -589,7 +589,7 @@
                     },
                     "mySubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -616,7 +616,7 @@
                     },
                     "otherSubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -657,7 +657,7 @@
             },
             "myTenantMod": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myTenantMod",
               "scope": "/",
               "location": "[deployment().location]",
@@ -709,7 +709,7 @@
     "mySubscriptionModWithCondition": {
       "condition": "[equals(length('foo'), 3)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "mySubscriptionModWithCondition",
       "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
       "location": "[deployment().location]",
@@ -727,13 +727,13 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "16327556457495361115"
+              "templateHash": "14776429649509126253"
             }
           },
           "resources": {
             "myResourceGroupMod": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod",
               "resourceGroup": "myRg",
               "properties": {
@@ -750,13 +750,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7638849290223758923"
+                      "templateHash": "17548142436964263187"
                     }
                   },
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -789,7 +789,7 @@
                     },
                     "myOtherResourceGroup": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -822,7 +822,7 @@
                     },
                     "mySubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -849,7 +849,7 @@
                     },
                     "otherSubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -890,7 +890,7 @@
             },
             "myResourceGroupMod2": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod2",
               "resourceGroup": "myRg",
               "properties": {
@@ -907,13 +907,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7638849290223758923"
+                      "templateHash": "17548142436964263187"
                     }
                   },
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -946,7 +946,7 @@
                     },
                     "myOtherResourceGroup": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -979,7 +979,7 @@
                     },
                     "mySubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -1006,7 +1006,7 @@
                     },
                     "otherSubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -1047,7 +1047,7 @@
             },
             "myResourceGroupMod3": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myResourceGroupMod3",
               "subscriptionId": "subId",
               "resourceGroup": "myRg",
@@ -1065,13 +1065,13 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "7638849290223758923"
+                      "templateHash": "17548142436964263187"
                     }
                   },
                   "resources": {
                     "myTenantMod": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myTenantMod",
                       "scope": "/",
                       "location": "[resourceGroup().location]",
@@ -1104,7 +1104,7 @@
                     },
                     "myOtherResourceGroup": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myOtherResourceGroup",
                       "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
                       "resourceGroup": "myOtherRg",
@@ -1137,7 +1137,7 @@
                     },
                     "mySubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "mySubscription",
                       "subscriptionId": "[subscription().subscriptionId]",
                       "location": "[resourceGroup().location]",
@@ -1164,7 +1164,7 @@
                     },
                     "otherSubscription": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "otherSubscription",
                       "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
                       "location": "[resourceGroup().location]",
@@ -1205,7 +1205,7 @@
             },
             "myTenantMod": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myTenantMod",
               "scope": "/",
               "location": "[deployment().location]",
@@ -1256,7 +1256,7 @@
     },
     "mySubscriptionModWithDuplicatedNameButDifferentScope": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "mySubscriptionMod",
       "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
       "location": "[deployment().location]",

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "418624339200817120"
+      "templateHash": "12758565066981597317"
     }
   },
   "parameters": {
@@ -61,9 +61,9 @@
       "apiVersion": "2020-01-01",
       "name": "harry",
       "properties": {
-        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.stringOutputA.value]",
-        "modBDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modB'), '2020-10-01').outputs.myResourceId.value]",
-        "modCDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modC'), '2020-10-01').outputs.myResourceId.value]"
+        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.stringOutputA.value]",
+        "modBDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modB'), '2022-09-01').outputs.myResourceId.value]",
+        "modCDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modC'), '2022-09-01').outputs.myResourceId.value]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', 'modATest')]",
@@ -76,7 +76,7 @@
       "apiVersion": "2020-01-01",
       "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
       "properties": {
-        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2020-10-01').outputs.outputObj.value]"
+        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2022-09-01').outputs.outputObj.value]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix')))]",
@@ -85,7 +85,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modATest",
       "properties": {
         "expressionEvaluationOptions": {
@@ -178,7 +178,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modB",
       "properties": {
         "expressionEvaluationOptions": {
@@ -228,7 +228,7 @@
     {
       "condition": "[equals(add(1, 1), 2)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modBWithCondition",
       "properties": {
         "expressionEvaluationOptions": {
@@ -277,7 +277,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modC",
       "properties": {
         "expressionEvaluationOptions": {
@@ -318,7 +318,7 @@
     {
       "condition": "[equals(sub(2, 1), 1)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modCWithCondition",
       "properties": {
         "expressionEvaluationOptions": {
@@ -358,7 +358,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithNoParams1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -416,7 +416,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithNoParams2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -475,7 +475,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithNoParams3",
       "properties": {
         "expressionEvaluationOptions": {
@@ -547,7 +547,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithAllParamsAndManualDependency",
       "properties": {
         "expressionEvaluationOptions": {
@@ -623,7 +623,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithImplicitDependency",
       "properties": {
         "expressionEvaluationOptions": {
@@ -699,7 +699,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -779,7 +779,7 @@
         "count": "[length(variables('myModules'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('myModules')[copyIndex()].name]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -866,7 +866,7 @@
         "count": "[length(variables('myModules'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('myModules')[copyIndex()].name]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -958,7 +958,7 @@
         "count": "[length(variables('myModules'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('myModules')[copyIndex()].name]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1051,7 +1051,7 @@
         "count": "[length(variables('emptyArray'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('hello-{0}', variables('emptyArray')[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1147,7 +1147,7 @@
         "count": "[length(createArray())]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('hello-{0}', createArray()[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1243,7 +1243,7 @@
         "count": "[length(createArray())]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('hello-{0}', createArray()[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1332,7 +1332,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "propertyLoopInsideParameterValue",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1454,7 +1454,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "propertyLoopInsideParameterValueWithIndexes",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1581,7 +1581,7 @@
         "count": "[length(range(0, 1))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "propertyLoopInsideParameterValueInsideModuleLoop",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1703,7 +1703,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "secureModule1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1760,7 +1760,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "secureModule2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1821,7 +1821,7 @@
         "count": "[length(variables('secrets'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('secureModuleLooped-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1878,7 +1878,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "secureModuleCondition",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1920,7 +1920,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "withSpace",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1955,7 +1955,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "childWithSpace",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1990,7 +1990,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "withSeparateConfig",
       "properties": {
         "expressionEvaluationOptions": {
@@ -2029,23 +2029,23 @@
   "outputs": {
     "stringOutputA": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.stringOutputA.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.stringOutputA.value]"
     },
     "stringOutputB": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.stringOutputB.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.stringOutputB.value]"
     },
     "objOutput": {
       "type": "object",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.objOutput.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.objOutput.value]"
     },
     "arrayOutput": {
       "type": "array",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.arrayOutput.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.arrayOutput.value]"
     },
     "modCalculatedNameOutput": {
       "type": "object",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2020-10-01').outputs.outputObj.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2022-09-01').outputs.outputObj.value]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.sourcemap.bicep
@@ -14,7 +14,7 @@ param deployTimeSuffix string = newGuid()
 module modATest './modulea.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -125,7 +125,7 @@ module modATest './modulea.bicep' = {
 module modB './child/moduleb.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -183,7 +183,7 @@ module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
 //@    {
 //@      "condition": "[equals(add(1, 1), 2)]",
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -238,7 +238,7 @@ module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
 module modC './child/modulec.json' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -286,7 +286,7 @@ module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
 //@    {
 //@      "condition": "[equals(sub(2, 1), 1)]",
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -333,7 +333,7 @@ module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
 module optionalWithNoParams1 './child/optionalParams.bicep'= {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -395,7 +395,7 @@ module optionalWithNoParams1 './child/optionalParams.bicep'= {
 module optionalWithNoParams2 './child/optionalParams.bicep'= {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -460,7 +460,7 @@ module optionalWithNoParams2 './child/optionalParams.bicep'= {
 module optionalWithAllParams './child/optionalParams.bicep'= {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -555,18 +555,18 @@ resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
 //@      "properties": {
 //@      },
     modADep: modATest.outputs.stringOutputA
-//@        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.stringOutputA.value]",
+//@        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.stringOutputA.value]",
     modBDep: modB.outputs.myResourceId
-//@        "modBDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modB'), '2020-10-01').outputs.myResourceId.value]",
+//@        "modBDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modB'), '2022-09-01').outputs.myResourceId.value]",
     modCDep: modC.outputs.myResourceId
-//@        "modCDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modC'), '2020-10-01').outputs.myResourceId.value]"
+//@        "modCDep": "[reference(resourceId('Microsoft.Resources/deployments', 'modC'), '2022-09-01').outputs.myResourceId.value]"
   }
 }
 
 module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -656,7 +656,7 @@ module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= 
 module optionalWithImplicitDependency './child/optionalParams.bicep'= {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -742,7 +742,7 @@ module optionalWithImplicitDependency './child/optionalParams.bicep'= {
 module moduleWithCalculatedName './child/optionalParams.bicep'= {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -840,34 +840,34 @@ resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
 //@      "properties": {
 //@      },
     modADep: moduleWithCalculatedName.outputs.outputObj
-//@        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2020-10-01').outputs.outputObj.value]"
+//@        "modADep": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2022-09-01').outputs.outputObj.value]"
   }
 }
 
 output stringOutputA string = modATest.outputs.stringOutputA
 //@    "stringOutputA": {
 //@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.stringOutputA.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.stringOutputA.value]"
 //@    },
 output stringOutputB string = modATest.outputs.stringOutputB
 //@    "stringOutputB": {
 //@      "type": "string",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.stringOutputB.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.stringOutputB.value]"
 //@    },
 output objOutput object = modATest.outputs.objOutput
 //@    "objOutput": {
 //@      "type": "object",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.objOutput.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.objOutput.value]"
 //@    },
 output arrayOutput array = modATest.outputs.arrayOutput
 //@    "arrayOutput": {
 //@      "type": "array",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2020-10-01').outputs.arrayOutput.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'modATest'), '2022-09-01').outputs.arrayOutput.value]"
 //@    },
 output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
 //@    "modCalculatedNameOutput": {
 //@      "type": "object",
-//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2020-10-01').outputs.outputObj.value]"
+//@      "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))), '2022-09-01').outputs.outputObj.value]"
 //@    }
 
 /*
@@ -907,7 +907,7 @@ module storageResources 'modulea.bicep' = [for module in myModules: {
 //@        "count": "[length(variables('myModules'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1004,7 +1004,7 @@ module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules
 //@        "count": "[length(variables('myModules'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1109,7 +1109,7 @@ module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
 //@        "count": "[length(variables('myModules'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1212,7 +1212,7 @@ module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
 //@        "count": "[length(variables('emptyArray'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1321,7 +1321,7 @@ module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes 
 //@        "count": "[length(createArray())]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1431,7 +1431,7 @@ module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
 //@        "count": "[length(createArray())]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1529,7 +1529,7 @@ module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
 module propertyLoopInsideParameterValue 'modulea.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1673,7 +1673,7 @@ module propertyLoopInsideParameterValue 'modulea.bicep' = {
 module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1823,7 +1823,7 @@ module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for t
 //@        "count": "[length(range(0, 1))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -1974,7 +1974,7 @@ resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 module secureModule1 'child/secureParams.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -2044,7 +2044,7 @@ resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 module secureModule2 'child/secureParams.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -2164,7 +2164,7 @@ module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secre
 //@        "count": "[length(variables('secrets'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -2229,7 +2229,7 @@ module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secre
 module secureModuleCondition 'child/secureParams.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -2281,7 +2281,7 @@ module secureModuleCondition 'child/secureParams.bicep' = {
 module withSpace 'module with space.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -2320,7 +2320,7 @@ module withSpace 'module with space.bicep' = {
 module folderWithSpace 'child/folder with space/child with space.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"
@@ -2359,7 +2359,7 @@ module folderWithSpace 'child/folder with space/child with space.bicep' = {
 module withSeparateConfig './child/folder with separate config/moduleWithAzImport.bicep' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
 //@          "scope": "inner"

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7068977095541778338"
+      "templateHash": "17153612886995194724"
     }
   },
   "parameters": {
@@ -112,7 +112,7 @@
     },
     "modATest": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modATest",
       "properties": {
         "expressionEvaluationOptions": {
@@ -207,7 +207,7 @@
     },
     "modB": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modB",
       "properties": {
         "expressionEvaluationOptions": {
@@ -259,7 +259,7 @@
     "modBWithCondition": {
       "condition": "[equals(add(1, 1), 2)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modBWithCondition",
       "properties": {
         "expressionEvaluationOptions": {
@@ -310,7 +310,7 @@
     },
     "modC": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modC",
       "properties": {
         "expressionEvaluationOptions": {
@@ -351,7 +351,7 @@
     "modCWithCondition": {
       "condition": "[equals(sub(2, 1), 1)]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "modCWithCondition",
       "properties": {
         "expressionEvaluationOptions": {
@@ -391,7 +391,7 @@
     },
     "optionalWithNoParams1": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithNoParams1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -451,7 +451,7 @@
     },
     "optionalWithNoParams2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithNoParams2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -512,7 +512,7 @@
     },
     "optionalWithAllParams": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithNoParams3",
       "properties": {
         "expressionEvaluationOptions": {
@@ -586,7 +586,7 @@
     },
     "optionalWithAllParamsAndManualDependency": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithAllParamsAndManualDependency",
       "properties": {
         "expressionEvaluationOptions": {
@@ -664,7 +664,7 @@
     },
     "optionalWithImplicitDependency": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "optionalWithImplicitDependency",
       "properties": {
         "expressionEvaluationOptions": {
@@ -742,7 +742,7 @@
     },
     "moduleWithCalculatedName": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -824,7 +824,7 @@
         "count": "[length(variables('myModules'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('myModules')[copyIndex()].name]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -913,7 +913,7 @@
         "count": "[length(variables('myModules'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('myModules')[copyIndex()].name]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1007,7 +1007,7 @@
         "count": "[length(variables('myModules'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('myModules')[copyIndex()].name]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1102,7 +1102,7 @@
         "count": "[length(variables('emptyArray'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('hello-{0}', variables('emptyArray')[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1200,7 +1200,7 @@
         "count": "[length(createArray())]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('hello-{0}', createArray()[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1298,7 +1298,7 @@
         "count": "[length(createArray())]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('hello-{0}', createArray()[copyIndex()])]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1389,7 +1389,7 @@
     },
     "propertyLoopInsideParameterValue": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "propertyLoopInsideParameterValue",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1513,7 +1513,7 @@
     },
     "propertyLoopInsideParameterValueWithIndexes": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "propertyLoopInsideParameterValueWithIndexes",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1642,7 +1642,7 @@
         "count": "[length(range(0, 1))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "propertyLoopInsideParameterValueInsideModuleLoop",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1766,7 +1766,7 @@
     },
     "secureModule1": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "secureModule1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1825,7 +1825,7 @@
     },
     "secureModule2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "secureModule2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1888,7 +1888,7 @@
         "count": "[length(variables('secrets'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('secureModuleLooped-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1947,7 +1947,7 @@
     },
     "secureModuleCondition": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "secureModuleCondition",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1991,7 +1991,7 @@
     },
     "withSpace": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "withSpace",
       "properties": {
         "expressionEvaluationOptions": {
@@ -2028,7 +2028,7 @@
     },
     "folderWithSpace": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "childWithSpace",
       "properties": {
         "expressionEvaluationOptions": {
@@ -2065,7 +2065,7 @@
     },
     "withSeparateConfig": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "withSeparateConfig",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13942422277694370627"
+      "templateHash": "6747738551347707377"
     }
   },
   "variables": {
@@ -39,7 +39,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "planDeploy",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -100,7 +100,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "planDeploy2",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -165,7 +165,7 @@
         "count": "[length(variables('websites'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}siteDeploy', variables('websites')[copyIndex()].name)]",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -175,7 +175,7 @@
         "mode": "Incremental",
         "parameters": {
           "appPlanId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2020-10-01').outputs.planId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2022-09-01').outputs.planId.value]"
           },
           "namePrefix": {
             "value": "[variables('websites')[copyIndex()].name]"
@@ -266,7 +266,7 @@
         "count": "[length(variables('websites'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}siteDeploy2', variables('websites')[copyIndex()].name)]",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -276,7 +276,7 @@
         "mode": "Incremental",
         "parameters": {
           "appPlanId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2020-10-01').outputs.planId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2022-09-01').outputs.planId.value]"
           },
           "namePrefix": {
             "value": "[variables('websites')[copyIndex()].name]"
@@ -363,7 +363,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "storageDeploy",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -386,7 +386,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "storageDeploy2",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -413,7 +413,7 @@
         "count": "[length(variables('vnets'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}Deploy', variables('vnets')[copyIndex()].name)]",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -439,7 +439,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "port",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -482,7 +482,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv4",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -525,7 +525,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv4port",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -568,7 +568,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv6",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -611,7 +611,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv6port",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -658,7 +658,7 @@
       "type": "array",
       "copy": {
         "count": "[length(variables('websites'))]",
-        "input": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', format('{0}siteDeploy', variables('websites')[copyIndex()].name)), '2020-10-01').outputs.siteUrl.value]"
+        "input": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', format('{0}siteDeploy', variables('websites')[copyIndex()].name)), '2022-09-01').outputs.siteUrl.value]"
       }
     }
   }

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.sourcemap.bicep
@@ -14,7 +14,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2020-06-01' = {
 module appPlanDeploy 'br:mock-registry-one.invalid/demo/plan:v2' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -83,7 +83,7 @@ module appPlanDeploy 'br:mock-registry-one.invalid/demo/plan:v2' = {
 module appPlanDeploy2 'br/mock-registry-one:demo/plan:v2' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -177,7 +177,7 @@ module siteDeploy 'br:mock-registry-two.invalid/demo/site:v3' = [for site in web
 //@        "count": "[length(variables('websites'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -265,7 +265,7 @@ module siteDeploy 'br:mock-registry-two.invalid/demo/site:v3' = [for site in web
 //@        },
     appPlanId: appPlanDeploy.outputs.planId
 //@          "appPlanId": {
-//@            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2020-10-01').outputs.planId.value]"
+//@            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2022-09-01').outputs.planId.value]"
 //@          },
     namePrefix: site.name
 //@          "namePrefix": {
@@ -289,7 +289,7 @@ module siteDeploy2 'br/demo-two:site:v3' = [for site in websites: {
 //@        "count": "[length(variables('websites'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -377,7 +377,7 @@ module siteDeploy2 'br/demo-two:site:v3' = [for site in websites: {
 //@        },
     appPlanId: appPlanDeploy.outputs.planId
 //@          "appPlanId": {
-//@            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2020-10-01').outputs.planId.value]"
+//@            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', 'planDeploy'), '2022-09-01').outputs.planId.value]"
 //@          },
     namePrefix: site.name
 //@          "namePrefix": {
@@ -397,7 +397,7 @@ module siteDeploy2 'br/demo-two:site:v3' = [for site in websites: {
 module storageDeploy 'ts:00000000-0000-0000-0000-000000000000/test-rg/storage-spec:1.0' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -428,7 +428,7 @@ module storageDeploy 'ts:00000000-0000-0000-0000-000000000000/test-rg/storage-sp
 module storageDeploy2 'ts/mySpecRG:storage-spec:1.0' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -484,7 +484,7 @@ module vnetDeploy 'ts:11111111-1111-1111-1111-111111111111/prod-rg/vnet-spec:v2'
 //@        "count": "[length(variables('vnets'))]"
 //@      },
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -521,14 +521,14 @@ output siteUrls array = [for (site, i) in websites: siteDeploy[i].outputs.siteUr
 //@      "type": "array",
 //@      "copy": {
 //@        "count": "[length(variables('websites'))]",
-//@        "input": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', format('{0}siteDeploy', variables('websites')[copyIndex()].name)), '2020-10-01').outputs.siteUrl.value]"
+//@        "input": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'adotfrank-rg'), 'Microsoft.Resources/deployments', format('{0}siteDeploy', variables('websites')[copyIndex()].name)), '2022-09-01').outputs.siteUrl.value]"
 //@      }
 //@    }
 
 module passthroughPort 'br:localhost:5000/passthrough/port:v1' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -579,7 +579,7 @@ module passthroughPort 'br:localhost:5000/passthrough/port:v1' = {
 module ipv4 'br:127.0.0.1/passthrough/ipv4:v1' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -630,7 +630,7 @@ module ipv4 'br:127.0.0.1/passthrough/ipv4:v1' = {
 module ipv4port 'br:127.0.0.1:5000/passthrough/ipv4port:v1' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -681,7 +681,7 @@ module ipv4port 'br:127.0.0.1:5000/passthrough/ipv4port:v1' = {
 module ipv6 'br:[::1]/passthrough/ipv6:v1' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {
@@ -732,7 +732,7 @@ module ipv6 'br:[::1]/passthrough/ipv6:v1' = {
 module ipv6port 'br:[::1]:5000/passthrough/ipv6port:v1' = {
 //@    {
 //@      "type": "Microsoft.Resources/deployments",
-//@      "apiVersion": "2020-10-01",
+//@      "apiVersion": "2022-09-01",
 //@      "resourceGroup": "adotfrank-rg",
 //@      "properties": {
 //@        "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6826800482500580947"
+      "templateHash": "17291791314306692428"
     }
   },
   "variables": {
@@ -41,7 +41,7 @@
     },
     "appPlanDeploy": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "planDeploy",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -102,7 +102,7 @@
     },
     "appPlanDeploy2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "planDeploy2",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -167,7 +167,7 @@
         "count": "[length(variables('websites'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}siteDeploy', variables('websites')[copyIndex()].name)]",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -268,7 +268,7 @@
         "count": "[length(variables('websites'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}siteDeploy2', variables('websites')[copyIndex()].name)]",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -365,7 +365,7 @@
     },
     "storageDeploy": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "storageDeploy",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -388,7 +388,7 @@
     },
     "storageDeploy2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "storageDeploy2",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -415,7 +415,7 @@
         "count": "[length(variables('vnets'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}Deploy', variables('vnets')[copyIndex()].name)]",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -441,7 +441,7 @@
     },
     "passthroughPort": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "port",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -484,7 +484,7 @@
     },
     "ipv4": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv4",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -527,7 +527,7 @@
     },
     "ipv4port": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv4port",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -570,7 +570,7 @@
     },
     "ipv6": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv6",
       "resourceGroup": "adotfrank-rg",
       "properties": {
@@ -613,7 +613,7 @@
     },
     "ipv6port": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "ipv6port",
       "resourceGroup": "adotfrank-rg",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1539219181890185947"
+      "templateHash": "1060883810516541578"
     }
   },
   "parameters": {
@@ -142,7 +142,7 @@
     {
       "condition": "[variables('deployGroups')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "apimGroups",
       "properties": {
         "expressionEvaluationOptions": {
@@ -220,7 +220,7 @@
     {
       "condition": "[variables('deployUsers')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "apimUsers",
       "properties": {
         "expressionEvaluationOptions": {
@@ -295,7 +295,7 @@
     {
       "condition": "[variables('deployNameValuePairs')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "apimNameValuePairs",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3837822356568811887"
+      "templateHash": "4169629721319784163"
     }
   },
   "parameters": {
@@ -144,7 +144,7 @@
     "apimGroups": {
       "condition": "[variables('deployGroups')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "apimGroups",
       "properties": {
         "expressionEvaluationOptions": {
@@ -230,7 +230,7 @@
     "apimUsers": {
       "condition": "[variables('deployUsers')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "apimUsers",
       "properties": {
         "expressionEvaluationOptions": {
@@ -313,7 +313,7 @@
     "apimNVPairs": {
       "condition": "[variables('deployNameValuePairs')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "apimNameValuePairs",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-spring-cloud/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-spring-cloud/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8943762412804612021"
+      "templateHash": "4239200344224620335"
     }
   },
   "parameters": {
@@ -126,7 +126,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "setActiveDeployment",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-spring-cloud/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-spring-cloud/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12314803302758435083"
+      "templateHash": "399206377356114672"
     }
   },
   "parameters": {
@@ -128,7 +128,7 @@
     },
     "activeDeployment": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "setActiveDeployment",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/basic-publicip/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/basic-publicip/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7465735638459228836"
+      "templateHash": "10831612777047662097"
     }
   },
   "parameters": {
@@ -17,7 +17,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "publicIp",
       "properties": {
         "expressionEvaluationOptions": {
@@ -85,7 +85,7 @@
   "outputs": {
     "ipFqdn": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'publicIp'), '2020-10-01').outputs.ipFqdn.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'publicIp'), '2022-09-01').outputs.ipFqdn.value]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/basic-publicip/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/basic-publicip/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4444179136501566320"
+      "templateHash": "18429428395474695757"
     }
   },
   "parameters": {
@@ -19,7 +19,7 @@
   "resources": {
     "publicIp": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "publicIp",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/create-rg-lock-role-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/create-rg-lock-role-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12143792315987882936"
+      "templateHash": "12862994173378472724"
     }
   },
   "parameters": {
@@ -55,7 +55,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "applyLock",
       "resourceGroup": "[parameters('rgName')]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/create-rg-lock-role-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/create-rg-lock-role-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7994125576136996185"
+      "templateHash": "17267489257234649340"
     }
   },
   "parameters": {
@@ -57,7 +57,7 @@
     },
     "applyLock": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "applyLock",
       "resourceGroup": "[parameters('rgName')]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5265707706271113226"
+      "templateHash": "17944433273694515491"
     }
   },
   "parameters": {
@@ -29,7 +29,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hub-vnet",
       "resourceGroup": "hub-rg",
       "properties": {
@@ -110,7 +110,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "spoke-vnet",
       "resourceGroup": "spoke-rg",
       "properties": {
@@ -135,7 +135,7 @@
                 "properties": {
                   "addressPrefix": "10.0.0.0/24",
                   "routeTable": {
-                    "id": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'spoke-rg'), 'Microsoft.Resources/deployments', 'spoke-rot'), '2020-10-01').outputs.id.value]"
+                    "id": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'spoke-rg'), 'Microsoft.Resources/deployments', 'spoke-rot'), '2022-09-01').outputs.id.value]"
                   }
                 }
               }
@@ -196,7 +196,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hub-fwl",
       "resourceGroup": "hub-rg",
       "properties": {
@@ -209,7 +209,7 @@
             "value": "hub"
           },
           "hubId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-vnet'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-vnet'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -284,7 +284,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hub-to-spoke-peering",
       "resourceGroup": "hub-rg",
       "properties": {
@@ -294,13 +294,13 @@
         "mode": "Incremental",
         "parameters": {
           "localVnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-vnet'), '2020-10-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-vnet'), '2022-09-01').outputs.name.value]"
           },
           "remoteVnetName": {
             "value": "spoke"
           },
           "remoteVnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'spoke-rg'), 'Microsoft.Resources/deployments', 'spoke-vnet'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'spoke-rg'), 'Microsoft.Resources/deployments', 'spoke-vnet'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -350,7 +350,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "spoke-to-hub-peering",
       "resourceGroup": "spoke-rg",
       "properties": {
@@ -360,13 +360,13 @@
         "mode": "Incremental",
         "parameters": {
           "localVnetName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'spoke-rg'), 'Microsoft.Resources/deployments', 'spoke-vnet'), '2020-10-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'spoke-rg'), 'Microsoft.Resources/deployments', 'spoke-vnet'), '2022-09-01').outputs.name.value]"
           },
           "remoteVnetName": {
             "value": "hub"
           },
           "remoteVnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-vnet'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-vnet'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -416,7 +416,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "spoke-rot",
       "resourceGroup": "spoke-rg",
       "properties": {
@@ -429,7 +429,7 @@
             "value": "spoke"
           },
           "azFwlIp": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-fwl'), '2020-10-01').outputs.privateIp.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'hub-rg'), 'Microsoft.Resources/deployments', 'hub-fwl'), '2022-09-01').outputs.privateIp.value]"
           }
         },
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hub-and-spoke/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5659584937205744570"
+      "templateHash": "8557767377083791159"
     }
   },
   "parameters": {
@@ -31,7 +31,7 @@
     },
     "hubVNET": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hub-vnet",
       "resourceGroup": "hub-rg",
       "properties": {
@@ -114,7 +114,7 @@
     },
     "spokeVNET": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "spoke-vnet",
       "resourceGroup": "spoke-rg",
       "properties": {
@@ -202,7 +202,7 @@
     },
     "Hubfwl": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hub-fwl",
       "resourceGroup": "hub-rg",
       "properties": {
@@ -292,7 +292,7 @@
     },
     "HubToSpokePeering": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "hub-to-spoke-peering",
       "resourceGroup": "hub-rg",
       "properties": {
@@ -360,7 +360,7 @@
     },
     "SpokeToHubPeering": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "spoke-to-hub-peering",
       "resourceGroup": "spoke-rg",
       "properties": {
@@ -428,7 +428,7 @@
     },
     "route": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "spoke-rot",
       "resourceGroup": "spoke-rg",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4464118241273221545"
+      "templateHash": "15849314752825028364"
     }
   },
   "parameters": {
@@ -174,7 +174,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vmMod",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/1vm-2nics-2subnets-1vnet/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11186306488910279439"
+      "templateHash": "8858998543079328997"
     }
   },
   "parameters": {
@@ -176,7 +176,7 @@
     },
     "vmMod": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vmMod",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10568221366411196576"
+      "templateHash": "2741318052365544304"
     }
   },
   "parameters": {
@@ -53,7 +53,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "network",
       "properties": {
         "expressionEvaluationOptions": {
@@ -174,7 +174,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "anchor",
       "properties": {
         "expressionEvaluationOptions": {
@@ -189,7 +189,7 @@
             "value": "[resourceId('Microsoft.Compute/proximityPlacementGroups', 'Zone1')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "vmName": {
             "value": "anchor"
@@ -342,7 +342,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm01",
       "properties": {
         "expressionEvaluationOptions": {
@@ -357,7 +357,7 @@
             "value": "[resourceId('Microsoft.Compute/availabilitySets', 'as1')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "vmName": {
             "value": "vm01"
@@ -475,7 +475,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm02",
       "properties": {
         "expressionEvaluationOptions": {
@@ -490,7 +490,7 @@
             "value": "[resourceId('Microsoft.Compute/availabilitySets', 'as1')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "vmName": {
             "value": "vm02"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/anchored-proximity-placement-group/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16060564196779168614"
+      "templateHash": "13068808920884968922"
     }
   },
   "parameters": {
@@ -55,7 +55,7 @@
     },
     "network": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "network",
       "properties": {
         "expressionEvaluationOptions": {
@@ -178,7 +178,7 @@
     },
     "vmA": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "anchor",
       "properties": {
         "expressionEvaluationOptions": {
@@ -348,7 +348,7 @@
     },
     "vm01": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm01",
       "properties": {
         "expressionEvaluationOptions": {
@@ -483,7 +483,7 @@
     },
     "vm02": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm02",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2428758099845201020"
+      "templateHash": "3547092196470580673"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "myBicepLADiag",
       "resourceGroup": "[parameters('avdBackplaneResourceGroup')]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-LogAnalytics.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9489776290084525595"
+      "templateHash": "17360174109371358486"
     }
   },
   "parameters": {
@@ -46,7 +46,7 @@
     },
     "avdmonitor": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "myBicepLADiag",
       "resourceGroup": "[parameters('avdBackplaneResourceGroup')]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15925634747314689617"
+      "templateHash": "8569593233825144249"
     }
   },
   "parameters": {
@@ -108,7 +108,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "LAWorkspace",
       "resourceGroup": "[parameters('logAnalyticsResourceGroup')]",
       "properties": {
@@ -143,7 +143,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2428758099845201020"
+              "templateHash": "3547092196470580673"
             }
           },
           "parameters": {
@@ -182,7 +182,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myBicepLADiag",
               "resourceGroup": "[parameters('avdBackplaneResourceGroup')]",
               "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-backplane-module.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2067854167452600134"
+      "templateHash": "14232420119402199964"
     }
   },
   "parameters": {
@@ -110,7 +110,7 @@
     },
     "avdmonitor": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "LAWorkspace",
       "resourceGroup": "[parameters('logAnalyticsResourceGroup')]",
       "properties": {
@@ -147,7 +147,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9489776290084525595"
+              "templateHash": "17360174109371358486"
             }
           },
           "parameters": {
@@ -186,7 +186,7 @@
             },
             "avdmonitor": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "myBicepLADiag",
               "resourceGroup": "[parameters('avdBackplaneResourceGroup')]",
               "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12784656623399232906"
+      "templateHash": "2681152781874804439"
     }
   },
   "parameters": {
@@ -163,7 +163,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdbackplane",
       "resourceGroup": "[format('{0}BACKPLANE', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -225,7 +225,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15925634747314689617"
+              "templateHash": "8569593233825144249"
             }
           },
           "parameters": {
@@ -328,7 +328,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "LAWorkspace",
               "resourceGroup": "[parameters('logAnalyticsResourceGroup')]",
               "properties": {
@@ -363,7 +363,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "2428758099845201020"
+                      "templateHash": "3547092196470580673"
                     }
                   },
                   "parameters": {
@@ -402,7 +402,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myBicepLADiag",
                       "resourceGroup": "[parameters('avdBackplaneResourceGroup')]",
                       "properties": {
@@ -526,7 +526,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdnetwork",
       "resourceGroup": "[format('{0}NETWORK', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -642,7 +642,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdFileServices",
       "resourceGroup": "[format('{0}FILESERVICES', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -733,7 +733,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "privateEndpoint",
       "resourceGroup": "[format('{0}NETWORK', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -749,13 +749,13 @@
             "value": "pep-sto"
           },
           "storageAccountId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}FILESERVICES', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdFileServices'), '2020-10-01').outputs.storageAccountId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}FILESERVICES', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdFileServices'), '2022-09-01').outputs.storageAccountId.value]"
           },
           "vnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdnetwork'), '2020-10-01').outputs.vnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdnetwork'), '2022-09-01').outputs.vnetId.value]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdnetwork'), '2020-10-01').outputs.subnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}NETWORK', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdnetwork'), '2022-09-01').outputs.subnetId.value]"
           }
         },
         "template": {
@@ -868,7 +868,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdsig",
       "resourceGroup": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -1042,7 +1042,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('avdimagebuilder{0}', 'avdsig')]",
       "resourceGroup": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -1067,7 +1067,7 @@
             "value": "[parameters('imageSKU')]"
           },
           "galleryImageId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}SIG', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdsig'), '2020-10-01').outputs.avdidoutput.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}SIG', parameters('resourceGroupPrefrix'))), 'Microsoft.Resources/deployments', 'avdsig'), '2022-09-01').outputs.avdidoutput.value]"
           },
           "InvokeRunImageBuildThroughDeploymentScript": {
             "value": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9782243042621896192"
+      "templateHash": "3562708831309571470"
     }
   },
   "parameters": {
@@ -165,7 +165,7 @@
     },
     "avdbackplane": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdbackplane",
       "resourceGroup": "[format('{0}BACKPLANE', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -229,7 +229,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2067854167452600134"
+              "templateHash": "14232420119402199964"
             }
           },
           "parameters": {
@@ -332,7 +332,7 @@
             },
             "avdmonitor": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "LAWorkspace",
               "resourceGroup": "[parameters('logAnalyticsResourceGroup')]",
               "properties": {
@@ -369,7 +369,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "9489776290084525595"
+                      "templateHash": "17360174109371358486"
                     }
                   },
                   "parameters": {
@@ -408,7 +408,7 @@
                     },
                     "avdmonitor": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "myBicepLADiag",
                       "resourceGroup": "[parameters('avdBackplaneResourceGroup')]",
                       "properties": {
@@ -546,7 +546,7 @@
     },
     "avdnetwork": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdnetwork",
       "resourceGroup": "[format('{0}NETWORK', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -664,7 +664,7 @@
     },
     "avdFileServices": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdFileServices",
       "resourceGroup": "[format('{0}FILESERVICES', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -757,7 +757,7 @@
     },
     "pep": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "privateEndpoint",
       "resourceGroup": "[format('{0}NETWORK', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -894,7 +894,7 @@
     },
     "avdsig": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "avdsig",
       "resourceGroup": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
       "properties": {
@@ -1070,7 +1070,7 @@
     },
     "avdaib": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('avdimagebuilder{0}', 'avdsig')]",
       "resourceGroup": "[format('{0}SIG', parameters('resourceGroupPrefrix'))]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1741291079951645308"
+      "templateHash": "11164534960160840547"
     }
   },
   "parameters": {
@@ -66,7 +66,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "network",
       "properties": {
         "expressionEvaluationOptions": {
@@ -187,7 +187,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "cycleserver",
       "properties": {
         "expressionEvaluationOptions": {
@@ -202,7 +202,7 @@
             "value": "[variables('customData')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(resourceId('Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "userAssignedIdentity": {
             "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'CycleCloud-MI')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cyclecloud/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2727258305323069403"
+      "templateHash": "1344477251848009864"
     }
   },
   "parameters": {
@@ -68,7 +68,7 @@
     },
     "network": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "network",
       "properties": {
         "expressionEvaluationOptions": {
@@ -191,7 +191,7 @@
     },
     "vm": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "cycleserver",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5790911459543227271"
+      "templateHash": "12171729092113973289"
     }
   },
   "parameters": {
@@ -23,7 +23,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "policy",
       "location": "[deployment().location]",
       "properties": {
@@ -386,7 +386,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "assignment",
       "location": "[deployment().location]",
       "properties": {
@@ -396,7 +396,7 @@
         "mode": "Incremental",
         "parameters": {
           "monitoringGovernanceId": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', 'policy'), '2020-10-01').outputs.monitoringGovernanceId.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', 'policy'), '2022-09-01').outputs.monitoringGovernanceId.value]"
           },
           "assignmentIdentityLocation": {
             "value": "[parameters('assignmentIdentityLocation')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/policy-azmonitor-agent-and-dcr-association/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1245359541512081358"
+      "templateHash": "7177604768617228482"
     }
   },
   "parameters": {
@@ -25,7 +25,7 @@
   "resources": {
     "policy": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "policy",
       "location": "[deployment().location]",
       "properties": {
@@ -390,7 +390,7 @@
     },
     "assignment": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "assignment",
       "location": "[deployment().location]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14082802463726556737"
+      "templateHash": "3234558960987152966"
     }
   },
   "parameters": {
@@ -484,7 +484,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vnet",
       "properties": {
         "expressionEvaluationOptions": {
@@ -819,7 +819,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "bastion",
       "properties": {
         "expressionEvaluationOptions": {
@@ -831,7 +831,7 @@
             "value": "[parameters('bastionName')]"
           },
           "bastionSubnetId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2020-10-01').outputs.bastionSubnetId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2022-09-01').outputs.bastionSubnetId.value]"
           },
           "location": {
             "value": "[parameters('location')]"
@@ -917,7 +917,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "log-analytics.bicep",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1008,7 +1008,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "jumpbox",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1062,13 +1062,13 @@
             "value": "[parameters('blobStorageAccountPrivateEndpointName')]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep'), '2020-10-01').outputs.logAnalyticsWorkspaceId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep'), '2022-09-01').outputs.logAnalyticsWorkspaceId.value]"
           },
           "virtualNetworkId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2020-10-01').outputs.virtualNetworkResourceId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2022-09-01').outputs.virtualNetworkResourceId.value]"
           },
           "vmSubnetId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2020-10-01').outputs.vmSubnetId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2022-09-01').outputs.vmSubnetId.value]"
           }
         },
         "template": {
@@ -1447,7 +1447,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "aks",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1567,10 +1567,10 @@
             "value": "[parameters('nodePoolVmSize')]"
           },
           "virtualNetworkId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2020-10-01').outputs.virtualNetworkResourceId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2022-09-01').outputs.virtualNetworkResourceId.value]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep'), '2020-10-01').outputs.logAnalyticsWorkspaceId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep'), '2022-09-01').outputs.logAnalyticsWorkspaceId.value]"
           }
         },
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "428520512058815685"
+      "templateHash": "9451447587212366180"
     }
   },
   "parameters": {
@@ -486,7 +486,7 @@
   "resources": {
     "vnet": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vnet",
       "properties": {
         "expressionEvaluationOptions": {
@@ -850,7 +850,7 @@
     },
     "bastion": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "bastion",
       "properties": {
         "expressionEvaluationOptions": {
@@ -950,7 +950,7 @@
     },
     "logAnalytics": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "log-analytics.bicep",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1043,7 +1043,7 @@
     },
     "jumpbox": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "jumpbox",
       "properties": {
         "expressionEvaluationOptions": {
@@ -1490,7 +1490,7 @@
     },
     "aks": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "aks",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15697172255155232419"
+      "templateHash": "11745064405835740649"
     }
   },
   "parameters": {
@@ -47,7 +47,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "network",
       "resourceGroup": "bicep-network-rg",
       "properties": {
@@ -172,7 +172,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "anchor",
       "resourceGroup": "bicep-anchor-rg",
       "properties": {
@@ -185,7 +185,7 @@
             "value": "[parameters('adminSshKey')]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-network-rg'), 'Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-network-rg'), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "vmName": {
             "value": "anchor"
@@ -351,7 +351,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm01",
       "resourceGroup": "bicep-workload-rg",
       "properties": {
@@ -364,10 +364,10 @@
             "value": "[parameters('adminSshKey')]"
           },
           "ppgId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-anchor-rg'), 'Microsoft.Resources/deployments', 'anchor'), '2020-10-01').outputs.ppgId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-anchor-rg'), 'Microsoft.Resources/deployments', 'anchor'), '2022-09-01').outputs.ppgId.value]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-network-rg'), 'Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-network-rg'), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "vmName": {
             "value": "vm01"
@@ -503,7 +503,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm02",
       "resourceGroup": "bicep-workload-rg",
       "properties": {
@@ -516,10 +516,10 @@
             "value": "[parameters('adminSshKey')]"
           },
           "ppgId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-anchor-rg'), 'Microsoft.Resources/deployments', 'anchor'), '2020-10-01').outputs.ppgId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-anchor-rg'), 'Microsoft.Resources/deployments', 'anchor'), '2022-09-01').outputs.ppgId.value]"
           },
           "subnetId": {
-            "value": "[format('{0}/subnets/Default', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-network-rg'), 'Microsoft.Resources/deployments', 'network'), '2020-10-01').outputs.vnetId.value)]"
+            "value": "[format('{0}/subnets/Default', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'bicep-network-rg'), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.vnetId.value)]"
           },
           "vmName": {
             "value": "vm02"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/proximity-placement-with-multi-resource-groups/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15022094691720197916"
+      "templateHash": "2161638637279308186"
     }
   },
   "parameters": {
@@ -49,7 +49,7 @@
     },
     "network": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "network",
       "resourceGroup": "bicep-network-rg",
       "properties": {
@@ -176,7 +176,7 @@
     },
     "ppg": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "anchor",
       "resourceGroup": "bicep-anchor-rg",
       "properties": {
@@ -357,7 +357,7 @@
     },
     "vm01": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm01",
       "resourceGroup": "bicep-workload-rg",
       "properties": {
@@ -511,7 +511,7 @@
     },
     "vm02": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vm02",
       "resourceGroup": "bicep-workload-rg",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4831046691818870354"
+      "templateHash": "18139798135441946142"
     }
   },
   "parameters": {
@@ -21,7 +21,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "webAppPlanDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -142,7 +142,7 @@
     {
       "condition": "[parameters('logging')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "loggingDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -151,7 +151,7 @@
         "mode": "Incremental",
         "parameters": {
           "appName": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'webAppPlanDeploy'), '2020-10-01').outputs.appServiceName.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'webAppPlanDeploy'), '2022-09-01').outputs.appServiceName.value]"
           }
         },
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-conditional-log/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1889610016231344093"
+      "templateHash": "5451253905307483118"
     }
   },
   "parameters": {
@@ -23,7 +23,7 @@
   "resources": {
     "webappModule": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "webAppPlanDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -146,7 +146,7 @@
     "loggingModule": {
       "condition": "[parameters('logging')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "loggingDeploy",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "3681483897619266264"
+      "templateHash": "2507679041385979875"
     }
   },
   "parameters": {
@@ -17,7 +17,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "appServicePlanDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -86,7 +86,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "appServiceDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -98,10 +98,10 @@
             "value": "[parameters('appName')]"
           },
           "appServicePlanID": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appServicePlanDeploy'), '2020-10-01').outputs.appServicePlanID.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appServicePlanDeploy'), '2022-09-01').outputs.appServicePlanID.value]"
           },
           "APPINSIGHTS_INSTRUMENTATIONKEY": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appInsightsDeploy'), '2020-10-01').outputs.APPINSIGHTS_INSTRUMENTATIONKEY.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'appInsightsDeploy'), '2022-09-01').outputs.APPINSIGHTS_INSTRUMENTATIONKEY.value]"
           }
         },
         "template": {
@@ -209,7 +209,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "appInsightsDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -221,7 +221,7 @@
             "value": "[parameters('appName')]"
           },
           "logAnalaticsWorkspaceResourceID": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalyticsWorkspaceDeploy'), '2020-10-01').outputs.logAnalaticsWorkspaceResourceID.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'logAnalyticsWorkspaceDeploy'), '2022-09-01').outputs.logAnalaticsWorkspaceResourceID.value]"
           }
         },
         "template": {
@@ -280,7 +280,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "logAnalyticsWorkspaceDeploy",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/web-app-loganalytics-mod/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1398436724047333027"
+      "templateHash": "13077378601139967077"
     }
   },
   "parameters": {
@@ -19,7 +19,7 @@
   "resources": {
     "appServicePlanModule": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "appServicePlanDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -90,7 +90,7 @@
     },
     "appServiceModule": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "appServiceDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -215,7 +215,7 @@
     },
     "appInsightsModule": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "appInsightsDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -288,7 +288,7 @@
     },
     "logAnalyticsWorkspace": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "logAnalyticsWorkspaceDeploy",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15497682551507496643"
+      "templateHash": "16044931613901748829"
     }
   },
   "parameters": {
@@ -572,7 +572,7 @@
     {
       "condition": "[parameters('addToWorkspace')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('Workspace-linkedTemplate-{0}', parameters('deploymentId'))]",
       "resourceGroup": "[variables('workspaceResourceGroup_var')]",
       "properties": {
@@ -629,7 +629,7 @@
     {
       "condition": "[and(and(variables('createVMs'), equals(parameters('availabilityOption'), 'AvailabilitySet')), parameters('createAvailabilitySet'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "AVSet-deployment",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -712,7 +712,7 @@
     {
       "condition": "[and(and(variables('createVMs'), equals(parameters('vmImageType'), 'CustomVHD')), parameters('vmUseManagedDisks'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-managedDisks-customvhdvm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -837,7 +837,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11987168975588361348"
+              "templateHash": "5496671400759637143"
             }
           },
           "parameters": {
@@ -1321,7 +1321,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1398,7 +1398,7 @@
     {
       "condition": "[and(and(variables('createVMs'), equals(parameters('vmImageType'), 'CustomVHD')), not(parameters('vmUseManagedDisks')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-unmanagedDisks-customvhdvm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -1523,7 +1523,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9080275681022015337"
+              "templateHash": "12820056084073504429"
             }
           },
           "parameters": {
@@ -1992,7 +1992,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2069,7 +2069,7 @@
     {
       "condition": "[and(variables('createVMs'), equals(parameters('vmImageType'), 'CustomImage'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-managedDisks-customimagevm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -2194,7 +2194,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "18101554483569597011"
+              "templateHash": "5275119469596650755"
             }
           },
           "parameters": {
@@ -2659,7 +2659,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2736,7 +2736,7 @@
     {
       "condition": "[and(and(variables('createVMs'), equals(parameters('vmImageType'), 'Gallery')), parameters('vmUseManagedDisks'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-managedDisks-galleryvm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -2861,7 +2861,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15709312384976462390"
+              "templateHash": "951626561695186356"
             }
           },
           "parameters": {
@@ -3329,7 +3329,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10697799942139425780"
+      "templateHash": "14641791797984039205"
     }
   },
   "parameters": {
@@ -574,7 +574,7 @@
     "workspace": {
       "condition": "[parameters('addToWorkspace')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('Workspace-linkedTemplate-{0}', parameters('deploymentId'))]",
       "resourceGroup": "[variables('workspaceResourceGroup_var')]",
       "properties": {
@@ -633,7 +633,7 @@
     "AVSet": {
       "condition": "[and(and(variables('createVMs'), equals(parameters('availabilityOption'), 'AvailabilitySet')), parameters('createAvailabilitySet'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "AVSet-deployment",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -718,7 +718,7 @@
     "vmCreation_customVHD_managedDisks": {
       "condition": "[and(and(variables('createVMs'), equals(parameters('vmImageType'), 'CustomVHD')), parameters('vmUseManagedDisks'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-managedDisks-customvhdvm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -845,7 +845,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14729746078648953301"
+              "templateHash": "11281229788072385683"
             }
           },
           "parameters": {
@@ -1329,7 +1329,7 @@
             },
             "NSG": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -1408,7 +1408,7 @@
     "vmCreation_customVHD_unmanagedDisks": {
       "condition": "[and(and(variables('createVMs'), equals(parameters('vmImageType'), 'CustomVHD')), not(parameters('vmUseManagedDisks')))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-unmanagedDisks-customvhdvm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -1535,7 +1535,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "12358829301622519981"
+              "templateHash": "14190063536201337959"
             }
           },
           "parameters": {
@@ -2004,7 +2004,7 @@
             },
             "NSG": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2083,7 +2083,7 @@
     "vmCreation_customeImage": {
       "condition": "[and(variables('createVMs'), equals(parameters('vmImageType'), 'CustomImage'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-managedDisks-customimagevm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -2210,7 +2210,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11565825066403435536"
+              "templateHash": "5228748956448808827"
             }
           },
           "parameters": {
@@ -2675,7 +2675,7 @@
             },
             "NSG": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -2754,7 +2754,7 @@
     "vmCreation_Gallery": {
       "condition": "[and(and(variables('createVMs'), equals(parameters('vmImageType'), 'Gallery')), parameters('vmUseManagedDisks'))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('vmCreation-linkedTemplate-{0}-managedDisks-galleryvm', parameters('deploymentId'))]",
       "resourceGroup": "[parameters('vmResourceGroup')]",
       "properties": {
@@ -2881,7 +2881,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5842820804083342742"
+              "templateHash": "5026583956773796744"
             }
           },
           "parameters": {
@@ -3349,7 +3349,7 @@
             },
             "NSG": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "NSG-linkedTemplate",
               "properties": {
                 "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18101554483569597011"
+      "templateHash": "5275119469596650755"
     }
   },
   "parameters": {
@@ -396,11 +396,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -416,11 +416,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -439,11 +439,11 @@
       ]
     },
     {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -470,7 +470,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customimagevm.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11565825066403435536"
+      "templateHash": "5228748956448808827"
     }
   },
   "parameters": {
@@ -398,11 +398,11 @@
       ]
     },
     "vm_AADLoginForWindows": {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -418,11 +418,11 @@
       ]
     },
     "vm_AADLoginForWindowsWithIntune": {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -441,11 +441,11 @@
       ]
     },
     "vm_joindomain": {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -472,7 +472,7 @@
     },
     "NSG": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11987168975588361348"
+      "templateHash": "5496671400759637143"
     }
   },
   "parameters": {
@@ -415,11 +415,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -435,11 +435,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -458,11 +458,11 @@
       ]
     },
     {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -489,7 +489,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-customvhdvm.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14729746078648953301"
+      "templateHash": "11281229788072385683"
     }
   },
   "parameters": {
@@ -417,11 +417,11 @@
       ]
     },
     "vm_AADLoginForWindows": {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -437,11 +437,11 @@
       ]
     },
     "vm_AADLoginForWindowsWithIntune": {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -460,11 +460,11 @@
       ]
     },
     "vm_joindomain": {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -491,7 +491,7 @@
     },
     "NSG": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15709312384976462390"
+      "templateHash": "951626561695186356"
     }
   },
   "parameters": {
@@ -399,11 +399,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -419,11 +419,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -442,11 +442,11 @@
       ]
     },
     {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -473,7 +473,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/managedDisks-galleryvm.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5842820804083342742"
+      "templateHash": "5026583956773796744"
     }
   },
   "parameters": {
@@ -401,11 +401,11 @@
       ]
     },
     "vm_AADLoginForWindows": {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -421,11 +421,11 @@
       ]
     },
     "vm_AADLoginForWindowsWithIntune": {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -444,11 +444,11 @@
       ]
     },
     "vm_joindomain": {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -475,7 +475,7 @@
     },
     "NSG": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9080275681022015337"
+      "templateHash": "12820056084073504429"
     }
   },
   "parameters": {
@@ -400,11 +400,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -420,11 +420,11 @@
       ]
     },
     {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -443,11 +443,11 @@
       ]
     },
     {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -474,7 +474,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/modules/unmanagedDisks-customvhdvm.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12358829301622519981"
+      "templateHash": "14190063536201337959"
     }
   },
   "parameters": {
@@ -402,11 +402,11 @@
       ]
     },
     "vm_AADLoginForWindows": {
-      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "copy": {
         "name": "vm_AADLoginForWindows",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), not(parameters('intune')))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindows', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -422,11 +422,11 @@
       ]
     },
     "vm_AADLoginForWindowsWithIntune": {
-      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "copy": {
         "name": "vm_AADLoginForWindowsWithIntune",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[and(parameters('aadJoin'), parameters('intune'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/AADLoginForWindowsWithIntune', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -445,11 +445,11 @@
       ]
     },
     "vm_joindomain": {
-      "condition": "[not(parameters('aadJoin'))]",
       "copy": {
         "name": "vm_joindomain",
         "count": "[length(range(0, parameters('rdshNumberOfInstances')))]"
       },
+      "condition": "[not(parameters('aadJoin'))]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2018-10-01",
       "name": "[format('{0}{1}/joindomain', parameters('rdshPrefix'), add(range(0, parameters('rdshNumberOfInstances'))[copyIndex()], parameters('vmInitialNumber')))]",
@@ -476,7 +476,7 @@
     },
     "NSG": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "NSG-linkedTemplate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6815454708028283922"
+      "templateHash": "11445298703890420186"
     }
   },
   "parameters": {
@@ -115,7 +115,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "actionGroup",
       "resourceGroup": "[parameters('resourceGroupName')]",
       "properties": {
@@ -210,7 +210,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "policy",
       "location": "[deployment().location]",
       "properties": {
@@ -220,13 +220,13 @@
         "mode": "Incremental",
         "parameters": {
           "actionGroupName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'actionGroup'), '2020-10-01').outputs.actionGroupName.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'actionGroup'), '2022-09-01').outputs.actionGroupName.value]"
           },
           "actionGroupRG": {
             "value": "[parameters('resourceGroupName')]"
           },
           "actionGroupId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'actionGroup'), '2020-10-01').outputs.actionGroupId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('resourceGroupName')), 'Microsoft.Resources/deployments', 'actionGroup'), '2022-09-01').outputs.actionGroupId.value]"
           },
           "metricAlertResourceNamespace": {
             "value": "[parameters('metricAlertResourceNamespace')]"
@@ -583,7 +583,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "assignment",
       "location": "[deployment().location]",
       "properties": {
@@ -593,7 +593,7 @@
         "mode": "Incremental",
         "parameters": {
           "bicepExampleInitiativeId": {
-            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', 'policy'), '2020-10-01').outputs.bicepExampleInitiativeId.value]"
+            "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', 'policy'), '2022-09-01').outputs.bicepExampleInitiativeId.value]"
           },
           "assignmentIdentityLocation": {
             "value": "[parameters('resourceGrouplocation')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployifnotexists-policy-with-initiative-and-assignment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17956464977895668129"
+      "templateHash": "17913465126883830954"
     }
   },
   "parameters": {
@@ -117,7 +117,7 @@
     },
     "ag": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "actionGroup",
       "resourceGroup": "[parameters('resourceGroupName')]",
       "properties": {
@@ -214,7 +214,7 @@
     },
     "policy": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "policy",
       "location": "[deployment().location]",
       "properties": {
@@ -589,7 +589,7 @@
     },
     "assignment": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "assignment",
       "location": "[deployment().location]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18096088897546366532"
+      "templateHash": "17567947960576152813"
     }
   },
   "parameters": {
@@ -43,7 +43,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-deploy', parameters('storageName'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -156,7 +156,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-deploy', parameters('containerName'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -171,13 +171,13 @@
             "value": "[parameters('location')]"
           },
           "storageName": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-deploy', parameters('storageName'))), '2020-10-01').outputs.storageName.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-deploy', parameters('storageName'))), '2022-09-01').outputs.storageName.value]"
           },
           "storageId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-deploy', parameters('storageName'))), '2020-10-01').outputs.resourceId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-deploy', parameters('storageName'))), '2022-09-01').outputs.resourceId.value]"
           },
           "fileShareName": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-deploy', parameters('storageName'))), '2020-10-01').outputs.fileShareName.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-deploy', parameters('storageName'))), '2022-09-01').outputs.fileShareName.value]"
           },
           "type": {
             "value": "[parameters('type')]"

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/deployment-script-dev-environment/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16089438292107659838"
+      "templateHash": "14796059719308117528"
     }
   },
   "parameters": {
@@ -45,7 +45,7 @@
   "resources": {
     "storage": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-deploy', parameters('storageName'))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -160,7 +160,7 @@
     },
     "container": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-deploy', parameters('containerName'))]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5090156930551489182"
+      "templateHash": "7505587682154385275"
     }
   },
   "parameters": {
@@ -181,7 +181,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-{1}-sni-enable', deployment().name, parameters('applicationName'))]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11652692909663690723"
+      "templateHash": "5931821411364537702"
     }
   },
   "parameters": {
@@ -183,7 +183,7 @@
     },
     "functionAppCustomHostEnable": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('{0}-{1}-sni-enable', deployment().name, parameters('applicationName'))]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17070701769985672199"
+      "templateHash": "3169094683099930793"
     }
   },
   "parameters": {
@@ -69,7 +69,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('vnetname')]",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -331,7 +331,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vpngw-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -347,7 +347,7 @@
             "value": "[variables('vpngwname')]"
           },
           "subnetref": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', variables('vnetname')), '2020-10-01').outputs.subnets.value[2].id]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', variables('vnetname')), '2022-09-01').outputs.subnets.value[2].id]"
           },
           "vpngwpipname": {
             "value": "[variables('vpngwpipname')]"
@@ -468,7 +468,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "fwpolicy-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -636,7 +636,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "pip-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -743,7 +743,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "fw-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -762,13 +762,13 @@
             "value": "VNet"
           },
           "fwpolicyid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'fwpolicy-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'fwpolicy-deploy'), '2022-09-01').outputs.id.value]"
           },
           "publicipid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'pip-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'pip-deploy'), '2022-09-01').outputs.id.value]"
           },
           "subnetid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', variables('vnetname')), '2020-10-01').outputs.subnets.value[3].id]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', variables('vnetname')), '2022-09-01').outputs.subnets.value[3].id]"
           }
         },
         "template": {
@@ -899,7 +899,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vwan-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -976,7 +976,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhub-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -995,7 +995,7 @@
             "value": "10.10.0.0/24"
           },
           "wanid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vwan-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vwan-deploy'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -1067,7 +1067,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubfwpolicy-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1235,7 +1235,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubfw-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1254,13 +1254,13 @@
             "value": "vWAN"
           },
           "hubid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhub-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhub-deploy'), '2022-09-01').outputs.id.value]"
           },
           "hubpublicipcount": {
             "value": 1
           },
           "fwpolicyid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubfwpolicy-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubfwpolicy-deploy'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -1390,7 +1390,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubvpngw",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1406,7 +1406,7 @@
             "value": "[variables('vhubvpngwname')]"
           },
           "hubid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhub-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhub-deploy'), '2022-09-01').outputs.id.value]"
           },
           "asn": {
             "value": 65515
@@ -1490,7 +1490,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vwanvpnsite-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1506,19 +1506,19 @@
             "value": "[parameters('vwanlocation')]"
           },
           "addressprefix": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', variables('vnetname')), '2020-10-01').outputs.vnetaddress.value[0]]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', variables('vnetname')), '2022-09-01').outputs.vnetaddress.value[0]]"
           },
           "bgppeeringpddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2020-10-01').outputs.vpngwbgpaddress.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2022-09-01').outputs.vpngwbgpaddress.value]"
           },
           "ipaddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2020-10-01').outputs.vpngwip.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2022-09-01').outputs.vpngwip.value]"
           },
           "remotesiteasn": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2020-10-01').outputs.bgpasn.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2022-09-01').outputs.bgpasn.value]"
           },
           "wanid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vwan-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vwan-deploy'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -1614,7 +1614,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubs2s-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1624,13 +1624,13 @@
         "mode": "Incremental",
         "parameters": {
           "hubvpngwname": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2020-10-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2022-09-01').outputs.name.value]"
           },
           "psk": {
             "value": "[parameters('psk')]"
           },
           "vpnsiteid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vwanvpnsite-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vwanvpnsite-deploy'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {
@@ -1685,7 +1685,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vnets2s-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1702,26 +1702,26 @@
           },
           "addressprefixes": {
             "value": [
-              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhub-deploy'), '2020-10-01').outputs.vhubaddress.value]"
+              "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhub-deploy'), '2022-09-01').outputs.vhubaddress.value]"
             ]
           },
           "connectionname": {
             "value": "[variables('vpnconname')]"
           },
           "bgppeeringpddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2020-10-01').outputs.gwprivateip.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2022-09-01').outputs.gwprivateip.value]"
           },
           "gwipaddress": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2020-10-01').outputs.gwpublicip.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2022-09-01').outputs.gwpublicip.value]"
           },
           "remotesiteasn": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2020-10-01').outputs.bgpasn.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-vwan-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vhubvpngw'), '2022-09-01').outputs.bgpasn.value]"
           },
           "psk": {
             "value": "[parameters('psk')]"
           },
           "vpngwid": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2020-10-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-hubvnet-rg', parameters('nameprefix'))), 'Microsoft.Resources/deployments', 'vpngw-deploy'), '2022-09-01').outputs.id.value]"
           }
         },
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/modules-vwan-to-vnet-s2s-with-fw/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2021617875632265089"
+      "templateHash": "656388433720155968"
     }
   },
   "parameters": {
@@ -71,7 +71,7 @@
     },
     "vnet": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('vnetname')]",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -335,7 +335,7 @@
     },
     "vpngw": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vpngw-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -474,7 +474,7 @@
     },
     "fwpolicy": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "fwpolicy-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -644,7 +644,7 @@
     },
     "fwpip": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "pip-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -753,7 +753,7 @@
     },
     "fw": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "fw-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {
@@ -911,7 +911,7 @@
     },
     "vwan": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vwan-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -990,7 +990,7 @@
     },
     "vhub": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhub-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1083,7 +1083,7 @@
     },
     "vhubfwpolicy": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubfwpolicy-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1253,7 +1253,7 @@
     },
     "vhubfw": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubfw-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1410,7 +1410,7 @@
     },
     "vhubvpngw": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubvpngw",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1512,7 +1512,7 @@
     },
     "vwanvpnsite": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vwanvpnsite-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1638,7 +1638,7 @@
     },
     "vhubs2s": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vhubs2s-deploy",
       "resourceGroup": "[format('{0}-vwan-rg', parameters('nameprefix'))]",
       "properties": {
@@ -1711,7 +1711,7 @@
     },
     "vnets2s": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "vnets2s-deploy",
       "resourceGroup": "[format('{0}-hubvnet-rg', parameters('nameprefix'))]",
       "properties": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10921241789386566543"
+      "templateHash": "15170593239736320559"
     }
   },
   "parameters": {
@@ -215,7 +215,7 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('azureVMsSubnetNSGName'))]"
               },
               "routeTable": {
-                "id": "[reference(resourceId('Microsoft.Resources/deployments', 'udrDeploy'), '2020-10-01').outputs.udrId.value]"
+                "id": "[reference(resourceId('Microsoft.Resources/deployments', 'udrDeploy'), '2022-09-01').outputs.udrId.value]"
               }
             }
           }
@@ -274,13 +274,13 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2020-10-01').outputs.nicId.value]",
+              "id": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2022-09-01').outputs.nicId.value]",
               "properties": {
                 "primary": true
               }
             },
             {
-              "id": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2020-10-01').outputs.nicId.value]",
+              "id": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2022-09-01').outputs.nicId.value]",
               "properties": {
                 "primary": false
               }
@@ -330,7 +330,7 @@
           "fileUris": [
             "[variables('HVHostSetupScriptUri')]"
           ],
-          "commandToExecute": "[format('powershell -ExecutionPolicy Unrestricted -File HVHostSetup.ps1 -NIC1IPAddress {0} -NIC2IPAddress {1} -GhostedSubnetPrefix {2} -VirtualNetworkPrefix {3}', reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2020-10-01').outputs.assignedIp.value, reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2020-10-01').outputs.assignedIp.value, parameters('ghostedSubnetPrefix'), parameters('virtualNetworkAddressPrefix'))]"
+          "commandToExecute": "[format('powershell -ExecutionPolicy Unrestricted -File HVHostSetup.ps1 -NIC1IPAddress {0} -NIC2IPAddress {1} -GhostedSubnetPrefix {2} -VirtualNetworkPrefix {3}', reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2022-09-01').outputs.assignedIp.value, reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2022-09-01').outputs.assignedIp.value, parameters('ghostedSubnetPrefix'), parameters('virtualNetworkAddressPrefix'))]"
         }
       },
       "dependsOn": [
@@ -341,7 +341,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "createNic1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -445,7 +445,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "createNic2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -548,7 +548,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "updateNic1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -560,7 +560,7 @@
             "value": "Static"
           },
           "staticIpAddress": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2020-10-01').outputs.assignedIp.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2022-09-01').outputs.assignedIp.value]"
           },
           "nicName": {
             "value": "[parameters('HostNetworkInterface1Name')]"
@@ -659,7 +659,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "updateNic2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -671,7 +671,7 @@
             "value": "Static"
           },
           "staticIpAddress": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2020-10-01').outputs.assignedIp.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2022-09-01').outputs.assignedIp.value]"
           },
           "nicName": {
             "value": "[parameters('HostNetworkInterface2Name')]"
@@ -769,7 +769,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "udrDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -830,7 +830,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "udrUpdate",
       "properties": {
         "expressionEvaluationOptions": {
@@ -845,7 +845,7 @@
             "value": "[parameters('ghostedSubnetPrefix')]"
           },
           "nextHopAddress": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2020-10-01').outputs.assignedIp.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2022-09-01').outputs.assignedIp.value]"
           }
         },
         "template": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/nested-vms-in-virtual-network/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15157782753481557314"
+      "templateHash": "16087589206325078585"
     }
   },
   "parameters": {
@@ -343,7 +343,7 @@
     },
     "createNic1": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "createNic1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -449,7 +449,7 @@
     },
     "createNic2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "createNic2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -554,7 +554,7 @@
     },
     "updateNic1": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "updateNic1",
       "properties": {
         "expressionEvaluationOptions": {
@@ -667,7 +667,7 @@
     },
     "updateNic2": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "updateNic2",
       "properties": {
         "expressionEvaluationOptions": {
@@ -779,7 +779,7 @@
     },
     "createAzureVmUdr": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "udrDeploy",
       "properties": {
         "expressionEvaluationOptions": {
@@ -842,7 +842,7 @@
     },
     "updateAzureVmUdr": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "udrUpdate",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1560887606774239053"
+      "templateHash": "15164359622209391311"
     }
   },
   "parameters": {
@@ -34,7 +34,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "sqlLogicalServers",
       "resourceGroup": "[parameters('resourceGroup').name]",
       "properties": {
@@ -57,7 +57,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15587230493181934046"
+              "templateHash": "1077367506196072885"
             }
           },
           "parameters": {
@@ -127,7 +127,7 @@
                 "count": "[length(parameters('sqlLogicalServers'))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('sqlLogicalServer-{0}', copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -157,7 +157,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "879416403877336575"
+                      "templateHash": "14079262913009766647"
                     }
                   },
                   "parameters": {
@@ -404,7 +404,7 @@
                         "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -466,7 +466,7 @@
                         "count": "[length(parameters('sqlLogicalServer').databases)]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -491,7 +491,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "15221157786117041750"
+                              "templateHash": "835507220631375508"
                             }
                           },
                           "parameters": {
@@ -637,7 +637,7 @@
                             {
                               "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2020-10-01",
+                              "apiVersion": "2022-09-01",
                               "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                               "properties": {
                                 "expressionEvaluationOptions": {
@@ -689,7 +689,7 @@
                             },
                             {
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2020-10-01",
+                              "apiVersion": "2022-09-01",
                               "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                               "properties": {
                                 "expressionEvaluationOptions": {
@@ -744,7 +744,7 @@
                             },
                             {
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2020-10-01",
+                              "apiVersion": "2022-09-01",
                               "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                               "properties": {
                                 "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7552115982904905326"
+      "templateHash": "6747116570890744030"
     }
   },
   "parameters": {
@@ -36,7 +36,7 @@
     },
     "sqlLogicalServers": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "sqlLogicalServers",
       "resourceGroup": "[parameters('resourceGroup').name]",
       "properties": {
@@ -61,7 +61,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9131415092628301864"
+              "templateHash": "10319507846578421190"
             }
           },
           "parameters": {
@@ -143,7 +143,7 @@
                 "count": "[length(parameters('sqlLogicalServers'))]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('sqlLogicalServer-{0}', copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -175,7 +175,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "14969792597051860280"
+                      "templateHash": "17904364761423502628"
                     }
                   },
                   "parameters": {
@@ -449,7 +449,7 @@
                         "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -513,7 +513,7 @@
                         "count": "[length(parameters('sqlLogicalServer').databases)]"
                       },
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -540,7 +540,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "6436984656200986237"
+                              "templateHash": "17114950105215420528"
                             }
                           },
                           "parameters": {
@@ -703,7 +703,7 @@
                             "shortTermBackup": {
                               "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2020-10-01",
+                              "apiVersion": "2022-09-01",
                               "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                               "properties": {
                                 "expressionEvaluationOptions": {
@@ -757,7 +757,7 @@
                             },
                             "azureDefender": {
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2020-10-01",
+                              "apiVersion": "2022-09-01",
                               "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                               "properties": {
                                 "expressionEvaluationOptions": {
@@ -814,7 +814,7 @@
                             },
                             "auditSettings": {
                               "type": "Microsoft.Resources/deployments",
-                              "apiVersion": "2020-10-01",
+                              "apiVersion": "2022-09-01",
                               "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                               "properties": {
                                 "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15221157786117041750"
+      "templateHash": "835507220631375508"
     }
   },
   "parameters": {
@@ -151,7 +151,7 @@
     {
       "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -203,7 +203,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -258,7 +258,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6436984656200986237"
+      "templateHash": "17114950105215420528"
     }
   },
   "parameters": {
@@ -170,7 +170,7 @@
     "shortTermBackup": {
       "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -224,7 +224,7 @@
     },
     "azureDefender": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -281,7 +281,7 @@
     },
     "auditSettings": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
       "properties": {
         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "879416403877336575"
+      "templateHash": "14079262913009766647"
     }
   },
   "parameters": {
@@ -165,13 +165,13 @@
       ]
     },
     {
-      "condition": "[and(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
       "copy": {
         "name": "dummyDeployments",
         "count": "[length(range(0, 5))]",
         "mode": "serial",
         "batchSize": 1
       },
+      "condition": "[and(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2021-04-01",
       "name": "[format('dummyTemplateSqlServer-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
@@ -252,7 +252,7 @@
         "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -314,7 +314,7 @@
         "count": "[length(parameters('sqlLogicalServer').databases)]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -339,7 +339,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15221157786117041750"
+              "templateHash": "835507220631375508"
             }
           },
           "parameters": {
@@ -485,7 +485,7 @@
             {
               "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -537,7 +537,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -592,7 +592,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
               "properties": {
                 "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14969792597051860280"
+      "templateHash": "17904364761423502628"
     }
   },
   "parameters": {
@@ -175,13 +175,13 @@
       ]
     },
     "dummyDeployments": {
-      "condition": "[and(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
       "copy": {
         "name": "dummyDeployments",
         "count": "[length(range(0, 5))]",
         "mode": "serial",
         "batchSize": 1
       },
+      "condition": "[and(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2021-04-01",
       "name": "[format('dummyTemplateSqlServer-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
@@ -281,7 +281,7 @@
         "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -345,7 +345,7 @@
         "count": "[length(parameters('sqlLogicalServer').databases)]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -372,7 +372,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "6436984656200986237"
+              "templateHash": "17114950105215420528"
             }
           },
           "parameters": {
@@ -535,7 +535,7 @@
             "shortTermBackup": {
               "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -589,7 +589,7 @@
             },
             "azureDefender": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -646,7 +646,7 @@
             },
             "auditSettings": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
               "properties": {
                 "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15587230493181934046"
+      "templateHash": "1077367506196072885"
     }
   },
   "parameters": {
@@ -75,7 +75,7 @@
         "count": "[length(parameters('sqlLogicalServers'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('sqlLogicalServer-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -105,7 +105,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "879416403877336575"
+              "templateHash": "14079262913009766647"
             }
           },
           "parameters": {
@@ -352,7 +352,7 @@
                 "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -414,7 +414,7 @@
                 "count": "[length(parameters('sqlLogicalServer').databases)]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -439,7 +439,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "15221157786117041750"
+                      "templateHash": "835507220631375508"
                     }
                   },
                   "parameters": {
@@ -585,7 +585,7 @@
                     {
                       "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -637,7 +637,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -692,7 +692,7 @@
                     },
                     {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                       "properties": {
                         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9131415092628301864"
+      "templateHash": "10319507846578421190"
     }
   },
   "parameters": {
@@ -89,7 +89,7 @@
         "count": "[length(parameters('sqlLogicalServers'))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[format('sqlLogicalServer-{0}', copyIndex())]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -121,7 +121,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "14969792597051860280"
+              "templateHash": "17904364761423502628"
             }
           },
           "parameters": {
@@ -395,7 +395,7 @@
                 "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -459,7 +459,7 @@
                 "count": "[length(parameters('sqlLogicalServer').databases)]"
               },
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
+              "apiVersion": "2022-09-01",
               "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -486,7 +486,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "6436984656200986237"
+                      "templateHash": "17114950105215420528"
                     }
                   },
                   "parameters": {
@@ -649,7 +649,7 @@
                     "shortTermBackup": {
                       "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -703,7 +703,7 @@
                     },
                     "azureDefender": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                       "properties": {
                         "expressionEvaluationOptions": {
@@ -760,7 +760,7 @@
                     },
                     "auditSettings": {
                       "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2020-10-01",
+                      "apiVersion": "2022-09-01",
                       "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
                       "properties": {
                         "expressionEvaluationOptions": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13873757649926262153"
+      "templateHash": "231429512460861705"
     }
   },
   "parameters": {
@@ -33,7 +33,7 @@
     },
     "aks": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "aks-deploy",
       "resourceGroup": "[parameters('baseName')]",
       "properties": {
@@ -142,7 +142,7 @@
     },
     "kubernetes": {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "kubernetes-deploy",
       "resourceGroup": "[parameters('baseName')]",
       "properties": {

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.Emit
         public const string TemplateHashPropertyName = "templateHash";
 
         // IMPORTANT: Do not update this API version until the new one is confirmed to be deployed and available in ALL the clouds.
-        public const string NestedDeploymentResourceApiVersion = "2020-10-01";
+        public const string NestedDeploymentResourceApiVersion = "2022-09-01";
 
         private static readonly ImmutableHashSet<string> DecoratorsToEmitAsResourceProperties = new[] {
             LanguageConstants.ParameterSecurePropertyName,


### PR DESCRIPTION
Current nested deployment version of 2020-10-01 is over 2 years old. Therefore, generated deployment template fails arm-ttk validation tests. These tests are used when approving Azure Marketplace apps and hence would be prudent to move to the latest version.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
