### PR TITLE
Formatter v2 part 2: Cache syntax errors in interval trees

### DIFF
--- a/src/Bicep.Cli/Commands/FormatCommand.cs
+++ b/src/Bicep.Cli/Commands/FormatCommand.cs
@@ -53,7 +53,7 @@ namespace Bicep.Cli.Commands
                     args.InsertFinalNewline ?? false
                 );
 
-                string output = PrettyPrinter.PrintProgram(programSyntax, options);
+                string output = PrettyPrinter.PrintProgram(programSyntax, options, parser.LexingErrorLookup, parser.ParsingErrorLookup);
                 if (args.OutputToStdOut)
                 {
                     io.Output.Write(output);

--- a/src/Bicep.Core.IntegrationTests/ExamplesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExamplesTests.cs
@@ -101,10 +101,10 @@ namespace Bicep.Core.IntegrationTests
             var baselineFolder = BaselineFolder.BuildOutputFolder(TestContext, embeddedBicep);
             var bicepFile = baselineFolder.EntryFile;
 
-            var program = ParserHelper.Parse(embeddedBicep.Contents);
+            var program = ParserHelper.Parse(embeddedBicep.Contents, out var lexingErrorLookup, out var parsingErrorLookup);
             var printOptions = new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, true);
 
-            var formattedContents = PrettyPrinter.PrintProgram(program, printOptions);
+            var formattedContents = PrettyPrinter.PrintProgram(program, printOptions, lexingErrorLookup, parsingErrorLookup);
             formattedContents.Should().NotBeNull();
 
             File.WriteAllText(bicepFile.OutputFilePath, formattedContents);

--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -54,42 +54,42 @@ namespace Bicep.Core.IntegrationTests
         }
 
         [DataTestMethod]
-        //[DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        //[TestCategory(BaselineHelper.BaselineTestCategory)]
-        public void Parser_should_produce_expected_syntax()
+        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
+        [TestCategory(BaselineHelper.BaselineTestCategory)]
+        public void Parser_should_produce_expected_syntax(DataSet dataSet)
         {
-            var program = ParserHelper.Parse(@"resource expectedLoopItemName2 'Microsoft.Network/dnsZones@2018-05-01' = [for (
-");
+            var program = ParserHelper.Parse(dataSet.Bicep);
             var syntaxList = SyntaxCollectorVisitor.Build(program);
             var syntaxByParent = syntaxList.ToLookup(x => x.Parent);
 
-            //TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
+            TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
 
-            //var sourceTextWithDiags = DataSet.AddDiagsToSourceText(dataSet, syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
-            //var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainSyntax), sourceTextWithDiags);
+            var sourceTextWithDiags = DataSet.AddDiagsToSourceText(dataSet, syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
+            var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainSyntax), sourceTextWithDiags);
 
-            //sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
-            //    TestContext,
-            //    dataSet.Syntax,
-            //    expectedLocation: DataSet.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainSyntax),
-            //    actualLocation: resultsFile);
+            sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
+                TestContext,
+                dataSet.Syntax,
+                expectedLocation: DataSet.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainSyntax),
+                actualLocation: resultsFile);
         }
 
         [DataTestMethod]
-        //[BaselineData_Bicepparam.TestData()]
-        //[TestCategory(BaselineHelper.BaselineTestCategory)]
-        public void Params_Parser_should_produce_expected_syntax()
+        [BaselineData_Bicepparam.TestData()]
+        [TestCategory(BaselineHelper.BaselineTestCategory)]
+        public void Params_Parser_should_produce_expected_syntax(BaselineData_Bicepparam baselineData)
         {
-            var program = ParserHelper.Parse("var v3 = concat('abc', 'DEF'), 'hello')");
+            var data = baselineData.GetData(TestContext);
+            var program = ParserHelper.ParamsParse(data.Parameters.EmbeddedFile.Contents);
             var syntaxList = SyntaxCollectorVisitor.Build(program);
             var syntaxByParent = syntaxList.ToLookup(x => x.Parent);
 
-            //TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
+            TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
 
-            //var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(data.Parameters.EmbeddedFile.Contents, "\n", syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
+            var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(data.Parameters.EmbeddedFile.Contents, "\n", syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
 
-            //data.Syntax.WriteToOutputFolder(sourceTextWithDiags);
-            //data.Syntax.ShouldHaveExpectedValue();
+            data.Syntax.WriteToOutputFolder(sourceTextWithDiags);
+            data.Syntax.ShouldHaveExpectedValue();
         }
 
         private static IEnumerable<object[]> GetData()

--- a/src/Bicep.Core.IntegrationTests/ParserTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParserTests.cs
@@ -54,42 +54,42 @@ namespace Bicep.Core.IntegrationTests
         }
 
         [DataTestMethod]
-        [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
-        [TestCategory(BaselineHelper.BaselineTestCategory)]
-        public void Parser_should_produce_expected_syntax(DataSet dataSet)
+        //[DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
+        //[TestCategory(BaselineHelper.BaselineTestCategory)]
+        public void Parser_should_produce_expected_syntax()
         {
-            var program = ParserHelper.Parse(dataSet.Bicep);
+            var program = ParserHelper.Parse(@"resource expectedLoopItemName2 'Microsoft.Network/dnsZones@2018-05-01' = [for (
+");
             var syntaxList = SyntaxCollectorVisitor.Build(program);
             var syntaxByParent = syntaxList.ToLookup(x => x.Parent);
 
-            TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
+            //TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
 
-            var sourceTextWithDiags = DataSet.AddDiagsToSourceText(dataSet, syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
-            var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainSyntax), sourceTextWithDiags);
+            //var sourceTextWithDiags = DataSet.AddDiagsToSourceText(dataSet, syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
+            //var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainSyntax), sourceTextWithDiags);
 
-            sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
-                TestContext,
-                dataSet.Syntax,
-                expectedLocation: DataSet.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainSyntax),
-                actualLocation: resultsFile);
+            //sourceTextWithDiags.Should().EqualWithLineByLineDiffOutput(
+            //    TestContext,
+            //    dataSet.Syntax,
+            //    expectedLocation: DataSet.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainSyntax),
+            //    actualLocation: resultsFile);
         }
 
         [DataTestMethod]
-        [BaselineData_Bicepparam.TestData()]
-        [TestCategory(BaselineHelper.BaselineTestCategory)]
-        public void Params_Parser_should_produce_expected_syntax(BaselineData_Bicepparam baselineData)
+        //[BaselineData_Bicepparam.TestData()]
+        //[TestCategory(BaselineHelper.BaselineTestCategory)]
+        public void Params_Parser_should_produce_expected_syntax()
         {
-            var data = baselineData.GetData(TestContext);
-            var program = ParserHelper.ParamsParse(data.Parameters.EmbeddedFile.Contents);
+            var program = ParserHelper.Parse("var v3 = concat('abc', 'DEF'), 'hello')");
             var syntaxList = SyntaxCollectorVisitor.Build(program);
             var syntaxByParent = syntaxList.ToLookup(x => x.Parent);
 
-            TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
+            //TextSpan getSpan(SyntaxCollectorVisitor.SyntaxItem data) => data.Syntax.Span;
 
-            var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(data.Parameters.EmbeddedFile.Contents, "\n", syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
+            //var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(data.Parameters.EmbeddedFile.Contents, "\n", syntaxList, getSpan, syntax => GetSyntaxLoggingString(syntaxByParent, syntax));
 
-            data.Syntax.WriteToOutputFolder(sourceTextWithDiags);
-            data.Syntax.ShouldHaveExpectedValue();
+            //data.Syntax.WriteToOutputFolder(sourceTextWithDiags);
+            //data.Syntax.ShouldHaveExpectedValue();
         }
 
         private static IEnumerable<object[]> GetData()

--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
@@ -28,10 +28,10 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
         [TestCategory(BaselineHelper.BaselineTestCategory)]
         public void PrintProgram_AnyProgram_ShouldProduceExpectedOutput(DataSet dataSet)
         {
-            var program = ParserHelper.Parse(dataSet.Bicep);
+            var program = ParserHelper.Parse(dataSet.Bicep, out var lexingErrorLookup, out var parsingErrorLookup);
             var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true);
 
-            var formattedOutput = PrettyPrinter.PrintProgram(program, options);
+            var formattedOutput = PrettyPrinter.PrintProgram(program, options, lexingErrorLookup, parsingErrorLookup);
             formattedOutput.Should().NotBeNull();
 
             var resultsFile = FileHelper.SaveResultFile(this.TestContext, Path.Combine(dataSet.Name, DataSet.TestFileMainFormatted), formattedOutput!);
@@ -49,10 +49,10 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
         public void PrintProgram_ParamsFile_ShouldProduceExpectedOutput(BaselineData_Bicepparam baselineData)
         {
             var data = baselineData.GetData(TestContext);
-            var program = ParserHelper.ParamsParse(data.Parameters.EmbeddedFile.Contents);
+            var program = ParserHelper.ParamsParse(data.Parameters.EmbeddedFile.Contents, out var lexingErrorLookup, out var parsingErrorLookup);
             var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true);
 
-            var formattedOutput = PrettyPrinter.PrintProgram(program, options);
+            var formattedOutput = PrettyPrinter.PrintProgram(program, options, lexingErrorLookup, parsingErrorLookup);
             formattedOutput.Should().NotBeNull();
 
             data.Formatted.WriteToOutputFolder(formattedOutput);
@@ -63,20 +63,19 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
         [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
         public void PrintProgram_PrintTwice_ReturnsConsistentResults(DataSet dataSet)
         {
-            var program = ParserHelper.Parse(dataSet.Bicep);
-            var diagnostics = program.ParsingErrorLookup;
-            var diagnosticMessages = diagnostics.Select(d => d.Message);
+            var program = ParserHelper.Parse(dataSet.Bicep, out var lexingErrorLookup, out var parsingErrorLookup);
+            var syntaxErrors = lexingErrorLookup.Concat(parsingErrorLookup);
+            var syntaxErrroMessages = syntaxErrors.Select(d => d.Message);
 
             var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true);
-            var formattedOutput = PrettyPrinter.PrintProgram(program, options);
-            var formattedProgram = ParserHelper.Parse(formattedOutput!);
-
-            var newDiagnostics = formattedProgram.ParsingErrorLookup;
-            var newDiagnosticMessages = newDiagnostics.Select(d => d.Message);
+            var formattedOutput = PrettyPrinter.PrintProgram(program, options, lexingErrorLookup, parsingErrorLookup);
+            var formattedProgram = ParserHelper.Parse(formattedOutput!, out var newLexingErrorLookup, out var newParsingErrorLookup);
+            var newSyntaxErrors = newLexingErrorLookup.Concat(newParsingErrorLookup);
+            var newSyntaxErrorMessages = newSyntaxErrors.Select(d => d.Message);
 
             // Diagnostic messages should remain the same after formatting.
-            newDiagnostics.Should().HaveSameCount(diagnostics);
-            newDiagnosticMessages.Should().BeEquivalentTo(diagnosticMessages);
+            syntaxErrors.Should().HaveSameCount(newSyntaxErrorMessages);
+            newSyntaxErrorMessages.Should().BeEquivalentTo(syntaxErrroMessages);
 
             // Normalize formatting
             var regex = new Regex("[\\r\\n\\s]+");

--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
@@ -63,11 +63,6 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
         [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
         public void PrintProgram_PrintTwice_ReturnsConsistentResults(DataSet dataSet)
         {
-            if (dataSet.Name != "InvalidLambdas_LF")
-            {
-                return;
-            }
-
             var program = ParserHelper.Parse(dataSet.Bicep);
             var diagnostics = program.ParsingErrorLookup;
             var diagnosticMessages = diagnostics.Select(d => d.Message);

--- a/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/PrettyPrint/PrettyPrinterTests.cs
@@ -63,15 +63,20 @@ namespace Bicep.Core.IntegrationTests.PrettyPrint
         [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
         public void PrintProgram_PrintTwice_ReturnsConsistentResults(DataSet dataSet)
         {
+            if (dataSet.Name != "InvalidLambdas_LF")
+            {
+                return;
+            }
+
             var program = ParserHelper.Parse(dataSet.Bicep);
-            var diagnostics = program.GetParseDiagnostics();
+            var diagnostics = program.ParsingErrorLookup;
             var diagnosticMessages = diagnostics.Select(d => d.Message);
 
             var options = new PrettyPrintOptions(NewlineOption.Auto, IndentKindOption.Space, 2, true);
             var formattedOutput = PrettyPrinter.PrintProgram(program, options);
             var formattedProgram = ParserHelper.Parse(formattedOutput!);
 
-            var newDiagnostics = formattedProgram.GetParseDiagnostics();
+            var newDiagnostics = formattedProgram.ParsingErrorLookup;
             var newDiagnosticMessages = newDiagnostics.Select(d => d.Message);
 
             // Diagnostic messages should remain the same after formatting.

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.formatted.bicep
@@ -84,7 +84,8 @@ var errorInsideArrayAccess = [
 ][!0]
 var integerIndexOnNonArray = (null)[0]
 var stringIndexOnNonObject = 'test'['test']
-var malformedStringIndex = {}[ 'test\e']
+var malformedStringIndex = {
+}['test\e']
 var invalidIndexTypeOverAny = any(true)[true]
 var badIndexOverArray = [][null]
 var badIndexOverArray2 = []['s']

--- a/src/Bicep.Core.Samples/Files/InvalidMultilineString_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidMultilineString_CRLF/main.formatted.bicep
@@ -1,2 +1,2 @@
-var unterminatedMultilineString =   '''
+var unterminatedMultilineString = '''
 hello!''

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
@@ -64,24 +64,24 @@ param objectCompletions object =
 param wrongType fluffyBunny = 'what' s up doc?'
 
 // invalid escape
-param wrongType fluffyBunny =   'what\s up doc?'
+param wrongType fluffyBunny = 'what\s up doc?'
 
 // unterminated string 
-param wrongType fluffyBunny =   'what\'s up doc?
+param wrongType fluffyBunny = 'what\'s up doc?
 
 // unterminated interpolated string
 param wrongType fluffyBunny = 'what\'s ${
-param wrongType fluffyBunny =   'what\'s ${ up 
-param wrongType fluffyBunny =   'what\'s ${ up }
-param wrongType fluffyBunny =   'what\'s ${   'up 
+param wrongType fluffyBunny = 'what\'s ${up
+param wrongType fluffyBunny = 'what\'s ${up}
+param wrongType fluffyBunny = 'what\'s ${'up
 
 // unterminated nested interpolated string
 param wrongType fluffyBunny = 'what\'s ${'up${
 param wrongType fluffyBunny = 'what\'s ${'up${
-param wrongType fluffyBunny =   'what\'s ${   'up${ doc 
-param wrongType fluffyBunny =   'what\'s ${   'up${ doc } 
-param wrongType fluffyBunny =   'what\'s ${ 'up${doc}' 
-param wrongType fluffyBunny =   'what\'s ${ 'up${doc}' }?
+param wrongType fluffyBunny = 'what\'s ${'up${doc
+param wrongType fluffyBunny = 'what\'s ${'up${doc}
+param wrongType fluffyBunny = 'what\'s ${'up${doc}'
+param wrongType fluffyBunny = 'what\'s ${'up${doc}'}?
 
 // object literal inside interpolated string
 param wrongType fluffyBunny = '${{this: doesnt}.work}'

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -70,19 +70,19 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-0
 }
 
 // duplicate property at the top level
-resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = {
   name: 'foo'
   name: true
 }
 
 // duplicate property at the top level with string literal syntax
-resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = {
   name: 'foo'
   'name': true
 }
 
 // duplicate property inside
-resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = {
   name: 'foo'
   properties: {
     foo: 'a'
@@ -91,7 +91,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 }
 
 // duplicate property inside with string literal syntax
-resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = {
   name: 'foo'
   properties: {
     foo: 'a'

--- a/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidVariables_LF/main.symbols.bicep
@@ -93,7 +93,7 @@ var test3 = {
 
 // duplicate properties
 var testDupe = {
-//@[04:12) Variable testDupe. Type: object. Declaration start char: 0, length: 56
+//@[04:12) Variable testDupe. Type: error. Declaration start char: 0, length: 56
   'duplicate': true
   duplicate: true
 }

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Parameters/parameters.formatted.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Parameters/parameters.formatted.bicepparam
@@ -1,6 +1,6 @@
 using './main.bicep'
 
-param para1 =   'value
+param para1 = 'value
 
 para
 

--- a/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
@@ -45,7 +45,7 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<BicepFileAssertions> NotHaveParseErrors(string because = "", params object[] becauseArgs)
         {
-            Subject.ProgramSyntax.GetParseDiagnostics().Should().NotContain(d => d.Level == DiagnosticLevel.Error, because, becauseArgs);
+            Subject.ProgramSyntax.ParsingErrorLookup.Should().NotContain(d => d.Level == DiagnosticLevel.Error, because, becauseArgs);
 
             return new AndConstraint<BicepFileAssertions>(this);
         }

--- a/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/BicepFileAssertions.cs
@@ -45,7 +45,7 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<BicepFileAssertions> NotHaveParseErrors(string because = "", params object[] becauseArgs)
         {
-            Subject.ProgramSyntax.ParsingErrorLookup.Should().NotContain(d => d.Level == DiagnosticLevel.Error, because, becauseArgs);
+            Subject.ParsingErrorLookup.Should().NotContain(d => d.Level == DiagnosticLevel.Error, because, becauseArgs);
 
             return new AndConstraint<BicepFileAssertions>(this);
         }

--- a/src/Bicep.Core.UnitTests/Collections/Trees/IntervalTreeNodeTests.cs
+++ b/src/Bicep.Core.UnitTests/Collections/Trees/IntervalTreeNodeTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Collections.Trees;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static FluentAssertions.FluentActions;
+
+namespace Bicep.Core.UnitTests.Collections.Trees
+{
+    [TestClass]
+    public class IntervalTreeNodeTests
+    {
+        [DataTestMethod]
+        [DataRow(0, -1)]
+        [DataRow(100, 20)]
+        [DataRow(10, 0)]
+        public void IntervalTree_EndSmallerThanStart_Throws(int start, int end)
+        {
+            Invoking(() => new IntervalTreeNode<int>(start, end, 0))
+                .Should()
+                .Throw<ArgumentException>()
+                .WithMessage($"The argument {nameof(end)} ({end}) cannot be smaller than the argument {nameof(start)} ({start}).");
+        }
+
+        [DataTestMethod]
+        [DataRow(0, 0)]
+        [DataRow(100, 200)]
+        [DataRow(20, 21)]
+        public void IntervalTree_StartSmallerThanOrEqualToEnd_DoesNotThrow(int start, int end)
+        {
+            Invoking(() => new IntervalTreeNode<int>(start, end, 0))
+                .Should()
+                .NotThrow();
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/Collections/Trees/IntervalTreeTests.cs
+++ b/src/Bicep.Core.UnitTests/Collections/Trees/IntervalTreeTests.cs
@@ -281,63 +281,6 @@ namespace Bicep.Core.UnitTests.Collections.Trees
             }
         }
 
-        //[DataTestMethod]
-        //[DataRow(-10, -1, false)]
-        //[DataRow(11, 11, false)]
-        //[DataRow(21, 22, false)]
-        //[DataRow(22, 29, false)]
-        //[DataRow(61, 99, false)]
-        //[DataRow(70, 80, false)]
-        //[DataRow(101, 102, false)]
-        //[DataRow(0, 0, true)]
-        //[DataRow(0, 10, true)]
-        //[DataRow(0, 100, true)]
-        //[DataRow(10, 10, true)]
-        //[DataRow(2, 2, true)]
-        //[DataRow(3, 6, true)]
-        //[DataRow(21, 31, true)]
-        //[DataRow(31, 31, true)]
-        //[DataRow(50, 70, true)]
-        //public void ContainsOverlappingNodes_AnyInverval_ReturnsTrueIfFoundOverlappingNodes(int start, int end, bool expectedResult)
-        //{
-        //    var sut = new TestIntervalTree();
-
-        //    sut.Insert(0, 10, "aaaa");
-        //    sut.Insert(12, 20, "bbbb");
-        //    sut.Insert(30, 60, "cccc");
-        //    sut.Insert(100, 100, "dddd");
-
-        //    var result = sut.Contains(start, end);
-
-        //    result.Should().Be(expectedResult);
-        //}
-
-        //[DataTestMethod]
-        //[DataRow(0, 9, new string[0])]
-        //[DataRow(1, 8, new string[0])]
-        //[DataRow(200, 300, new string[0])]
-        //[DataRow(9, 10, new[] { "bbbb" })]
-        //[DataRow(60, 60, new[] { "ffff" })]
-        //[DataRow(300, 400, new[] { "eeee" })]
-        //[DataRow(5, 80, new[] { "aaaa", "bbbb", "ffff" })]
-        //[DataRow(0, 777, new[] { "aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff" })]
-        //[DataRow(700, 800, new[] { "cccc", "dddd" })]
-        //public void FindOverlappingNodes_AnyInverval_ReturnsOverlappingNodes(int start, int end, string[] expectedOverlappingNodeData)
-        //{
-        //    var sut = new TestIntervalTree();
-
-        //    sut.Insert(20, 22, "aaaa");
-        //    sut.Insert(10, 14, "bbbb");
-        //    sut.Insert(666, 777, "cccc");
-        //    sut.Insert(666, 777, "dddd");
-        //    sut.Insert(400, 500, "eeee");
-        //    sut.Insert(50, 60, "ffff");
-
-        //    var overlappingNodeData = sut.Find(start, end).SelectMany(x => x.Data);
-
-        //    overlappingNodeData.Should().BeEquivalentTo(expectedOverlappingNodeData);
-        //}
-
         [TestMethod]
         public void TraverseInOrder_NonEmptyTree_ReturnsInOrderSequence()
         {

--- a/src/Bicep.Core.UnitTests/Collections/Trees/IntervalTreeTests.cs
+++ b/src/Bicep.Core.UnitTests/Collections/Trees/IntervalTreeTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Collections.Trees;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.UnitTests.Collections.Trees
+{
+    [TestClass]
+    public class IntervalTreeTests
+    {
+        public class TestIntervalTree : IntervalTree<string>
+        {
+            public string Visualize()
+            {
+                var treeBuilder = new StringBuilder();
+
+                Visualize(treeBuilder, Root, "", true);
+
+                return treeBuilder.ToString();
+            }
+
+            private void Visualize(StringBuilder treeBuilder, IntervalTreeNode<string> node, string indent, bool isLast)
+            {
+                if (node.IsNil)
+                {
+                    return;
+                }
+                
+                treeBuilder.AppendLine($"{indent}+- [{node.Start}, {node.End} | {node.MaxEnd}]: {string.Join(", ", node.Data)}");
+                indent += isLast ? "   " : "|  ";
+
+                if (node.Right.IsNotNil)
+                {
+                    Visualize(treeBuilder, node.Right, indent, node.Left.IsNil);
+                }
+
+                if (node.Left.IsNotNil)
+                {
+                    Visualize(treeBuilder, node.Left, indent, isLast: true);
+                }
+
+            }
+        }
+
+        [TestMethod]
+        public void Insert_NodeSequence_ProducesExpectedTrees()
+        {
+            var nodeSequence = new IntervalTreeNode<string>[]
+            {
+                new(123, 456, "aaaa"),
+                new(89, 192, "bbbb"),
+                new(500, 1000, "cccc"),
+                new(236, 250, "dddd"),
+                new(122, 122, "eeee"),
+                new(0, 40, "ffff"),
+                new(409, 460, "gggg"),
+                new(41, 42, "hhhh"),
+                new(602, 701, "iiii"),
+                new(800, 888, "jjjj"),
+            };
+
+            var expectedTrees = new[]
+            {
+                """
+                +- [123, 456 | 456]: aaaa
+
+                """,
+                """
+                +- [123, 456 | 456]: aaaa
+                   +- [89, 192 | 192]: bbbb
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [500, 1000 | 1000]: cccc
+                   +- [89, 192 | 192]: bbbb
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [500, 1000 | 1000]: cccc
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [500, 1000 | 1000]: cccc
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [500, 1000 | 1000]: cccc
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 40]: ffff
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [409, 460 | 1000]: gggg
+                   |  +- [500, 1000 | 1000]: cccc
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 40]: ffff
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [409, 460 | 1000]: gggg
+                   |  +- [500, 1000 | 1000]: cccc
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 42]: ffff
+                         +- [41, 42 | 42]: hhhh
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [409, 460 | 1000]: gggg
+                   |  +- [500, 1000 | 1000]: cccc
+                   |  |  +- [602, 701 | 701]: iiii
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 42]: ffff
+                         +- [41, 42 | 42]: hhhh
+
+                """,
+                """
+                +- [123, 456 | 1000]: aaaa
+                   +- [409, 460 | 1000]: gggg
+                   |  +- [602, 701 | 1000]: iiii
+                   |  |  +- [800, 888 | 888]: jjjj
+                   |  |  +- [500, 1000 | 1000]: cccc
+                   |  +- [236, 250 | 250]: dddd
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 42]: ffff
+                         +- [41, 42 | 42]: hhhh
+
+                """,
+            };
+
+            var sut = new TestIntervalTree();
+
+            for (int i = 0; i < nodeSequence.Length; i++)
+            {
+                sut.Insert(nodeSequence[i]);
+
+                sut.Visualize().Should().Be(expectedTrees[i].ReplaceLineEndings());
+
+            }
+        }
+
+        [TestMethod]
+        public void Delete_NodeSequence_ProducesExpectedTrees()
+        {
+            var nodeSequence = new IntervalTreeNode<string>[]
+            {
+                new(123, 456, "aaaa"),
+                new(89, 192, "bbbb"),
+                new(500, 1000, "cccc"),
+                new(236, 250, "dddd"),
+                new(122, 122, "eeee"),
+                new(0, 40, "ffff"),
+                new(409, 460, "gggg"),
+                new(41, 42, "hhhh"),
+                new(602, 701, "iiii"),
+                new(800, 888, "jjjj"),
+            };
+
+            var expectedTrees = new[]
+            {
+                """
+                +- [236, 250 | 1000]: dddd
+                   +- [602, 701 | 1000]: iiii
+                   |  +- [800, 888 | 888]: jjjj
+                   |  +- [409, 460 | 1000]: gggg
+                   |     +- [500, 1000 | 1000]: cccc
+                   +- [89, 192 | 192]: bbbb
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 42]: ffff
+                         +- [41, 42 | 42]: hhhh
+
+                """,
+                """
+                +- [236, 250 | 1000]: dddd
+                   +- [602, 701 | 1000]: iiii
+                   |  +- [800, 888 | 888]: jjjj
+                   |  +- [409, 460 | 1000]: gggg
+                   |     +- [500, 1000 | 1000]: cccc
+                   +- [41, 42 | 122]: hhhh
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 40]: ffff
+
+                """,
+                """
+                +- [236, 250 | 888]: dddd
+                   +- [602, 701 | 888]: iiii
+                   |  +- [800, 888 | 888]: jjjj
+                   |  +- [409, 460 | 460]: gggg
+                   +- [41, 42 | 122]: hhhh
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 40]: ffff
+
+                """,
+                """
+                +- [409, 460 | 888]: gggg
+                   +- [602, 701 | 888]: iiii
+                   |  +- [800, 888 | 888]: jjjj
+                   +- [41, 42 | 122]: hhhh
+                      +- [122, 122 | 122]: eeee
+                      +- [0, 40 | 40]: ffff
+
+                """,
+                """
+                +- [409, 460 | 888]: gggg
+                   +- [602, 701 | 888]: iiii
+                   |  +- [800, 888 | 888]: jjjj
+                   +- [41, 42 | 42]: hhhh
+                      +- [0, 40 | 40]: ffff
+
+                """,
+                """
+                +- [409, 460 | 888]: gggg
+                   +- [602, 701 | 888]: iiii
+                   |  +- [800, 888 | 888]: jjjj
+                   +- [41, 42 | 42]: hhhh
+
+                """,
+                """
+                +- [602, 701 | 888]: iiii
+                   +- [800, 888 | 888]: jjjj
+                   +- [41, 42 | 42]: hhhh
+
+                """,
+                """
+                +- [602, 701 | 888]: iiii
+                   +- [800, 888 | 888]: jjjj
+
+                """,
+                """
+                +- [800, 888 | 888]: jjjj
+
+                """,
+                """
+
+                """,
+            };
+
+
+            var sut = new TestIntervalTree();
+
+            foreach (var node in nodeSequence)
+            {
+                sut.Insert(node);
+            }
+
+            for (int i = 0; i < nodeSequence.Length; i++)
+            {
+                sut.Delete(nodeSequence[i]);
+
+                sut.Visualize().Should().Be(expectedTrees[i].ReplaceLineEndings());
+            }
+        }
+
+        //[DataTestMethod]
+        //[DataRow(-10, -1, false)]
+        //[DataRow(11, 11, false)]
+        //[DataRow(21, 22, false)]
+        //[DataRow(22, 29, false)]
+        //[DataRow(61, 99, false)]
+        //[DataRow(70, 80, false)]
+        //[DataRow(101, 102, false)]
+        //[DataRow(0, 0, true)]
+        //[DataRow(0, 10, true)]
+        //[DataRow(0, 100, true)]
+        //[DataRow(10, 10, true)]
+        //[DataRow(2, 2, true)]
+        //[DataRow(3, 6, true)]
+        //[DataRow(21, 31, true)]
+        //[DataRow(31, 31, true)]
+        //[DataRow(50, 70, true)]
+        //public void ContainsOverlappingNodes_AnyInverval_ReturnsTrueIfFoundOverlappingNodes(int start, int end, bool expectedResult)
+        //{
+        //    var sut = new TestIntervalTree();
+
+        //    sut.Insert(0, 10, "aaaa");
+        //    sut.Insert(12, 20, "bbbb");
+        //    sut.Insert(30, 60, "cccc");
+        //    sut.Insert(100, 100, "dddd");
+
+        //    var result = sut.Contains(start, end);
+
+        //    result.Should().Be(expectedResult);
+        //}
+
+        //[DataTestMethod]
+        //[DataRow(0, 9, new string[0])]
+        //[DataRow(1, 8, new string[0])]
+        //[DataRow(200, 300, new string[0])]
+        //[DataRow(9, 10, new[] { "bbbb" })]
+        //[DataRow(60, 60, new[] { "ffff" })]
+        //[DataRow(300, 400, new[] { "eeee" })]
+        //[DataRow(5, 80, new[] { "aaaa", "bbbb", "ffff" })]
+        //[DataRow(0, 777, new[] { "aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff" })]
+        //[DataRow(700, 800, new[] { "cccc", "dddd" })]
+        //public void FindOverlappingNodes_AnyInverval_ReturnsOverlappingNodes(int start, int end, string[] expectedOverlappingNodeData)
+        //{
+        //    var sut = new TestIntervalTree();
+
+        //    sut.Insert(20, 22, "aaaa");
+        //    sut.Insert(10, 14, "bbbb");
+        //    sut.Insert(666, 777, "cccc");
+        //    sut.Insert(666, 777, "dddd");
+        //    sut.Insert(400, 500, "eeee");
+        //    sut.Insert(50, 60, "ffff");
+
+        //    var overlappingNodeData = sut.Find(start, end).SelectMany(x => x.Data);
+
+        //    overlappingNodeData.Should().BeEquivalentTo(expectedOverlappingNodeData);
+        //}
+
+        [TestMethod]
+        public void TraverseInOrder_NonEmptyTree_ReturnsInOrderSequence()
+        {
+            var sut = new TestIntervalTree();
+
+            sut.Insert(new(20, 22, "aaaa"));
+            sut.Insert(new(10, 14, "bbbb"));
+            sut.Insert(new(666, 777, "cccc"));
+            sut.Insert(new(400, 500, "eeee"));
+            sut.Insert(new(50, 60, "ffff"));
+
+            var traversedNodesData = sut.Traverse().SelectMany(x => x.Data);
+
+            traversedNodesData.Should().Equal("bbbb", "aaaa", "ffff", "eeee", "cccc");
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/Diagnostics/DiagnosticTreeTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/DiagnosticTreeTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Collections.Trees;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.UnitTests.Diagnostics
+{
+    [TestClass]
+    public class DiagnosticTreeTests
+    {
+        private static readonly DiagnosticTree Sut = new();
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext _)
+        {
+
+            WriteDummyDiagnostic(0, 4, "aaaa");
+            WriteDummyDiagnostic(5, 5, "bbbb");
+            WriteDummyDiagnostic(5, 10, "cccc");
+            WriteDummyDiagnostic(10, 10, "dddd");
+            WriteDummyDiagnostic(20, 30, "eeee");
+            WriteDummyDiagnostic(22, 25, "ffff");
+            WriteDummyDiagnostic(120, 200, "gggg");
+            WriteDummyDiagnostic(201, 210, "hhhh");
+        }
+
+        [TestMethod]
+        [DataRow(0, 4)]
+        [DataRow(1, 5)]
+        [DataRow(5, 5)]
+        [DataRow(5, 10)]
+        [DataRow(10, 10)]
+        [DataRow(20, 30)]
+        [DataRow(22, 25)]
+        [DataRow(120, 200)]
+        [DataRow(201, 210)]
+        [DataRow(0, 5)]
+        [DataRow(0, 40)]
+        [DataRow(4, 10)]
+        [DataRow(4, 11)]
+        [DataRow(5, 5)]
+        [DataRow(10, 10)]
+        [DataRow(5, 11)]
+        [DataRow(21, 25)]
+        [DataRow(22, 26)]
+        [DataRow(21, 26)]
+        [DataRow(120, 201)]
+        [DataRow(200, 210)]
+        [DataRow(0, 1000)]
+        public void Contains_EnclosingSpan_ReturnsTrue(int start, int end)
+        {
+            var span = new TextSpan(start, end - start);
+
+            var result = Sut.Contains(span);
+
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        [DataRow(0, 3)]
+        [DataRow(1, 2)]
+        [DataRow(6, 9)]
+        [DataRow(21, 24)]
+        [DataRow(23, 25)]
+        [DataRow(100, 199)]
+        [DataRow(210, 210)]
+        [DataRow(300, 400)]
+        public void Contains_NotEnclosingSpan_ReturnsFalse(int start, int end)
+        {
+            var span = new TextSpan(start, end - start);
+
+            var result = Sut.Contains(span);
+
+            result.Should().BeFalse();
+        }
+
+        [TestMethod]
+        [DataRow(0, 3)]
+        [DataRow(1, 2)]
+        [DataRow(6, 9)]
+        [DataRow(21, 24)]
+        [DataRow(23, 25)]
+        [DataRow(100, 199)]
+        [DataRow(210, 210)]
+        [DataRow(300, 400)]
+        public void Indexer_NotEnclosingSpan_ReturnsEmptyEnumerable(int start, int end)
+        {
+            var span = new TextSpan(start, end - start);
+
+            var diagnostics = Sut[span];
+
+            diagnostics.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        [DataRow(0, 4, new[] { "aaaa" })]
+        [DataRow(5, 5, new[] { "bbbb" })]
+        [DataRow(5, 10, new[] { "bbbb", "cccc", "dddd" })]
+        [DataRow(10, 10, new[] { "dddd" })]
+        [DataRow(22, 25, new[] { "ffff" })]
+        [DataRow(21, 26, new[] { "ffff" })]
+        [DataRow(8, 205, new[] { "dddd", "eeee", "ffff", "gggg" })]
+        [DataRow(0, 1000, new[] { "aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff", "gggg", "hhhh" })]
+        public void Indexer_EnclosingSpan_ReturnsEnclosedDiagnostics(int start, int end, string[] expectedDiagnosticCodes)
+        {
+            var span = new TextSpan(start, end - start);
+
+            var enclosedDiagnostics = Sut[span];
+
+            enclosedDiagnostics.Select(x => x.Code).Should().BeEquivalentTo(expectedDiagnosticCodes);
+        }
+
+        private static void WriteDummyDiagnostic(int start, int end, string code) =>
+            Sut.Write(new Diagnostic(new(start, end - start), DiagnosticLevel.Off, code, ""));
+    }
+}

--- a/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
@@ -104,6 +104,11 @@ namespace Bicep.Core.UnitTests.Diagnostics
                 return new List<string> { $"<value_{index}" };
             }
 
+            if (parameter.ParameterType == typeof(IDiagnosticLookup))
+            {
+                return new DiagnosticTree();
+            }
+
             if (parameter.ParameterType == typeof(ImmutableArray<string>))
             {
                 return new[] { $"<value_{index}" }.ToImmutableArray();

--- a/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
@@ -48,7 +48,7 @@ namespace Bicep.Core.UnitTests.Parsing
             {
                 var becauseFileValid = $"{file} is considered valid";
                 var program = ParserHelper.Parse(file);
-                program.GetParseDiagnostics().Should().BeEmpty(becauseFileValid);
+                program.ParsingErrorLookup.Should().BeEmpty(becauseFileValid);
                 program.Declarations.Should().HaveCount(statementCount, becauseFileValid);
                 program.Declarations.Should().AllBeOfType(expectedType, becauseFileValid);
             }
@@ -61,7 +61,7 @@ namespace Bicep.Core.UnitTests.Parsing
             foreach (var file in invalidFiles)
             {
                 var program = ParserHelper.Parse(file);
-                program.GetParseDiagnostics().Should().NotBeEmpty();
+                program.ParsingErrorLookup.Should().NotBeEmpty();
             }
         }
 
@@ -169,8 +169,7 @@ namespace Bicep.Core.UnitTests.Parsing
         public void UnaryOperatorsCannotBeChained(string text)
         {
             var expression = ParseAndVerifyType<UnaryOperationSyntax>(text);
-            expression.Expression.Should().BeOfType<SkippedTriviaSyntax>()
-                .Which.Diagnostics.Single().Message.Should().Be("Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.");
+            expression.Expression.Should().BeOfType<SkippedTriviaSyntax>();
         }
 
         [DataTestMethod]
@@ -482,9 +481,8 @@ type multilineUnion = 'a'
             where TSyntax : SyntaxBase
         {
             var expression = ParserHelper.ParseExpression(text);
-            expression.Should().BeOfType<TSyntax>();
 
-            return (TSyntax)expression;
+            return expression.Should().BeOfType<TSyntax>().Subject;
         }
 
         private static string SerializeExpressionWithExtraParentheses(SyntaxBase expression)

--- a/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/ParserTests.cs
@@ -47,8 +47,9 @@ namespace Bicep.Core.UnitTests.Parsing
             foreach (var (statementCount, file) in validFiles)
             {
                 var becauseFileValid = $"{file} is considered valid";
-                var program = ParserHelper.Parse(file);
-                program.ParsingErrorLookup.Should().BeEmpty(becauseFileValid);
+                var program = ParserHelper.Parse(file, out var lexingErrorLookup, out var parsingErrorLookup);
+                lexingErrorLookup.Should().BeEmpty(becauseFileValid);
+                parsingErrorLookup.Should().BeEmpty(becauseFileValid);
                 program.Declarations.Should().HaveCount(statementCount, becauseFileValid);
                 program.Declarations.Should().AllBeOfType(expectedType, becauseFileValid);
             }
@@ -60,8 +61,8 @@ namespace Bicep.Core.UnitTests.Parsing
 
             foreach (var file in invalidFiles)
             {
-                var program = ParserHelper.Parse(file);
-                program.ParsingErrorLookup.Should().NotBeEmpty();
+                ParserHelper.Parse(file, out var syntaxErrors);
+                syntaxErrors.Should().NotBeEmpty();
             }
         }
 

--- a/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/PrettyPrint/PrettyPrinterTestsBase.cs
@@ -18,15 +18,15 @@ namespace Bicep.Core.UnitTests.PrettyPrint
 
         protected void TestPrintProgram(string programText, string expectedOutput, PrettyPrintOptions? options = null)
         {
-            ProgramSyntax? programSyntax = ParserHelper.Parse(programText);
+            ProgramSyntax? programSyntax = ParserHelper.Parse(programText, out var lexingErrorLookup, out var parsingErrorLookup);
             options ??= CommonOptions;
 
-            string output = PrettyPrinter.PrintProgram(programSyntax, options);
+            string output = PrettyPrinter.PrintProgram(programSyntax, options, lexingErrorLookup, parsingErrorLookup);
 
             output.Should().Be(expectedOutput);
 
-            programSyntax = ParserHelper.Parse(expectedOutput);
-            output = PrettyPrinter.PrintProgram(programSyntax, options);
+            programSyntax = ParserHelper.Parse(expectedOutput, out lexingErrorLookup, out parsingErrorLookup);
+            output = PrettyPrinter.PrintProgram(programSyntax, options, lexingErrorLookup, parsingErrorLookup);
 
             // The formatter should produce consistent results.
             output.Should().Be(expectedOutput);

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxModifierTests.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxModifierTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Rewriters;
@@ -114,7 +115,7 @@ var adsf = [
 
                 return CallbackRewriter.Rewrite(
                     program,
-                    node => node == array && SyntaxModifier.TryRemoveItem(array, item) is {} newArray ? newArray : node);
+                    node => node == array && SyntaxModifier.TryRemoveItem(array, item, program.ParsingErrorLookup) is {} newArray ? newArray : node);
             });
 
         rewritten.Should().BeEquivalentToIgnoringNewlines(expected);
@@ -196,7 +197,7 @@ var adsf = {
 
                 return CallbackRewriter.Rewrite(
                     program,
-                    node => node == @object && SyntaxModifier.TryRemoveProperty(@object, property) is {} newObject ? newObject : node);
+                    node => node == @object && SyntaxModifier.TryRemoveProperty(@object, property, program.ParsingErrorLookup) is {} newObject ? newObject : node);
             });
 
         rewritten.Should().BeEquivalentToIgnoringNewlines(expected);
@@ -268,8 +269,8 @@ var adsf = {
                 return CallbackRewriter.Rewrite(
                     program,
                     node => (node == @object &&
-                      SyntaxModifier.TryAddProperty(@object, startProp, prevIndex) is {} newObject &&
-                      SyntaxModifier.TryAddProperty(newObject, endProp, prevIndex + 2) is {} newObject2)
+                      SyntaxModifier.TryAddProperty(@object, startProp, program.ParsingErrorLookup, prevIndex) is {} newObject &&
+                      SyntaxModifier.TryAddProperty(newObject, endProp, program.ParsingErrorLookup, prevIndex + 2) is {} newObject2)
                       ? newObject2 : node);
             });
 

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
@@ -961,7 +961,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 .Setup(x => x.GetSymbolInfo(It.IsAny<SyntaxBase>()))
                 .Returns<Symbol?>(null);
 
-            parsingErrorLookup ??= new DiagnosticTree();
+            parsingErrorLookup ??= EmptyDiagnosticLookup.Instance;
 
             var typeManager = new TypeManager(BicepTestConstants.Features, binderMock.Object, fileResolverMock.Object, parsingErrorLookup, Core.Workspaces.BicepSourceFileKind.BicepFile);
 

--- a/src/Bicep.Core.UnitTests/Utils/ParserHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ParserHelper.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
 using FluentAssertions;
@@ -19,11 +20,43 @@ namespace Bicep.Core.UnitTests.Utils
             return parser.Program();
         }
 
+        public static ProgramSyntax Parse(string text, out IEnumerable<IDiagnostic> syntaxErrors)
+        {
+            var parser = new Parser(text);
+            var program = parser.Program();
+
+            syntaxErrors = parser.LexingErrorLookup.Concat(parser.ParsingErrorLookup);
+
+            return program;
+        }
+
+        public static ProgramSyntax Parse(string text, out IDiagnosticLookup lexingErrorLookup, out IDiagnosticLookup parsingErrorLookup)
+        {
+            var parser = new Parser(text);
+            var program = parser.Program();
+
+            lexingErrorLookup = parser.LexingErrorLookup;
+            parsingErrorLookup = parser.ParsingErrorLookup;
+
+            return program;
+        }
+
         public static ProgramSyntax ParamsParse(string text)
         {
             var parser = new ParamsParser(text);
 
             return parser.Program();
+        }
+
+        public static ProgramSyntax ParamsParse(string text, out IDiagnosticLookup lexingErrorLookup, out IDiagnosticLookup parsingErrorLookup)
+        {
+            var parser = new ParamsParser(text);
+            var program = parser.Program();
+
+            lexingErrorLookup = parser.LexingErrorLookup;
+            parsingErrorLookup = parser.ParsingErrorLookup;
+
+            return program;
         }
 
         public static SyntaxBase ParseExpression(string text, ExpressionFlags expressionFlags = ExpressionFlags.AllowComplexLiterals) => new Parser(text).Expression(expressionFlags);

--- a/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrint;
@@ -26,10 +27,10 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static string PrintAndCheckForParseErrors(ProgramSyntax programSyntax)
         {
-            var asString = PrettyPrinter.PrintProgram(programSyntax, DefaultOptions);
+            var asString = PrettyPrinter.PrintProgram(programSyntax, DefaultOptions, EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance);
 
-            var parsed = ParserHelper.Parse(asString);
-            parsed.ParsingErrorLookup.Should().BeEmpty();
+            ParserHelper.Parse(asString, out var syntaxErrors);
+            syntaxErrors.Should().BeEmpty();
 
             return asString;
         }

--- a/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
@@ -29,7 +29,7 @@ namespace Bicep.Core.UnitTests.Utils
             var asString = PrettyPrinter.PrintProgram(programSyntax, DefaultOptions);
 
             var parsed = ParserHelper.Parse(asString);
-            parsed.GetParseDiagnostics().Should().BeEmpty();
+            parsed.ParsingErrorLookup.Should().BeEmpty();
 
             return asString;
         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/ArtifactsParametersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/ArtifactsParametersRule.cs
@@ -78,13 +78,13 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             Debug.Assert(artifactsSasParam is not null);
 
             // RULE: _artifactsLocation must be a string.
-            if (VerifyParameterType(diagnosticLevel, artifactsLocationParam, LanguageConstants.TypeNameString) is IDiagnostic diagnosticLocType)
+            if (VerifyParameterType(model, diagnosticLevel, artifactsLocationParam, LanguageConstants.TypeNameString) is IDiagnostic diagnosticLocType)
             {
                 yield return diagnosticLocType;
             }
 
             // RULE: _artifactsLocationSasToken must be a secure string.
-            if (VerifyParameterType(diagnosticLevel, artifactsSasParam, LanguageConstants.TypeNameString) is IDiagnostic diagnosticSasType)
+            if (VerifyParameterType(model, diagnosticLevel, artifactsSasParam, LanguageConstants.TypeNameString) is IDiagnostic diagnosticSasType)
             {
                 yield return diagnosticSasType;
             }
@@ -218,12 +218,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return null;
         }
 
-        private static string? GetParameterType(ParameterSymbol parameterSymbol)
+        private static string? GetParameterType(SemanticModel model, ParameterSymbol parameterSymbol)
         {
             if (parameterSymbol.DeclaringSyntax is ParameterDeclarationSyntax parameterDeclaration
                && parameterDeclaration.Type is VariableAccessSyntax typeSyntax)
             {
-                if (typeSyntax.HasParseErrors())
+                if (model.HasParsingError(typeSyntax))
                 {
                     return null;
                 }
@@ -234,9 +234,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return null;
         }
 
-        private IDiagnostic? VerifyParameterType(DiagnosticLevel diagnosticLevel, ParameterSymbol parameter, string expectedTypeName)
+        private IDiagnostic? VerifyParameterType(SemanticModel model, DiagnosticLevel diagnosticLevel, ParameterSymbol parameter, string expectedTypeName)
         {
-            if (GetParameterType(parameter) is string paramType
+            if (GetParameterType(model, parameter) is string paramType
                && paramType != expectedTypeName)
             {
                 return CreateFixableDiagnosticForSpan(

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoUnnecessaryDependsOnRule.cs
@@ -109,7 +109,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     if (declaredDependencies.Items.Count() == 1)
                     {
                         // we only have one entry - remove the whole dependsOn property
-                        if (SyntaxModifier.TryRemoveProperty(body, dependsOnProperty) is {} newObject)
+                        if (SyntaxModifier.TryRemoveProperty(body, dependsOnProperty, model.ParsingErrorLookup) is {} newObject)
                         {
                             codeReplacement = new CodeReplacement(body.Span, newObject.ToTextPreserveFormatting());
                         }
@@ -117,7 +117,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     else
                     {
                         // we have multiple entries - just remove this one
-                        if (SyntaxModifier.TryRemoveItem(declaredDependencies, declaredDependency) is {} newArray)
+                        if (SyntaxModifier.TryRemoveItem(declaredDependencies, declaredDependency, model.ParsingErrorLookup) is {} newArray)
                         {
                             codeReplacement = new CodeReplacement(declaredDependencies.Span, newArray.ToTextPreserveFormatting());
                         }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferInterpolationRule.cs
@@ -51,8 +51,8 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             {
                 // must have more than 1 argument to use interpolation
                 if (syntax.NameEquals(concatFunction)
-                   && syntax.Arguments.Count() > 1
-                   && !syntax.GetParseDiagnostics().Any())
+                   && syntax.Arguments.Length > 1
+                   && !this.model.HasParsingError(syntax))
                 {
                     // We should only suggest rewriting concat() calls that result in a string (concat can also operate on and
                     // return arrays)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseParentPropertyRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseParentPropertyRule.cs
@@ -45,7 +45,7 @@ public sealed class UseParentPropertyRule : LinterRuleBase
             }
 
             if (TryGetReplacementChildName(model, childName) is {} info &&
-                TryCreateDiagnostic(diagnosticLevel, info.parent, resource, info.name) is {} nameDiagnostic)
+                TryCreateDiagnostic(model, diagnosticLevel, info.parent, resource, info.name) is {} nameDiagnostic)
             {
                 yield return nameDiagnostic;
                 continue;
@@ -60,7 +60,7 @@ public sealed class UseParentPropertyRule : LinterRuleBase
                 if (!parentResource.Symbol.IsCollection &&
                     parentResource.TryGetNameSyntax() is {} parentNameSyntax &&
                     TryGetReplacementChildName(model, parentNameSyntax, childName) is {} replacement &&
-                    TryCreateDiagnostic(diagnosticLevel, parentResource, resource, replacement) is {} diagnostic)
+                    TryCreateDiagnostic(model, diagnosticLevel, parentResource, resource, replacement) is {} diagnostic)
                 {
                     yield return diagnostic;
                     break;
@@ -177,7 +177,7 @@ public sealed class UseParentPropertyRule : LinterRuleBase
         return null;
     }
 
-    private IDiagnostic? TryCreateDiagnostic(DiagnosticLevel diagnosticLevel, DeclaredResourceMetadata parentResource, DeclaredResourceMetadata childResource, SyntaxBase replacementName)
+    private IDiagnostic? TryCreateDiagnostic(SemanticModel model, DiagnosticLevel diagnosticLevel, DeclaredResourceMetadata parentResource, DeclaredResourceMetadata childResource, SyntaxBase replacementName)
     {
         if (childResource.Symbol.DeclaringResource.TryGetBody() is not {} body ||
             body.TryGetPropertyByName("name") is not {} nameProp)
@@ -190,6 +190,7 @@ public sealed class UseParentPropertyRule : LinterRuleBase
             SyntaxFactory.CreateObjectProperty(
                 "parent",
                 SyntaxFactory.CreateIdentifier(parentResource.Symbol.NameIdentifier.IdentifierName)),
+            model.ParsingErrorLookup,
             atIndex: body.Properties.IndexOf(x => x == nameProp));
         if (updatedBody is null)
         {

--- a/src/Bicep.Core/CodeAction/Fixes/MultilineObjectsAndArraysCodeFixProvider.cs
+++ b/src/Bicep.Core/CodeAction/Fixes/MultilineObjectsAndArraysCodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace Bicep.Core.CodeAction.Fixes
         public IEnumerable<CodeFix> GetFixes(SemanticModel semanticModel, IReadOnlyList<SyntaxBase> matchingNodes)
         {
             var objectOrArray = matchingNodes.Where(x => x is ArraySyntax or ObjectSyntax).LastOrDefault();
-            if (objectOrArray is null || objectOrArray.HasParseErrors())
+            if (objectOrArray is null || semanticModel.HasParsingError(objectOrArray))
             {
                 yield break;
             }

--- a/src/Bicep.Core/Collections/Trees/BinaryTreeIndex.cs
+++ b/src/Bicep.Core/Collections/Trees/BinaryTreeIndex.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Collections.Trees
+{
+    public enum BinaryTreeIndex
+    {
+        Left,
+
+        Right,
+    }
+}

--- a/src/Bicep.Core/Collections/Trees/BinaryTreeIndexer.cs
+++ b/src/Bicep.Core/Collections/Trees/BinaryTreeIndexer.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Collections.Trees
+{
+    public readonly struct BinaryTreeIndexer
+    {
+        public static readonly BinaryTreeIndexer Default = new(inverted: false);
+
+        public static readonly BinaryTreeIndexer Inverted = new(inverted: true);
+
+        private readonly bool inverted;
+
+        private BinaryTreeIndexer(bool inverted)
+        {
+            this.inverted = inverted;
+        }
+
+        public BinaryTreeIndex LeftIndex => inverted ? BinaryTreeIndex.Right : BinaryTreeIndex.Left;
+
+        public BinaryTreeIndex RightIndex => inverted ? BinaryTreeIndex.Left : BinaryTreeIndex.Right;
+
+        public void Deconstruct(out BinaryTreeIndex leftIndex, out BinaryTreeIndex rightIndex)
+        {
+            leftIndex = LeftIndex;
+            rightIndex = RightIndex;
+        }
+
+        public BinaryTreeIndexer Invert() => inverted ? Default : Inverted;
+    }
+}

--- a/src/Bicep.Core/Collections/Trees/IntervalTree.cs
+++ b/src/Bicep.Core/Collections/Trees/IntervalTree.cs
@@ -25,8 +25,14 @@ namespace Bicep.Core.Collections.Trees
 
         public IntervalTreeNode<TData> Root { get; private set; } = IntervalTreeNode<TData>.Nil;
 
+        /// <summary>
+        /// Performs an in-order traversal for the tree and returns the nodes traversed.
+        /// </summary>
         public IEnumerable<IntervalTreeNode<TData>> Traverse() => this.Traverse(this.Root);
 
+        /// <summary>
+        /// Performs an in-order traversal for the sub-tree rooted at node and returns the nodes traversed.
+        /// </summary>
         public IEnumerable<IntervalTreeNode<TData>> Traverse(IntervalTreeNode<TData> node)
         {
             // Do an in-order traversal so the nodes are sorted by interval starts.
@@ -48,6 +54,10 @@ namespace Bicep.Core.Collections.Trees
             }
         }
 
+        /// <summary>
+        /// Insert a node to the tree in O(lg n).
+        /// </summary>
+        /// <param name="node">The node to insert.</param>
         public void Insert(IntervalTreeNode<TData> node)
         {
             var parent = IntervalTreeNode<TData>.Nil;
@@ -97,6 +107,10 @@ namespace Bicep.Core.Collections.Trees
             FixAdjancentRed(node);
         }
 
+        /// <summary>
+        /// Delete a node from the tree in O(lg n).
+        /// </summary>
+        /// <param name="node">The node to delete.</param>
         public void Delete(IntervalTreeNode<TData> node)
         {
             if (this.Root.IsNil)
@@ -151,6 +165,13 @@ namespace Bicep.Core.Collections.Trees
             this.PaintBlack(node);
         }
 
+        /// <summary>
+        /// Perform a <see href="https://en.wikipedia.org/wiki/Tree_rotation">tree rotation</see>.
+        /// If indexer is <see cref="BinaryTreeIndexer.Default">BinaryTreeIndexer.Default</see>, the rotation is a left-rotation.
+        /// If indexer is <see cref="BinaryTreeIndexer.Inverted">BinaryTreeIndexer.Inverted</see>, the rotation is a right-rotation.
+        /// </summary>
+        /// <param name="node">The root node of the tree to rotate.</param>
+        /// <param name="indexer">The indexer that controls the rotation direction.</param>
         private void Rotate(IntervalTreeNode<TData> node, BinaryTreeIndexer indexer)
         {
             var (leftIndex, rightIndex) = indexer;
@@ -190,6 +211,11 @@ namespace Bicep.Core.Collections.Trees
 
         }
 
+        /// <summary>
+        /// Within the current tree, replace a sub-tree whose root is node by a sub-tree whose root is subsitution.
+        /// </summary>
+        /// <param name="node">The root of the sub-tree to be replaced.</param>
+        /// <param name="subsitution">The root of the sub-tree to transplant.</param>
         private void Transplant(IntervalTreeNode<TData> node, IntervalTreeNode<TData> subsitution)
         {
             if (node.IsRoot)
@@ -208,6 +234,11 @@ namespace Bicep.Core.Collections.Trees
             subsitution.Parent = node.Parent;
         }
 
+        /// <summary>
+        /// The method is called after an insertion to fix the violation to the red-black tree property that
+        /// if a node is red, then both its children are black (no adjancent red nodes).
+        /// </summary>
+        /// <param name="node">The node to fix.</param>
         private void FixAdjancentRed(IntervalTreeNode<TData> node)
         {
             while (IsRed(node.Parent))
@@ -242,6 +273,10 @@ namespace Bicep.Core.Collections.Trees
             this.PaintBlack(Root);
         }
 
+        /// <summary>
+        /// The method is called after a deletion to fix a doubly-black or red-or-black node.
+        /// </summary>
+        /// <param name="node">The node to fix.</param>
         private void FixExtraBlack(IntervalTreeNode<TData> node)
         {
             while (node.IsNotRoot && this.IsBlack(node))

--- a/src/Bicep.Core/Collections/Trees/IntervalTree.cs
+++ b/src/Bicep.Core/Collections/Trees/IntervalTree.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Extensions;
+using Newtonsoft.Json.Schema;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Collections.Trees
+{
+    /// <summary>
+    /// An augumented red-black tree that holds intervals [start, end].
+    /// For reference, see chapter 14.3 of <see href="https://en.wikipedia.org/wiki/Introduction_to_Algorithms">Introduction to Algorithms (3rd Edition)</see>.
+    /// </summary>
+    /// <typeparam name="TData">The tree node payload data type.</typeparam>
+    public class IntervalTree<TData>
+    {
+        private readonly HashSet<IntervalTreeNode<TData>> redNodes = new();
+
+        public IntervalTreeNode<TData> Root { get; private set; } = IntervalTreeNode<TData>.Nil;
+
+        public IEnumerable<IntervalTreeNode<TData>> Traverse() => this.Traverse(this.Root);
+
+        public IEnumerable<IntervalTreeNode<TData>> Traverse(IntervalTreeNode<TData> node)
+        {
+            // Do an in-order traversal so the nodes are sorted by interval starts.
+            var stack = new Stack<IntervalTreeNode<TData>>();
+
+            while (stack.Any() || node.IsNotNil)
+            {
+                if (node.IsNotNil)
+                {
+                    stack.Push(node);
+                    node = node.Left;
+                }
+                else
+                {
+                    node = stack.Pop();
+                    yield return node;
+                    node = node.Right;
+                }
+            }
+        }
+
+        public void Insert(IntervalTreeNode<TData> node)
+        {
+            var parent = IntervalTreeNode<TData>.Nil;
+            var current = Root;
+
+            while (current.IsNotNil)
+            {
+                parent = current;
+
+                if (node.Start < current.Start)
+                {
+                    current = current.Left;
+                    parent.MaxEnd = Math.Max(parent.MaxEnd, node.MaxEnd);
+                }
+                else
+                {
+                    current = current.Right;
+                    parent.MaxEnd = Math.Max(parent.MaxEnd, node.MaxEnd);
+                }
+            }
+
+            if (parent.Start == node.Start && parent.End == node.End)
+            {
+                parent.Data.AddRange(node.Data);
+                return;
+            }
+
+            node.Parent = parent;
+
+            if (parent.IsNil)
+            {
+                Root = node;
+            }
+            else if (node.Start < parent.Start)
+            {
+                parent.Left = node;
+            }
+            else
+            {
+                parent.Right = node;
+            }
+
+            node.Left = IntervalTreeNode<TData>.Nil;
+            node.Right = IntervalTreeNode<TData>.Nil;
+
+            PaintRed(node);
+            FixAdjancentRed(node);
+        }
+
+        public void Delete(IntervalTreeNode<TData> node)
+        {
+            if (this.Root.IsNil)
+            {
+                return;
+            }
+
+            if (node.Left.IsNil || node.Right.IsNil)
+            {
+                var subsitution = node.Left.IsNil ? node.Right : node.Left;
+
+                this.Transplant(node, subsitution);
+                subsitution.Parent.RefreshMaxEndUpwards();
+
+                if (IsBlack(node))
+                {
+                    this.FixExtraBlack(subsitution);
+                }
+            }
+            else
+            {
+                var successor = node.Right.GetSuccessor();
+                var successorSubsitution = successor.Right;
+
+                if (successor.Parent == node)
+                {
+                    successorSubsitution.Parent = successor; // Normalize the special case where successorSubsitution is Nil.
+                }
+                else
+                {
+                    this.Transplant(successor, successorSubsitution);
+                    successor.Right = node.Right;
+                    successor.Right.Parent = successor;
+                }
+
+                Transplant(node, successor);
+                successor.Left = node.Left;
+                successor.Left.Parent = successor;
+
+                successorSubsitution.Parent.RefreshMaxEndUpwards();
+
+                var successorWasBlack = this.IsBlack(successor);
+
+                this.CopyColor(node, successor);
+
+                if (successorWasBlack)
+                {
+                    this.FixExtraBlack(successorSubsitution);
+                }
+            }
+
+            this.PaintBlack(node);
+        }
+
+        private void Rotate(IntervalTreeNode<TData> node, BinaryTreeIndexer indexer)
+        {
+            var (leftIndex, rightIndex) = indexer;
+            var right = node[rightIndex];
+
+            // Turn child's left subtree into node's right subtree.
+            node[rightIndex] = right[leftIndex];
+
+            if (right[leftIndex].IsNotNil)
+            {
+                right[leftIndex].Parent = node;
+            }
+
+            // Link node's parent to child.
+            right.Parent = node.Parent;
+
+            if (node.IsRoot)
+            {
+                Root = right;
+            }
+            else if (node.IsLeft)
+            {
+                node.Parent.Left = right;
+            }
+            else
+            {
+                node.Parent.Right = right;
+            }
+
+            // Put node on child's left.
+            right[leftIndex] = node;
+            node.Parent = right;
+
+            // Update max end.
+            right.MaxEnd = node.MaxEnd;
+            node.RefreshMaxEnd();
+
+        }
+
+        private void Transplant(IntervalTreeNode<TData> node, IntervalTreeNode<TData> subsitution)
+        {
+            if (node.IsRoot)
+            {
+                this.Root = subsitution;
+            }
+            else if (node.IsLeft)
+            {
+                node.Parent.Left = subsitution;
+            }
+            else
+            {
+                node.Parent.Right = subsitution;
+            }
+
+            subsitution.Parent = node.Parent;
+        }
+
+        private void FixAdjancentRed(IntervalTreeNode<TData> node)
+        {
+            while (IsRed(node.Parent))
+            {
+                var indexer = node.Parent.IsLeft ? BinaryTreeIndexer.Default : BinaryTreeIndexer.Inverted;
+                var uncle = node.Parent.Parent[indexer.RightIndex];
+
+                // Case 1.
+                if (IsRed(uncle))
+                {
+                    PaintBlack(node.Parent);
+                    PaintBlack(uncle);
+                    PaintRed(node.Parent.Parent);
+                    node = node.Parent.Parent;
+                }
+                else
+                {
+                    // Case 2.
+                    if (node == node.Parent[indexer.RightIndex])
+                    {
+                        node = node.Parent;
+                        Rotate(node, indexer);
+                    }
+
+                    // Case 3.
+                    PaintBlack(node.Parent);
+                    PaintRed(node.Parent.Parent);
+                    Rotate(node.Parent.Parent, indexer.Invert());
+                }
+            }
+
+            this.PaintBlack(Root);
+        }
+
+        private void FixExtraBlack(IntervalTreeNode<TData> node)
+        {
+            while (node.IsNotRoot && this.IsBlack(node))
+            {
+                var indexer = node.IsLeft ? BinaryTreeIndexer.Default : BinaryTreeIndexer.Inverted;
+                var (leftIndex, rightIndex) = indexer; 
+
+                var sibling = node.Parent[rightIndex];
+
+                // Case 1.
+                if (this.IsRed(sibling))
+                {
+                    this.PaintBlack(sibling);
+                    this.PaintRed(node.Parent);
+                    this.Rotate(node.Parent, indexer);
+                    sibling = node.Parent[rightIndex];
+                }
+
+                // Case 2.
+                if (this.IsBlack(sibling.Left) && this.IsBlack(sibling.Right))
+                {
+                    this.PaintRed(sibling);
+                    node = node.Parent;
+                }
+                else
+                {
+                    // Case 3.
+                    if (this.IsBlack(sibling[rightIndex]))
+                    {
+                        this.PaintBlack(sibling[leftIndex]);
+                        this.PaintRed(sibling);
+                        this.Rotate(sibling, indexer.Invert());
+                        sibling = node.Parent[rightIndex];
+                    }
+
+                    // Case 4.
+                    this.CopyColor(node.Parent, sibling);
+                    this.PaintBlack(node.Parent);
+                    this.PaintBlack(sibling[rightIndex]);
+                    this.Rotate(node.Parent, indexer);
+                    node = this.Root;
+                }
+            }
+
+            this.PaintBlack(node);
+        }
+
+        private bool IsRed(IntervalTreeNode<TData> node) => redNodes.Contains(node);
+
+        private bool IsBlack(IntervalTreeNode<TData> node) => !redNodes.Contains(node);
+
+        private void PaintRed(IntervalTreeNode<TData> node) => redNodes.Add(node);
+
+        private void PaintBlack(IntervalTreeNode<TData> node) => redNodes.Remove(node);
+
+        private void CopyColor(IntervalTreeNode<TData> source, IntervalTreeNode<TData> target)
+        {
+            if (this.IsRed(source))
+            {
+                this.PaintRed(target);
+            }
+            else
+            {
+                this.PaintBlack(target);
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Collections/Trees/IntervalTreeNode.cs
+++ b/src/Bicep.Core/Collections/Trees/IntervalTreeNode.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Collections.Trees
+{
+    public class IntervalTreeNode<TData>
+    {
+        public readonly static IntervalTreeNode<TData> Nil = new(-1, -1, new List<TData>());
+
+        private readonly IntervalTreeNode<TData>[] children = new[] { Nil, Nil };
+
+        public IntervalTreeNode(int start, int end, TData data)
+            : this(start, end, new List<TData>() { data })
+        {
+        }
+
+        private IntervalTreeNode(int start, int end, IList<TData> data)
+        {
+            if (end < start)
+            {
+                throw new ArgumentException($"The argument {nameof(end)} ({end}) cannot be smaller than the argument {nameof(start)} ({start}).");
+            }
+
+            Start = start;
+            End = end;
+            MaxEnd = end;
+            Data = data;
+        }
+
+        public IntervalTreeNode<TData> this[BinaryTreeIndex index]
+        {
+            get => children[(int)index];
+            set => children[(int)index] = value;
+        }
+
+        public IntervalTreeNode<TData> Parent { get; set; } = Nil;
+
+        public IntervalTreeNode<TData> Left
+        {
+            get => this[BinaryTreeIndex.Left];
+            set => this[BinaryTreeIndex.Left] = value;
+        }
+
+        public IntervalTreeNode<TData> Right
+        {
+            get => this[BinaryTreeIndex.Right];
+            set => this[BinaryTreeIndex.Right] = value;
+        }
+
+        public int Start { get; }
+
+        public int End { get; }
+
+        public IList<TData> Data { get; }
+
+        public int MaxEnd { get; set; }
+
+        public bool IsNil => this == Nil;
+
+        public bool IsNotNil => this != Nil;
+
+        public bool IsRoot => this.Parent == Nil;
+
+        public bool IsNotRoot => this.Parent != Nil;
+
+        public bool IsLeft => this == Parent.Left;
+
+        public bool IsRight => this == Parent.Right;
+
+        public IntervalTreeNode<TData> GetSuccessor()
+        {
+            var node = this;
+
+            while (node.Left.IsNotNil)
+            {
+                node = node.Left;
+            }
+
+            return node;
+        }
+
+        public void RefreshMaxEnd() => this.MaxEnd = Math.Max(this.End, Math.Max(this.Left.MaxEnd, this.Right.MaxEnd));
+
+        public void RefreshMaxEndUpwards()
+        {
+            var current = this;
+
+            while (current.IsNotNil)
+            {
+                current.RefreshMaxEnd();
+                current = current.Parent;
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -228,7 +228,7 @@ namespace Bicep.Core.Diagnostics
                 "BCP034",
                 $"The enclosing array expected an item of type \"{expectedType}\", but the provided item was of type \"{actualType}\".");
 
-            public Diagnostic MissingRequiredProperties(bool warnInsteadOfError, Symbol? sourceDeclaration, ObjectSyntax objectSyntax, ICollection<string> properties, string blockName, bool showTypeInaccuracy)
+            public Diagnostic MissingRequiredProperties(bool warnInsteadOfError, Symbol? sourceDeclaration, ObjectSyntax objectSyntax, ICollection<string> properties, string blockName, bool showTypeInaccuracy, IDiagnosticLookup parsingErrorLookup)
             {
                 var sourceDeclarationClause = sourceDeclaration is not null
                     ? $" from source declaration \"{sourceDeclaration.Name}\""
@@ -236,8 +236,8 @@ namespace Bicep.Core.Diagnostics
 
                 var newSyntax = SyntaxModifier.TryAddProperties(
                     objectSyntax,
-                    properties.Select(p => SyntaxFactory.CreateObjectProperty(p, SyntaxFactory.EmptySkippedTrivia))
-                );
+                    properties.Select(p => SyntaxFactory.CreateObjectProperty(p, SyntaxFactory.EmptySkippedTrivia)),
+                    parsingErrorLookup);
 
                 if (newSyntax is null)
                 {

--- a/src/Bicep.Core/Diagnostics/DiagnosticTree.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticTree.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Collections.Trees;
+using Bicep.Core.Extensions;
+using Bicep.Core.Parsing;
+using Bicep.Core.PrettyPrint.Documents;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Bicep.Core.Diagnostics
+{
+    public sealed class DiagnosticTree : IntervalTree<IDiagnostic>, IDiagnosticWriter, IDiagnosticLookup
+    {
+        public IEnumerable<IDiagnostic> this[IPositionable positionable] =>
+            FindEnclosedNode(positionable).SelectMany(x => x.Data);
+
+        public bool Contains(IPositionable positionable) =>
+            this.ContainsEnclosedNode(positionable.GetPosition(), positionable.GetEndPosition());
+
+        public void Write(IDiagnostic diagnostic) => this.Insert(new(diagnostic.GetPosition(), diagnostic.GetEndPosition(), diagnostic));
+
+        public void Delete(IPositionable positionable)
+        {
+            foreach (var node in FindEnclosedNode(positionable))
+            {
+                this.Delete(node);
+            }
+        }
+
+        public IEnumerator<IDiagnostic> GetEnumerator() => this.Traverse().SelectMany(x => x.Data).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        /// <summary>
+        /// Check if there is at least one node enclosed by [start, end] in O(lg n),
+        /// where n is the number of diagnostics in the tree.
+        /// </summary>
+        /// <param name="start">The interval start position.</param>
+        /// <param name="end">The interval end position.</param>
+        private bool ContainsEnclosedNode(int start, int end)
+        {
+            if (this.Root.IsNil)
+            {
+                return false;
+            }
+
+            var current = this.Root;
+
+            while (true)
+            {
+                if (start <= current.Start && current.End <= end)
+                {
+                    return true;
+                }
+
+                if (start < current.Start)
+                {
+                    // ----|start...
+                    // ------|current.Start...
+                    // When start < current.Start, technically there can exist intervals enclosed by [start, end]
+                    // in both the left sub-tree and the right sub-tree. However, since the invervals in the tree
+                    // are spans of diagnostics attached to syntax nodes, and one syntax node can overlap with
+                    // another only when one of them is enclosed by the other, the following situation is impossible:
+                    //
+                    // ---|diganostic1.start...diagnostic1.end|
+                    // --------|diagnostic1.start...diagnostic2.end|
+                    // 
+                    // If start < current.Start, and current is not enclosed by [start, end], end must be smaller
+                    // than current.Start as well:
+                    //
+                    // ---|start...end|
+                    // ----------------|current.start...current.end|
+                    //
+                    // Thus, we only need to search the left-subtree.
+                    current = current.Left;
+                }
+                else
+                {
+                    // --------|start...
+                    // ------|current.Start...
+                    // Search current.Right since only the left sub-tree cannot have nodes enclosed by [start, end].
+                    current = current.Right;
+                }
+
+                if (current.IsNil)
+                {
+                    return false;
+                }
+
+                // ----------------------------------|start...
+                // --|current.Start...current.MaxEnd|...
+                // There are has no overlapping nodes.
+                if (start > current.MaxEnd)
+                {
+                    return false;
+                }
+            }
+        }
+
+        private IEnumerable<IntervalTreeNode<IDiagnostic>> FindEnclosedNode(IPositionable positionable) =>
+            FindEnclosedNodesRecursively(this.Root, positionable.GetPosition(), positionable.GetEndPosition());
+
+        /// <summary>
+        /// Find nodes enclosed by [start, end] in O(min(n, k * lg n)), where n is the number of diagnostics
+        /// in the tree, and k is the number of nodes enclosed by [start, end].
+        /// </summary>
+        /// <param name="root">The current root node to search.</param>
+        /// <param name="start">The interval start position.</param>
+        /// <param name="end">The interval end position.</param>
+        private static IEnumerable<IntervalTreeNode<IDiagnostic>> FindEnclosedNodesRecursively(IntervalTreeNode<IDiagnostic> root, int start, int end)
+        {
+            if (root.IsNil)
+            {
+                yield break;
+            }
+
+            if (root.Left.IsNotNil && start <= root.Left.MaxEnd)
+            {
+                foreach (var node in FindEnclosedNodesRecursively(root.Left, start, end))
+                {
+                    yield return node;
+                }
+            }
+
+            if (start <= root.Start && root.End <= end)
+            {
+                yield return root;
+            }
+
+            if (root.Right.IsNotNil && start <= root.Right.MaxEnd)
+            {
+                foreach (var node in FindEnclosedNodesRecursively(root.Right, start, end))
+                {
+                    yield return node;
+                }
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/Diagnostics/EmptyDiagnosticLookup.cs
+++ b/src/Bicep.Core/Diagnostics/EmptyDiagnosticLookup.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Diagnostics
+{
+    public sealed class EmptyDiagnosticLookup : IDiagnosticLookup
+    {
+        public readonly static EmptyDiagnosticLookup Instance = new();
+
+        private EmptyDiagnosticLookup() { }
+
+        public IEnumerable<IDiagnostic> this[IPositionable positionable] => Enumerable.Empty<IDiagnostic>();
+
+        public bool Contains(IPositionable positionable) => false;
+
+        public IEnumerator<IDiagnostic> GetEnumerator() => Enumerable.Empty<IDiagnostic>().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/src/Bicep.Core/Diagnostics/IDiagnosticLookup.cs
+++ b/src/Bicep.Core/Diagnostics/IDiagnosticLookup.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Diagnostics
+{
+    public interface IDiagnosticLookup : IEnumerable<IDiagnostic>
+    {
+        IEnumerable<IDiagnostic> this[IPositionable positionable] { get; }
+
+        bool Contains(IPositionable positionable);
+    }
+}

--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrint;
 using Bicep.Core.Syntax;
@@ -72,9 +73,9 @@ namespace Bicep.Core.Navigation
         public static string ToText(this SyntaxBase syntax, string indent = "", string? newLineSequence = null)
         {
             var sb = new StringBuilder();
-            var documentBuildVisitor = new DocumentBuildVisitor();
+            var documentBuildVisitor = new DocumentBuildVisitor(new DiagnosticTree(), new DiagnosticTree());
             var document = documentBuildVisitor.BuildDocument(syntax);
-            document.Layout(sb, indent, newLineSequence ?? System.Environment.NewLine);
+            document.Layout(sb, indent, newLineSequence ?? Environment.NewLine);
             return sb.ToString();
         }
 

--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -73,7 +73,7 @@ namespace Bicep.Core.Navigation
         public static string ToText(this SyntaxBase syntax, string indent = "", string? newLineSequence = null)
         {
             var sb = new StringBuilder();
-            var documentBuildVisitor = new DocumentBuildVisitor(new DiagnosticTree(), new DiagnosticTree());
+            var documentBuildVisitor = new DocumentBuildVisitor();
             var document = documentBuildVisitor.BuildDocument(syntax);
             document.Layout(sb, indent, newLineSequence ?? Environment.NewLine);
             return sb.ToString();

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -17,19 +17,18 @@ namespace Bicep.Core.Parsing
     {
         protected readonly TokenReader reader;
 
-        protected readonly ImmutableArray<IDiagnostic> lexerDiagnostics;
-
         protected BaseParser(string text)
         {
             // treating the lexer as an implementation detail of the parser
-            var diagnosticWriter = ToListDiagnosticWriter.Create();
-            var lexer = new Lexer(new SlidingTextWindow(text), diagnosticWriter);
+            var lexingErrorTree = new DiagnosticTree();
+            var lexer = new Lexer(new SlidingTextWindow(text), lexingErrorTree);
             lexer.Lex();
 
-            this.lexerDiagnostics = diagnosticWriter.GetDiagnostics().ToImmutableArray();
-
             this.reader = new TokenReader(lexer.GetTokens());
+            this.LexingErrorLookup = lexingErrorTree;
         }
+
+        protected IDiagnosticLookup LexingErrorLookup { get; }
 
         private static bool CheckKeyword(Token? token, string keyword) => token?.Type == TokenType.Identifier && token.Text == keyword;
 
@@ -307,7 +306,7 @@ namespace Bicep.Core.Parsing
                 _ => this.SkipEmpty(b => b.ExpectedLoopItemIdentifierOrVariableBlockStart())
             };
 
-            var inKeyword = this.WithRecovery(() => this.ExpectKeyword(LanguageConstants.InKeyword), variableSection.HasParseErrors() ? RecoveryFlags.SuppressDiagnostics : RecoveryFlags.None, TokenType.RightSquare, TokenType.NewLine);
+            var inKeyword = this.WithRecovery(() => this.ExpectKeyword(LanguageConstants.InKeyword), this.HasSyntaxError(variableSection) ? RecoveryFlags.SuppressDiagnostics : RecoveryFlags.None, TokenType.RightSquare, TokenType.NewLine);
             var expression = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(inKeyword), TokenType.Colon, TokenType.RightSquare, TokenType.NewLine);
             var colon = this.WithRecovery(() => this.Expect(TokenType.Colon, b => b.ExpectedCharacter(":")), GetSuppressionFlag(expression), TokenType.RightSquare, TokenType.NewLine);
             var body = this.WithRecovery(
@@ -325,7 +324,7 @@ namespace Bicep.Core.Parsing
 
             var variableBlock = GetVariableBlock(openParen, expressionsOrCommas, closeParen);
 
-            if (variableBlock.Arguments.Length != 2 && !variableBlock.HasParseErrors())
+            if (variableBlock.Arguments.Length != 2 && !this.HasSyntaxError(variableBlock))
             {
                 return Skip(variableBlock.AsEnumerable(), x => x.ExpectedLoopVariableBlockWith2Elements(variableBlock.Arguments.Length));
             }
@@ -426,7 +425,7 @@ namespace Bicep.Core.Parsing
                 VariableAccessSyntax varAccess => new LocalVariableSyntax(varAccess.Name),
                 Token { Type: TokenType.Comma } => item,
                 SkippedTriviaSyntax => item,
-                _ => new SkippedTriviaSyntax(item.Span, item.AsEnumerable(), Enumerable.Empty<IDiagnostic>()),
+                _ => new SkippedTriviaSyntax(item.Span, item.AsEnumerable()),
             });
 
             return new VariableBlockSyntax(openParen, rewritten, closeParen);
@@ -643,7 +642,7 @@ namespace Bicep.Core.Parsing
                         // Things start to get hairy to build the string if we return an uneven number of tokens and expressions.
                         // Rather than trying to add two expression nodes, combine them.
                         var combined = new[] { interpExpression, skippedSyntax };
-                        interpExpression = new SkippedTriviaSyntax(TextSpan.Between(combined.First(), combined.Last()), combined, Enumerable.Empty<IDiagnostic>());
+                        interpExpression = new SkippedTriviaSyntax(TextSpan.Between(combined.First(), combined.Last()), combined);
                     }
 
                     tokensOrSyntax.Add(interpExpression);
@@ -702,7 +701,7 @@ namespace Bicep.Core.Parsing
                 {
                     // This error-handling is just for cases where we were completely unable to interpret the string.
                     var span = TextSpan.BetweenInclusiveAndExclusive(startToken, reader.Peek());
-                    return new SkippedTriviaSyntax(span, tokensOrSyntax, Enumerable.Empty<IDiagnostic>());
+                    return new SkippedTriviaSyntax(span, tokensOrSyntax);
                 }
 
                 return null;
@@ -913,7 +912,7 @@ namespace Bicep.Core.Parsing
 
             if (stringValue is null)
             {
-                return new SkippedTriviaSyntax(token.Span, token.AsEnumerable(), Enumerable.Empty<IDiagnostic>());
+                return new SkippedTriviaSyntax(token.Span, token.AsEnumerable());
             }
 
             return new StringSyntax(token.AsEnumerable(), Enumerable.Empty<SyntaxBase>(), stringValue.AsEnumerable());
@@ -1164,11 +1163,12 @@ namespace Bicep.Core.Parsing
             return new SkippedTriviaSyntax(span, syntaxArray, errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable());
         }
 
-        private SkippedTriviaSyntax Skip(IEnumerable<SyntaxBase> syntax)
+        private static SkippedTriviaSyntax Skip(IEnumerable<SyntaxBase> syntax)
         {
             var syntaxArray = syntax.ToImmutableArray();
             var span = TextSpan.Between(syntaxArray.First(), syntaxArray.Last());
-            return new SkippedTriviaSyntax(span, syntaxArray, Enumerable.Empty<Diagnostic>());
+
+            return new SkippedTriviaSyntax(span, syntaxArray);
         }
 
         protected SkippedTriviaSyntax SkipEmpty()
@@ -1180,8 +1180,8 @@ namespace Bicep.Core.Parsing
         private SkippedTriviaSyntax SkipEmpty(int position, DiagnosticBuilder.ErrorBuilderDelegate? errorFunc)
         {
             var span = new TextSpan(position, 0);
-            var diagnostics = errorFunc is null ? Enumerable.Empty<IDiagnostic>() : errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable();
-            return new SkippedTriviaSyntax(span, ImmutableArray<SyntaxBase>.Empty, diagnostics);
+            var errors = errorFunc is null ? Enumerable.Empty<ErrorDiagnostic>() : errorFunc(DiagnosticBuilder.ForPosition(span)).AsEnumerable();
+            return new SkippedTriviaSyntax(span, ImmutableArray<SyntaxBase>.Empty, errors);
         }
 
         private void Synchronize(bool consumeTerminator, params TokenType[] expectedTypes)
@@ -1521,6 +1521,21 @@ namespace Bicep.Core.Parsing
             {
                 return SynchronizeAndReturnTrivia(startReaderPosition, flags, _ => exception.Error, terminatingTypes);
             }
+        }
+
+        private bool HasSyntaxError(SyntaxBase syntax)
+        {
+            if (this.LexingErrorLookup.Contains(syntax))
+            {
+                return true;
+            }
+
+            var diagnosticWriter = new SimpleDiagnosticWriter();
+            var parsingErrorVisitor = new ParseDiagnosticsVisitor(diagnosticWriter);
+
+            parsingErrorVisitor.Visit(syntax);
+
+            return diagnosticWriter.HasDiagnostics();
         }
     }
 }

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -25,10 +25,16 @@ namespace Bicep.Core.Parsing
             lexer.Lex();
 
             this.reader = new TokenReader(lexer.GetTokens());
+
+            this.ParsingErrorTree = new DiagnosticTree();
             this.LexingErrorLookup = lexingErrorTree;
         }
 
-        protected IDiagnosticLookup LexingErrorLookup { get; }
+        protected DiagnosticTree ParsingErrorTree { get; }
+
+        public IDiagnosticLookup LexingErrorLookup { get; }
+
+        public IDiagnosticLookup ParsingErrorLookup => ParsingErrorTree;
 
         private static bool CheckKeyword(Token? token, string keyword) => token?.Type == TokenType.Identifier && token.Text == keyword;
 

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -815,6 +815,12 @@ namespace Bicep.Core.Parsing
             {
                 return tokenType;
             }
+
+            if (identifier.Length > LanguageConstants.MaxIdentifierLength)
+            {
+                this.AddDiagnostic(b => b.IdentifierNameExceedsLimit());
+            }
+
             return TokenType.Identifier;
         }
 

--- a/src/Bicep.Core/Parsing/ParamsParser.cs
+++ b/src/Bicep.Core/Parsing/ParamsParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Generic;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Parsing
@@ -36,7 +37,13 @@ namespace Bicep.Core.Parsing
 
             var endOfFile = reader.Read();
 
-            return new ProgramSyntax(declarationsOrTokens, endOfFile, this.lexerDiagnostics);
+            var parsingErrorTree = new DiagnosticTree();
+            var parsingErrorVisitor = new ParseDiagnosticsVisitor(parsingErrorTree);
+            var programSyntax = new ProgramSyntax(declarationsOrTokens, endOfFile, this.LexingErrorLookup, parsingErrorTree);
+
+            parsingErrorVisitor.Visit(programSyntax);
+
+            return programSyntax;
         }
 
         protected override SyntaxBase Declaration() =>

--- a/src/Bicep.Core/Parsing/ParamsParser.cs
+++ b/src/Bicep.Core/Parsing/ParamsParser.cs
@@ -36,11 +36,9 @@ namespace Bicep.Core.Parsing
             }
 
             var endOfFile = reader.Read();
+            var programSyntax = new ProgramSyntax(declarationsOrTokens, endOfFile, this.LexingErrorLookup, this.ParsingErrorTree);
 
-            var parsingErrorTree = new DiagnosticTree();
-            var parsingErrorVisitor = new ParseDiagnosticsVisitor(parsingErrorTree);
-            var programSyntax = new ProgramSyntax(declarationsOrTokens, endOfFile, this.LexingErrorLookup, parsingErrorTree);
-
+            var parsingErrorVisitor = new ParseDiagnosticsVisitor(this.ParsingErrorTree);
             parsingErrorVisitor.Visit(programSyntax);
 
             return programSyntax;

--- a/src/Bicep.Core/Parsing/ParseDiagnosticsVisitor.cs
+++ b/src/Bicep.Core/Parsing/ParseDiagnosticsVisitor.cs
@@ -20,65 +20,11 @@ namespace Bicep.Core.Parsing
             this.diagnosticWriter = diagnosticWriter;
         }
 
-        public override void VisitProgramSyntax(ProgramSyntax syntax)
-        {
-            base.VisitProgramSyntax(syntax);
-
-            this.diagnosticWriter.WriteMultiple(syntax.LexerDiagnostics);
-
-            // find duplicate target scope declarations
-            var targetScopeSyntaxes = syntax.Children.OfType<TargetScopeSyntax>().ToImmutableArray();
-            if (targetScopeSyntaxes.Length > 1)
-            {
-                foreach (var targetScope in targetScopeSyntaxes)
-                {
-                    this.diagnosticWriter.Write(targetScope.Keyword, x => x.TargetScopeMultipleDeclarations());
-                }
-            }
-
-            // find duplicate using declarations
-            var usingSyntaxes = syntax.Children.OfType<UsingDeclarationSyntax>().ToImmutableArray();
-            if (usingSyntaxes.Length > 1)
-            {
-                foreach (var declaration in usingSyntaxes)
-                {
-                    this.diagnosticWriter.Write(declaration.Keyword, x => x.MoreThanOneUsingDeclarationSpecified());
-                }
-            }
-        }
-
         public override void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
         {
             base.VisitSkippedTriviaSyntax(syntax);
 
             this.diagnosticWriter.WriteMultiple(syntax.Diagnostics);
-        }
-
-        public override void VisitIdentifierSyntax(IdentifierSyntax syntax)
-        {
-            if (syntax.IdentifierName.Length > LanguageConstants.MaxIdentifierLength)
-            {
-                this.diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax.Child).IdentifierNameExceedsLimit());
-            }
-
-            base.VisitIdentifierSyntax(syntax);
-        }
-
-        public override void VisitObjectSyntax(ObjectSyntax syntax)
-        {
-            base.VisitObjectSyntax(syntax);
-
-            var duplicatedProperties = syntax.Properties
-                .GroupByExcludingNull(prop => prop.TryGetKeyText(), LanguageConstants.IdentifierComparer)
-                .Where(group => group.Count() > 1);
-
-            foreach (var group in duplicatedProperties)
-            {
-                foreach (ObjectPropertySyntax duplicatedProperty in group)
-                {
-                    this.diagnosticWriter.Write(DiagnosticBuilder.ForPosition(duplicatedProperty.Key).PropertyMultipleDeclarations(group.Key));
-                }
-            }
         }
     }
 }

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Syntax;
 
@@ -38,7 +39,13 @@ namespace Bicep.Core.Parsing
 
             var endOfFile = reader.Read();
 
-            return new ProgramSyntax(declarationsOrTokens, endOfFile, this.lexerDiagnostics);
+            var parsingErrorTree = new DiagnosticTree();
+            var parsingErrorVisitor = new ParseDiagnosticsVisitor(parsingErrorTree);
+            var programSyntax = new ProgramSyntax(declarationsOrTokens, endOfFile, this.LexingErrorLookup, parsingErrorTree);
+
+            parsingErrorVisitor.Visit(programSyntax);
+
+            return programSyntax;
         }
 
         protected override SyntaxBase Declaration() =>

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -39,10 +39,9 @@ namespace Bicep.Core.Parsing
 
             var endOfFile = reader.Read();
 
-            var parsingErrorTree = new DiagnosticTree();
-            var parsingErrorVisitor = new ParseDiagnosticsVisitor(parsingErrorTree);
-            var programSyntax = new ProgramSyntax(declarationsOrTokens, endOfFile, this.LexingErrorLookup, parsingErrorTree);
+            var programSyntax = new ProgramSyntax(declarationsOrTokens, endOfFile, this.LexingErrorLookup, this.ParsingErrorLookup);
 
+            var parsingErrorVisitor = new ParseDiagnosticsVisitor(this.ParsingErrorTree);
             parsingErrorVisitor.Visit(programSyntax);
 
             return programSyntax;

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrint.Documents;
@@ -33,7 +34,11 @@ namespace Bicep.Core.PrettyPrint
             .Concat(new[] { "name", "properties", "string", "bool", "int", "array", "object" })
             .ToImmutableDictionary(value => value, value => new TextDocument(value));
 
-        private readonly Stack<ILinkedDocument> documentStack = new Stack<ILinkedDocument>();
+        private readonly Stack<ILinkedDocument> documentStack = new();
+
+        private readonly IDiagnosticLookup lexingErrorLookup;
+
+        private readonly IDiagnosticLookup parsingErrorLookup;
 
         private bool visitingSkippedTriviaSyntax;
 
@@ -44,6 +49,12 @@ namespace Bicep.Core.PrettyPrint
         private bool visitingLeadingTrivia;
 
         private ILinkedDocument? LeadingDirectiveOrComments = null;
+
+        public DocumentBuildVisitor(IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
+        {
+            this.lexingErrorLookup = lexingErrorLookup;
+            this.parsingErrorLookup = parsingErrorLookup;
+        }
 
         public ILinkedDocument BuildDocument(SyntaxBase syntax)
         {
@@ -289,7 +300,7 @@ namespace Bicep.Core.PrettyPrint
                 {
                     var visitingBrokenStatement = this.visitingBrokenStatement;
 
-                    if (nodes[i].GetParseDiagnostics().Any())
+                    if (this.HasSyntaxError(nodes[i]))
                     {
                         this.visitingBrokenStatement = true;
                     }
@@ -628,7 +639,7 @@ namespace Bicep.Core.PrettyPrint
 
         private void BuildStatement(SyntaxBase syntax, Action visitAction)
         {
-            if (syntax.GetParseDiagnostics().Count > 0)
+            if (this.HasSyntaxError(syntax))
             {
                 this.visitingBrokenStatement = true;
                 visitAction();
@@ -755,5 +766,9 @@ namespace Bicep.Core.PrettyPrint
                 this.documentStack.Push(document);
             }
         }
+
+        private bool HasSyntaxError(SyntaxBase syntax) =>
+            this.lexingErrorLookup.Contains(syntax) ||
+            this.parsingErrorLookup.Contains(syntax);
     }
 }

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -50,6 +50,11 @@ namespace Bicep.Core.PrettyPrint
 
         private ILinkedDocument? LeadingDirectiveOrComments = null;
 
+        public DocumentBuildVisitor()
+            : this(EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance)
+        {
+        }
+
         public DocumentBuildVisitor(IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
         {
             this.lexingErrorLookup = lexingErrorLookup;

--- a/src/Bicep.Core/PrettyPrint/PrettyPrinter.cs
+++ b/src/Bicep.Core/PrettyPrint/PrettyPrinter.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrint.Options;
 using Bicep.Core.Syntax;
@@ -22,7 +23,7 @@ namespace Bicep.Core.PrettyPrint
                 _ => InferNewline(programSyntax)
             };
 
-            var documentBuildVisitor = new DocumentBuildVisitor();
+            var documentBuildVisitor = new DocumentBuildVisitor(programSyntax.LexingErrorLookup, programSyntax.ParsingErrorLookup);
             var sb = new StringBuilder();
 
             var document = documentBuildVisitor.BuildDocument(programSyntax);
@@ -36,12 +37,12 @@ namespace Bicep.Core.PrettyPrint
             return sb.ToString();
         }
 
-        public static string PrintSyntax(SyntaxBase syntax, PrettyPrintOptions options)
+        public static string PrintSyntax(SyntaxBase syntax, PrettyPrintOptions options, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
         {
             string indent = options.IndentKindOption == IndentKindOption.Space ? new string(' ', options.IndentSize) : "\t";
 
             var sb = new StringBuilder();
-            var documentBuildVisitor = new DocumentBuildVisitor();
+            var documentBuildVisitor = new DocumentBuildVisitor(lexingErrorLookup, parsingErrorLookup);
 
             var document = documentBuildVisitor.BuildDocument(syntax);
             document.Layout(sb, indent, Environment.NewLine);

--- a/src/Bicep.Core/PrettyPrint/PrettyPrinter.cs
+++ b/src/Bicep.Core/PrettyPrint/PrettyPrinter.cs
@@ -12,7 +12,10 @@ namespace Bicep.Core.PrettyPrint
 {
     public static class PrettyPrinter
     {
-        public static string PrintProgram(ProgramSyntax programSyntax, PrettyPrintOptions options)
+        public static string PrintValidProgram(ProgramSyntax programSyntax, PrettyPrintOptions options) =>
+            PrintProgram(programSyntax, options, EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance);
+
+        public static string PrintProgram(ProgramSyntax programSyntax, PrettyPrintOptions options, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
         {
             string indent = options.IndentKindOption == IndentKindOption.Space ? new string(' ', options.IndentSize) : "\t";
             string newline = options.NewlineOption switch
@@ -23,7 +26,7 @@ namespace Bicep.Core.PrettyPrint
                 _ => InferNewline(programSyntax)
             };
 
-            var documentBuildVisitor = new DocumentBuildVisitor(programSyntax.LexingErrorLookup, programSyntax.ParsingErrorLookup);
+            var documentBuildVisitor = new DocumentBuildVisitor(lexingErrorLookup, parsingErrorLookup);
             var sb = new StringBuilder();
 
             var document = documentBuildVisitor.BuildDocument(programSyntax);
@@ -37,12 +40,12 @@ namespace Bicep.Core.PrettyPrint
             return sb.ToString();
         }
 
-        public static string PrintSyntax(SyntaxBase syntax, PrettyPrintOptions options, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
+        public static string PrintValidSyntax(SyntaxBase syntax, PrettyPrintOptions options)
         {
             string indent = options.IndentKindOption == IndentKindOption.Space ? new string(' ', options.IndentSize) : "\t";
 
             var sb = new StringBuilder();
-            var documentBuildVisitor = new DocumentBuildVisitor(lexingErrorLookup, parsingErrorLookup);
+            var documentBuildVisitor = new DocumentBuildVisitor(EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance);
 
             var document = documentBuildVisitor.BuildDocument(syntax);
             document.Layout(sb, indent, Environment.NewLine);

--- a/src/Bicep.Core/Semantics/Decorator.cs
+++ b/src/Bicep.Core/Semantics/Decorator.cs
@@ -14,6 +14,7 @@ namespace Bicep.Core.Semantics
         TypeSymbol targetType,
         ITypeManager typeManager,
         IBinder binder,
+        IDiagnosticLookup parsingErrorLookup,
         IDiagnosticWriter diagnosticWriter);
 
     public delegate ObjectExpression? DecoratorEvaluator(
@@ -41,7 +42,7 @@ namespace Bicep.Core.Semantics
 
         public bool CanAttachTo(TypeSymbol targetType) => TypeValidator.AreTypesAssignable(targetType, attachableType);
 
-        public void Validate(DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticWriter diagnosticWriter)
+        public void Validate(DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticLookup parsingErrorLookup, IDiagnosticWriter diagnosticWriter)
         {
             // The following line makes the simplifying assumption that nullability does not impact decorator validity. This assumption is true at the moment
             // because aside from @metadata and @description (which are attachable to targets of any type), all decorators represent validation constraints
@@ -60,7 +61,7 @@ namespace Bicep.Core.Semantics
             }
 
             // Invoke custom validator if provided.
-            this.validator?.Invoke(this.Overload.Name, decoratorSyntax, targetType, typeManager, binder, diagnosticWriter);
+            this.validator?.Invoke(this.Overload.Name, decoratorSyntax, targetType, typeManager, binder, parsingErrorLookup, diagnosticWriter);
         }
 
         public ObjectExpression? Evaluate(FunctionCallExpression functionCall, TypeSymbol targetType, ObjectExpression? targetObject)

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1339,12 +1339,12 @@ namespace Bicep.Core.Semantics.Namespaces
                 }
             }
 
-            static void ValidateNotTargetingAlias(string decoratorName, DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticWriter diagnosticWriter)
+            static void ValidateNotTargetingAlias(string decoratorName, DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticLookup parsingErrorLookup, IDiagnosticWriter diagnosticWriter)
                 => EmitDiagnosticIfTargetingAlias(decoratorName, decoratorSyntax, GetDeclaredTypeSyntaxOfParent(decoratorSyntax, binder), binder, diagnosticWriter);
 
-            static void ValidateLength(string decoratorName, DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticWriter diagnosticWriter)
+            static void ValidateLength(string decoratorName, DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticLookup parsingErrorLookup, IDiagnosticWriter diagnosticWriter)
             {
-                ValidateNotTargetingAlias(decoratorName, decoratorSyntax, targetType, typeManager, binder, diagnosticWriter);
+                ValidateNotTargetingAlias(decoratorName, decoratorSyntax, targetType, typeManager, binder, parsingErrorLookup, diagnosticWriter);
 
                 if (targetType is UnionType || TypeHelper.IsLiteralType(targetType))
                 {
@@ -1384,7 +1384,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithDescription("Defines the allowed values of the parameter.")
                 .WithRequiredParameter("values", LanguageConstants.Array, "The allowed values.")
                 .WithFlags(FunctionFlags.ParameterDecorator)
-                .WithValidator((decoratorName, decoratorSyntax, targetType, typeManager, binder, diagnosticWriter) =>
+                .WithValidator((decoratorName, decoratorSyntax, targetType, typeManager, binder, parsingErrorLookup, diagnosticWriter) =>
                 {
                     var parentTypeSyntax = GetDeclaredTypeSyntaxOfParent(decoratorSyntax, binder);
 
@@ -1406,7 +1406,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     TypeValidator.NarrowTypeAndCollectDiagnostics(
                         typeManager,
                         binder,
-                        binder.FileSymbol.Syntax.ParsingErrorLookup,
+                        parsingErrorLookup,
                         diagnosticWriter,
                         SingleArgumentSelector(decoratorSyntax),
                         new TypedArrayType(targetType, TypeSymbolValidationFlags.Default));
@@ -1454,8 +1454,8 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithDescription("Defines metadata of the parameter.")
                 .WithRequiredParameter("object", LanguageConstants.Object, "The metadata object.")
                 .WithFlags(FunctionFlags.ParameterOutputOrTypeDecorator)
-                .WithValidator((_, decoratorSyntax, _, typeManager, binder, diagnosticWriter) =>
-                    TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, binder.FileSymbol.Syntax.ParsingErrorLookup, diagnosticWriter, SingleArgumentSelector(decoratorSyntax), LanguageConstants.ParameterModifierMetadata))
+                .WithValidator((_, decoratorSyntax, _, typeManager, binder, parsingErrorLookup, diagnosticWriter) =>
+                    TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, parsingErrorLookup, diagnosticWriter, SingleArgumentSelector(decoratorSyntax), LanguageConstants.ParameterModifierMetadata))
                 .WithEvaluator(MergeToTargetObject(LanguageConstants.ParameterMetadataPropertyName, SingleParameterSelector))
                 .Build();
 
@@ -1472,7 +1472,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter(LanguageConstants.BatchSizePropertyName, LanguageConstants.Int, "The size of the batch")
                 .WithFlags(FunctionFlags.ResourceOrModuleDecorator)
                 // the decorator is constrained to resources and modules already - checking for array alone is simple and should be sufficient
-                .WithValidator((decoratorName, decoratorSyntax, targetType, typeManager, binder, diagnosticWriter) =>
+                .WithValidator((decoratorName, decoratorSyntax, targetType, typeManager, binder, _, diagnosticWriter) =>
                 {
                     if (!TypeValidator.AreTypesAssignable(targetType, LanguageConstants.Array))
                     {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1406,6 +1406,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     TypeValidator.NarrowTypeAndCollectDiagnostics(
                         typeManager,
                         binder,
+                        binder.FileSymbol.Syntax.ParsingErrorLookup,
                         diagnosticWriter,
                         SingleArgumentSelector(decoratorSyntax),
                         new TypedArrayType(targetType, TypeSymbolValidationFlags.Default));
@@ -1454,7 +1455,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("object", LanguageConstants.Object, "The metadata object.")
                 .WithFlags(FunctionFlags.ParameterOutputOrTypeDecorator)
                 .WithValidator((_, decoratorSyntax, _, typeManager, binder, diagnosticWriter) =>
-                    TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnosticWriter, SingleArgumentSelector(decoratorSyntax), LanguageConstants.ParameterModifierMetadata))
+                    TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, binder.FileSymbol.Syntax.ParsingErrorLookup, diagnosticWriter, SingleArgumentSelector(decoratorSyntax), LanguageConstants.ParameterModifierMetadata))
                 .WithEvaluator(MergeToTargetObject(LanguageConstants.ParameterMetadataPropertyName, SingleParameterSelector))
                 .Build();
 

--- a/src/Bicep.Core/Semantics/SemanticDiagnosticVisitor.cs
+++ b/src/Bicep.Core/Semantics/SemanticDiagnosticVisitor.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace Bicep.Core.Semantics
 {
@@ -42,6 +45,28 @@ namespace Bicep.Core.Semantics
         {
             base.VisitFileSymbol(symbol);
             this.CollectDiagnostics(symbol);
+
+            // find duplicate target scope declarations
+            var targetScopeSyntaxes = symbol.Syntax.Children.OfType<TargetScopeSyntax>().ToImmutableArray();
+
+            if (targetScopeSyntaxes.Length > 1)
+            {
+                foreach (var targetScope in targetScopeSyntaxes)
+                {
+                    this.diagnosticWriter.Write(targetScope.Keyword, x => x.TargetScopeMultipleDeclarations());
+                }
+            }
+
+            // find duplicate using declarations
+            var usingSyntaxes = symbol.Syntax.Children.OfType<UsingDeclarationSyntax>().ToImmutableArray();
+
+            if (usingSyntaxes.Length > 1)
+            {
+                foreach (var declaration in usingSyntaxes)
+                {
+                    this.diagnosticWriter.Write(declaration.Keyword, x => x.MoreThanOneUsingDeclarationSpecified());
+                }
+            }
         }
 
         public override void VisitVariableSymbol(VariableSymbol symbol)

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -13,6 +13,7 @@ using Bicep.Core.Emit;
 using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Parsing;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
@@ -56,7 +57,7 @@ namespace Bicep.Core.Semantics
             SymbolContext = symbolContext;
 
             Binder = new Binder(compilation.NamespaceProvider, features, sourceFile, symbolContext);
-            TypeManager = new TypeManager(features, Binder, fileResolver, this.SourceFile.FileKind);
+            TypeManager = new TypeManager(features, Binder, fileResolver, this.ParsingErrorLookup, this.SourceFile.FileKind);
 
             // name binding is done
             // allow type queries now
@@ -78,8 +79,8 @@ namespace Bicep.Core.Semantics
             this.allResourcesLazy = new Lazy<ImmutableArray<ResourceMetadata>>(() => GetAllResourceMetadata());
             this.declaredResourcesLazy = new Lazy<ImmutableArray<DeclaredResourceMetadata>>(() => this.AllResources.OfType<DeclaredResourceMetadata>().ToImmutableArray());
 
-            this.assignmentsByDeclaration = new Lazy<ImmutableDictionary<ParameterSymbol, ParameterAssignmentSymbol?>>(() => InitializeDeclarationToAssignmentDictionary());
-            this.declarationsByAssignment = new Lazy<ImmutableDictionary<ParameterAssignmentSymbol, ParameterSymbol?>>(() => InitializeAssignmentToDeclarationDictionary());
+            this.assignmentsByDeclaration = new Lazy<ImmutableDictionary<ParameterSymbol, ParameterAssignmentSymbol?>>(InitializeDeclarationToAssignmentDictionary);
+            this.declarationsByAssignment = new Lazy<ImmutableDictionary<ParameterAssignmentSymbol, ParameterSymbol?>>(InitializeAssignmentToDeclarationDictionary);
 
             // lazy load single use diagnostic set
             this.allDiagnostics = new Lazy<ImmutableArray<IDiagnostic>>(() => AssembleDiagnostics());
@@ -152,6 +153,10 @@ namespace Bicep.Core.Semantics
 
         public IFileResolver FileResolver { get; }
 
+        public IDiagnosticLookup LexingErrorLookup => this.Root.Syntax.LexingErrorLookup;
+
+        public IDiagnosticLookup ParsingErrorLookup => this.Root.Syntax.ParsingErrorLookup;
+
         public EmitLimitationInfo EmitLimitationInfo => emitLimitationInfoLazy.Value;
 
         public ResourceAncestorGraph ResourceAncestors => resourceAncestorsLazy.Value;
@@ -186,11 +191,6 @@ namespace Bicep.Core.Semantics
                 yield return builderFunc(DiagnosticBuilder.ForDocumentStart());
             }
         }
-
-        /// <summary>
-        /// Gets all the parser and lexer diagnostics unsorted. Does not include diagnostics from the semantic model.
-        /// </summary>
-        private IEnumerable<IDiagnostic> GetParseDiagnostics() => this.Root.Syntax.GetParseDiagnostics();
 
         /// <summary>
         /// Gets all the semantic diagnostics unsorted. Does not include parser and lexer diagnostics.
@@ -238,7 +238,8 @@ namespace Bicep.Core.Semantics
         private ImmutableArray<IDiagnostic> AssembleDiagnostics()
         {
             var diagnostics = GetConfigDiagnostics()
-                .Concat(GetParseDiagnostics())
+                .Concat(this.LexingErrorLookup)
+                .Concat(this.ParsingErrorLookup)
                 .Concat(GetSemanticDiagnostics())
                 .Concat(GetAnalyzerDiagnostics())
                 // TODO: This could be eliminated if we change the params type checking code to operate more on symbols
@@ -275,6 +276,8 @@ namespace Bicep.Core.Semantics
         /// <returns>True if analysis finds errors</returns>
         public bool HasErrors()
             => allDiagnostics.Value.Any(x => x.Level == DiagnosticLevel.Error);
+
+        public bool HasParsingError(SyntaxBase syntax) => this.ParsingErrorLookup.Contains(syntax);
 
         public TypeSymbol GetTypeInfo(SyntaxBase syntax) => this.TypeManager.GetTypeInfo(syntax);
 

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -153,9 +153,9 @@ namespace Bicep.Core.Semantics
 
         public IFileResolver FileResolver { get; }
 
-        public IDiagnosticLookup LexingErrorLookup => this.Root.Syntax.LexingErrorLookup;
+        public IDiagnosticLookup LexingErrorLookup => this.SourceFile.LexingErrorLookup;
 
-        public IDiagnosticLookup ParsingErrorLookup => this.Root.Syntax.ParsingErrorLookup;
+        public IDiagnosticLookup ParsingErrorLookup => this.SourceFile.ParsingErrorLookup;
 
         public EmitLimitationInfo EmitLimitationInfo => emitLimitationInfoLazy.Value;
 

--- a/src/Bicep.Core/Syntax/ProgramSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProgramSyntax.cs
@@ -12,7 +12,7 @@ namespace Bicep.Core.Syntax
     public class ProgramSyntax : SyntaxBase
     {
         public ProgramSyntax(IEnumerable<SyntaxBase> children, Token endOfFile)
-            : this(children, endOfFile, new DiagnosticTree(), new DiagnosticTree())
+            : this(children, endOfFile, EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance)
         {
         }
 

--- a/src/Bicep.Core/Syntax/ProgramSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProgramSyntax.cs
@@ -11,18 +11,26 @@ namespace Bicep.Core.Syntax
 {
     public class ProgramSyntax : SyntaxBase
     {
-        public ProgramSyntax(IEnumerable<SyntaxBase> children, Token endOfFile, IEnumerable<IDiagnostic> lexerDiagnostics)
+        public ProgramSyntax(IEnumerable<SyntaxBase> children, Token endOfFile)
+            : this(children, endOfFile, new DiagnosticTree(), new DiagnosticTree())
+        {
+        }
+
+        public ProgramSyntax(IEnumerable<SyntaxBase> children, Token endOfFile, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
         {
             this.Children = children.ToImmutableArray();
             this.EndOfFile = endOfFile;
-            this.LexerDiagnostics = lexerDiagnostics.ToImmutableArray();
+            this.LexingErrorLookup = lexingErrorLookup;
+            this.ParsingErrorLookup = parsingErrorLookup;
         }
 
         public ImmutableArray<SyntaxBase> Children { get; }
 
         public Token EndOfFile { get; }
 
-        public ImmutableArray<IDiagnostic> LexerDiagnostics { get; }
+        public IDiagnosticLookup LexingErrorLookup { get; }
+
+        public IDiagnosticLookup ParsingErrorLookup { get; }
 
         public override void Accept(ISyntaxVisitor visitor)
             => visitor.VisitProgramSyntax(this);

--- a/src/Bicep.Core/Syntax/SkippedTriviaSyntax.cs
+++ b/src/Bicep.Core/Syntax/SkippedTriviaSyntax.cs
@@ -10,7 +10,12 @@ namespace Bicep.Core.Syntax
 {
     public class SkippedTriviaSyntax : SyntaxBase
     {
-        public SkippedTriviaSyntax(TextSpan span, IEnumerable<SyntaxBase> elements, IEnumerable<IDiagnostic> diagnostics)
+        public SkippedTriviaSyntax(TextSpan span, IEnumerable<SyntaxBase> elements)
+            : this(span, elements, ImmutableArray<ErrorDiagnostic>.Empty)
+        {
+        }
+
+        public SkippedTriviaSyntax(TextSpan span, IEnumerable<SyntaxBase> elements, IEnumerable<ErrorDiagnostic> diagnostics)
         {
             this.Span = span;
             this.Elements = elements.ToImmutableArray();
@@ -27,7 +32,7 @@ namespace Bicep.Core.Syntax
         /// <summary>
         /// Diagnostics to raise.
         /// </summary>
-        public ImmutableArray<IDiagnostic> Diagnostics { get; }
+        public ImmutableArray<ErrorDiagnostic> Diagnostics { get; }
 
         public string TriviaName => this.Elements.Any() ? LanguageConstants.ErrorName : LanguageConstants.MissingName;
 

--- a/src/Bicep.Core/Syntax/SyntaxExtensions.cs
+++ b/src/Bicep.Core/Syntax/SyntaxExtensions.cs
@@ -48,18 +48,6 @@ namespace Bicep.Core.Syntax
 
         public static bool IsOf(this Token token, TokenType type) => token.Type == type;
 
-        public static IReadOnlyList<IDiagnostic> GetParseDiagnostics(this SyntaxBase syntax)
-        {
-            var diagnosticWriter = ToListDiagnosticWriter.Create();
-            var parseErrorVisitor = new ParseDiagnosticsVisitor(diagnosticWriter);
-            parseErrorVisitor.Visit(syntax);
-
-            return diagnosticWriter.GetDiagnostics();
-        }
-
-        public static bool HasParseErrors(this SyntaxBase syntax)
-            => syntax.GetParseDiagnostics().Any(d => d.Level == DiagnosticLevel.Error);
-
         public static bool NameEquals(this FunctionCallSyntax funcSyntax, string compareTo)
             => LanguageConstants.IdentifierComparer.Equals(funcSyntax.Name.IdentifierName, compareTo);
 

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -18,7 +18,7 @@ namespace Bicep.Core.Syntax
         public static readonly IEnumerable<SyntaxTrivia> SingleSpaceTrivia = ImmutableArray.Create(
             new SyntaxTrivia(SyntaxTriviaType.Whitespace, TextSpan.Nil, " "));
 
-        public static readonly SkippedTriviaSyntax EmptySkippedTrivia = new(TextSpan.Nil, Enumerable.Empty<SyntaxBase>(), Enumerable.Empty<IDiagnostic>());
+        public static readonly SkippedTriviaSyntax EmptySkippedTrivia = new(TextSpan.Nil, Enumerable.Empty<SyntaxBase>());
 
         public static Token CreateToken(TokenType tokenType, string text = "", IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null)
         {

--- a/src/Bicep.Core/Syntax/SyntaxModifier.cs
+++ b/src/Bicep.Core/Syntax/SyntaxModifier.cs
@@ -4,12 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax;
 
-public static class SyntaxModifier
+public class SyntaxModifier
 {
     public static ObjectSyntax? TryUpdatePropertyValue(ObjectSyntax @object, string key, Func<SyntaxBase, SyntaxBase> updateFunc)
     {
@@ -26,12 +27,12 @@ public static class SyntaxModifier
             @object.CloseBrace);
     }
 
-    public static ObjectSyntax? TryAddProperty(ObjectSyntax @object, ObjectPropertySyntax newProperty, int? atIndex = null)
-        => TryAddProperties(@object, newProperty.AsEnumerable(), atIndex);
+    public static ObjectSyntax? TryAddProperty(ObjectSyntax @object, ObjectPropertySyntax newProperty, IDiagnosticLookup parsingErrorLookup, int? atIndex = null)
+        => TryAddProperties(@object, newProperty.AsEnumerable(), parsingErrorLookup, atIndex);
 
-    public static ObjectSyntax? TryAddProperties(ObjectSyntax @object, IEnumerable<ObjectPropertySyntax> newProperties, int? atIndex = null)
+    public static ObjectSyntax? TryAddProperties(ObjectSyntax @object, IEnumerable<ObjectPropertySyntax> newProperties, IDiagnosticLookup parsingErrorLookup, int? atIndex = null)
     {
-        if (@object.HasParseErrors())
+        if (parsingErrorLookup.Contains(@object))
         {
             return null;
         }
@@ -74,9 +75,9 @@ public static class SyntaxModifier
         return new ObjectSyntax(@object.OpenBrace, CollapseLeadingAndTrailingNewlines(newChildren), @object.CloseBrace);
     }
 
-    public static ObjectSyntax? TryRemoveProperty(ObjectSyntax @object, ObjectPropertySyntax property)
+    public static ObjectSyntax? TryRemoveProperty(ObjectSyntax @object, ObjectPropertySyntax property, IDiagnosticLookup parsingErrorLookup)
     {
-        if (@object.HasParseErrors())
+        if (parsingErrorLookup.Contains(@object))
         {
             return null;
         }
@@ -103,9 +104,9 @@ public static class SyntaxModifier
         return new(@object.OpenBrace, CollapseLeadingAndTrailingNewlines(newChildren), @object.CloseBrace);
     }
 
-    public static ArraySyntax? TryRemoveItem(ArraySyntax array, ArrayItemSyntax item)
+    public static ArraySyntax? TryRemoveItem(ArraySyntax array, ArrayItemSyntax item, IDiagnosticLookup parsingErrorLookup)
     {
-        if (array.HasParseErrors())
+        if (parsingErrorLookup.Contains(array))
         {
             return null;
         }

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -569,7 +569,7 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new ProgramSyntax(children, endOfFile, Enumerable.Empty<IDiagnostic>());
+            return new ProgramSyntax(children, endOfFile);
         }
         void ISyntaxVisitor.VisitProgramSyntax(ProgramSyntax syntax) => ReplaceCurrent(syntax, ReplaceProgramSyntax);
 
@@ -608,7 +608,7 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new SkippedTriviaSyntax(new TextSpan(0, 0), elements, Enumerable.Empty<IDiagnostic>());
+            return new SkippedTriviaSyntax(new TextSpan(0, 0), elements);
         }
         void ISyntaxVisitor.VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax) => ReplaceCurrent(syntax, ReplaceSkippedTriviaSyntax);
 

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -739,7 +739,7 @@ namespace Bicep.Core.TypeSystem
                             decoratorSyntaxesByMatchingDecorator[decorator] = new List<DecoratorSyntax> { decoratorSyntax };
                         }
 
-                        decorator.Validate(decoratorSyntax, targetType, this.typeManager, this.binder, diagnostics);
+                        decorator.Validate(decoratorSyntax, targetType, this.typeManager, this.binder, this.parsingErrorLookup, diagnostics);
                     }
                 }
             }
@@ -1581,7 +1581,7 @@ namespace Bicep.Core.TypeSystem
 
                 TypeValidator.GetCompileTimeConstantViolation(syntax.Value, diagnostics);
 
-                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, binder.FileSymbol.Syntax.ParsingErrorLookup, diagnostics, syntax.Value, declaredType);
+                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, parsingErrorLookup, diagnostics, syntax.Value, declaredType);
             });
 
         public override void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax) => AssignTypeWithDiagnostics(syntax, diagnostics =>
@@ -1880,7 +1880,7 @@ namespace Bicep.Core.TypeSystem
 
             var diagnosticWriter = ToListDiagnosticWriter.Create();
 
-            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, binder.FileSymbol.Syntax.ParsingErrorLookup, diagnosticWriter, defaultValueSyntax.DefaultValue, assignedType);
+            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, parsingErrorLookup, diagnosticWriter, defaultValueSyntax.DefaultValue, assignedType);
 
             return diagnosticWriter.GetDiagnostics();
         }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -27,17 +27,19 @@ namespace Bicep.Core.TypeSystem
         private readonly ITypeManager typeManager;
         private readonly IBinder binder;
         private readonly IFileResolver fileResolver;
+        private readonly IDiagnosticLookup parsingErrorLookup;
         private readonly ConcurrentDictionary<SyntaxBase, TypeAssignment> assignedTypes;
         private readonly ConcurrentDictionary<FunctionCallSyntaxBase, FunctionOverload> matchedFunctionOverloads;
         private readonly ConcurrentDictionary<FunctionCallSyntaxBase, Expression> matchedFunctionResultValues;
         private readonly BicepSourceFileKind fileKind;
 
-        public TypeAssignmentVisitor(ITypeManager typeManager, IFeatureProvider features, IBinder binder, IFileResolver fileResolver, Workspaces.BicepSourceFileKind fileKind)
+        public TypeAssignmentVisitor(ITypeManager typeManager, IFeatureProvider features, IBinder binder, IFileResolver fileResolver, IDiagnosticLookup parsingErrorLookup, Workspaces.BicepSourceFileKind fileKind)
         {
             this.typeManager = typeManager;
             this.features = features;
             this.binder = binder;
             this.fileResolver = fileResolver;
+            this.parsingErrorLookup = parsingErrorLookup;
             assignedTypes = new();
             matchedFunctionOverloads = new();
             matchedFunctionResultValues = new();
@@ -303,7 +305,7 @@ namespace Bicep.Core.TypeSystem
                     }
                 }
 
-                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnostics, syntax.Value, declaredType, true);
+                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, this.parsingErrorLookup, diagnostics, syntax.Value, declaredType, true);
             });
 
         public override void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax)
@@ -380,7 +382,7 @@ namespace Bicep.Core.TypeSystem
                 }
 
 
-                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnostics, syntax.Value, declaredType);
+                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, this.parsingErrorLookup, diagnostics, syntax.Value, declaredType);
             });
 
         public override void VisitParameterDeclarationSyntax(ParameterDeclarationSyntax syntax)
@@ -673,7 +675,7 @@ namespace Bicep.Core.TypeSystem
                     else
                     {
                         // Collect diagnostics for the configuration type assignment.
-                        TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnostics, syntax.Config, namespaceType.ConfigurationType.Type, false);
+                        TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, this.parsingErrorLookup, diagnostics, syntax.Config, namespaceType.ConfigurationType.Type, false);
                     }
                 }
                 else
@@ -884,6 +886,18 @@ namespace Bicep.Core.TypeSystem
             => AssignType(syntax, () =>
             {
                 var errors = new List<ErrorDiagnostic>();
+
+                var duplicatedProperties = syntax.Properties
+                    .GroupByExcludingNull(prop => prop.TryGetKeyText(), LanguageConstants.IdentifierComparer)
+                    .Where(group => group.Count() > 1);
+
+                foreach (var group in duplicatedProperties)
+                {
+                    foreach (ObjectPropertySyntax duplicatedProperty in group)
+                    {
+                        errors.Add(DiagnosticBuilder.ForPosition(duplicatedProperty.Key).PropertyMultipleDeclarations(group.Key));
+                    }
+                }
 
                 var propertyTypes = new List<TypeSymbol>();
                 foreach (var objectProperty in syntax.Properties)
@@ -1445,7 +1459,7 @@ namespace Bicep.Core.TypeSystem
                 }
 
                 var argumentTypes = syntax.GetLocalVariables().Select(x => typeManager.GetTypeInfo(x));
-                var returnType = TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnostics, syntax.Body, LanguageConstants.Any);
+                var returnType = TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, this.parsingErrorLookup, diagnostics, syntax.Body, LanguageConstants.Any);
 
                 return new LambdaType(argumentTypes.ToImmutableArray<ITypeReference>(), returnType);
             });
@@ -1567,12 +1581,12 @@ namespace Bicep.Core.TypeSystem
 
                 TypeValidator.GetCompileTimeConstantViolation(syntax.Value, diagnostics);
 
-                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnostics, syntax.Value, declaredType);
+                return TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, binder.FileSymbol.Syntax.ParsingErrorLookup, diagnostics, syntax.Value, declaredType);
             });
 
         public override void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax) => AssignTypeWithDiagnostics(syntax, diagnostics =>
         {
-            if (syntax.HasParseErrors())
+            if (this.parsingErrorLookup.Contains(syntax))
             {
                 // Skip adding semantic errors if there are parsing errors, as it might be a bit overwhelming.
                 return LanguageConstants.Any;
@@ -1866,7 +1880,7 @@ namespace Bicep.Core.TypeSystem
 
             var diagnosticWriter = ToListDiagnosticWriter.Create();
 
-            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, diagnosticWriter, defaultValueSyntax.DefaultValue, assignedType);
+            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, binder.FileSymbol.Syntax.ParsingErrorLookup, diagnosticWriter, defaultValueSyntax.DefaultValue, assignedType);
 
             return diagnosticWriter.GetDiagnostics();
         }

--- a/src/Bicep.Core/TypeSystem/TypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/TypeManager.cs
@@ -17,12 +17,12 @@ namespace Bicep.Core.TypeSystem
         private readonly TypeAssignmentVisitor typeAssignmentVisitor;
         private readonly DeclaredTypeManager declaredTypeManager;
 
-        public TypeManager(IFeatureProvider features, IBinder binder, IFileResolver fileResolver, BicepSourceFileKind kind)
+        public TypeManager(IFeatureProvider features, IBinder binder, IFileResolver fileResolver, IDiagnosticLookup parsingErrorLookup, BicepSourceFileKind kind)
         {
             // bindings will be modified by name binding after this object is created
             // so we can't make an immutable copy here
             // (using the IReadOnlyDictionary to prevent accidental mutation)
-            this.typeAssignmentVisitor = new TypeAssignmentVisitor(this, features, binder, fileResolver, kind);
+            this.typeAssignmentVisitor = new TypeAssignmentVisitor(this, features, binder, fileResolver, parsingErrorLookup, kind);
             this.declaredTypeManager = new DeclaredTypeManager(this, binder, features);
         }
 

--- a/src/Bicep.Core/Workspaces/BicepFile.cs
+++ b/src/Bicep.Core/Workspaces/BicepFile.cs
@@ -10,8 +10,8 @@ namespace Bicep.Core.Workspaces
 {
     public class BicepFile : BicepSourceFile
     {
-        public BicepFile(Uri fileUri, ImmutableArray<int> lineStarts, ProgramSyntax programSyntax)
-            : base(lineStarts, programSyntax, fileUri)
+        public BicepFile(Uri fileUri, ImmutableArray<int> lineStarts, ProgramSyntax programSyntax, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
+            : base(lineStarts, programSyntax, fileUri, lexingErrorLookup, parsingErrorLookup)
         {
         }
 

--- a/src/Bicep.Core/Workspaces/BicepParamFile.cs
+++ b/src/Bicep.Core/Workspaces/BicepParamFile.cs
@@ -10,8 +10,9 @@ namespace Bicep.Core.Workspaces
 {
     public class BicepParamFile : BicepSourceFile
     {
-        public BicepParamFile(Uri fileUri, ImmutableArray<int> lineStarts, ProgramSyntax programSyntax)
-            : base(lineStarts, programSyntax, fileUri)
+        public BicepParamFile(Uri fileUri, ImmutableArray<int> lineStarts, ProgramSyntax programSyntax, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
+
+            : base(lineStarts, programSyntax, fileUri, lexingErrorLookup, parsingErrorLookup)
         {
         }
 

--- a/src/Bicep.Core/Workspaces/BicepSourceFile.cs
+++ b/src/Bicep.Core/Workspaces/BicepSourceFile.cs
@@ -10,12 +10,14 @@ namespace Bicep.Core.Workspaces
 {
     public abstract class BicepSourceFile : ISourceFile
     {
-        protected BicepSourceFile(ImmutableArray<int> lineStarts, ProgramSyntax programSyntax, Uri fileUri)
+        protected BicepSourceFile(ImmutableArray<int> lineStarts, ProgramSyntax programSyntax, Uri fileUri, IDiagnosticLookup lexingErrorLookup, IDiagnosticLookup parsingErrorLookup)
         {
             LineStarts = lineStarts;
             ProgramSyntax = programSyntax;
             FileUri = fileUri;
             Hierarchy = SyntaxHierarchy.Build(ProgramSyntax);
+            LexingErrorLookup = lexingErrorLookup;
+            ParsingErrorLookup = parsingErrorLookup;
             DisabledDiagnosticsCache = new DisabledDiagnosticsCache(ProgramSyntax, lineStarts);
         }
 
@@ -25,6 +27,8 @@ namespace Bicep.Core.Workspaces
             LineStarts = original.LineStarts;
             ProgramSyntax = original.ProgramSyntax;
             Hierarchy = original.Hierarchy;
+            LexingErrorLookup = original.LexingErrorLookup;
+            ParsingErrorLookup = original.ParsingErrorLookup;
             DisabledDiagnosticsCache = original.DisabledDiagnosticsCache;
         }
 
@@ -37,6 +41,10 @@ namespace Bicep.Core.Workspaces
         public abstract BicepSourceFileKind FileKind { get; }
 
         public ISyntaxHierarchy Hierarchy { get; }
+
+        public IDiagnosticLookup LexingErrorLookup { get; }
+
+        public IDiagnosticLookup ParsingErrorLookup { get; }
 
         public DisabledDiagnosticsCache DisabledDiagnosticsCache { get; }
 

--- a/src/Bicep.Core/Workspaces/SourceFileFactory.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileFactory.cs
@@ -69,7 +69,7 @@ namespace Bicep.Core.Workspaces
             var parser = new ParamsParser(fileContents);
             var lineStarts = TextCoordinateConverter.GetLineStarts(fileContents);
 
-            return new(fileUri, lineStarts, parser.Program());
+            return new(fileUri, lineStarts, parser.Program(), parser.LexingErrorLookup, parser.ParsingErrorLookup);
         }
 
         public static BicepFile CreateBicepFile(Uri fileUri, string fileContents)
@@ -77,7 +77,7 @@ namespace Bicep.Core.Workspaces
             var parser = new Parser(fileContents);
             var lineStarts = TextCoordinateConverter.GetLineStarts(fileContents);
 
-            return new(fileUri, lineStarts, parser.Program());
+            return new(fileUri, lineStarts, parser.Program(), parser.LexingErrorLookup, parser.ParsingErrorLookup);
         }
 
         public static ArmTemplateFile CreateArmTemplateFile(Uri fileUri, string fileContents)

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -19,6 +19,7 @@ using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
+using Bicep.Core.Diagnostics;
 
 namespace Bicep.Decompiler;
 
@@ -138,7 +139,7 @@ public class BicepDecompiler
 
     private static string PrintSyntax(SyntaxBase syntax)
     {
-        return PrettyPrinter.PrintSyntax(syntax, GetPrettyPrintOptions());
+        return PrettyPrinter.PrintSyntax(syntax, GetPrettyPrintOptions(), new DiagnosticTree(), new DiagnosticTree());
     }
 
     private static PrettyPrintOptions GetPrettyPrintOptions() => new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false);

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -131,7 +131,7 @@ public class BicepDecompiler
                 continue;
             }
 
-            filesToSave[fileUri] = PrettyPrinter.PrintProgram(bicepFile.ProgramSyntax, GetPrettyPrintOptions());
+            filesToSave[fileUri] = PrettyPrinter.PrintProgram(bicepFile.ProgramSyntax, GetPrettyPrintOptions(), bicepFile.LexingErrorLookup, bicepFile.ParsingErrorLookup);
         }
 
         return filesToSave.ToImmutableDictionary();
@@ -139,7 +139,7 @@ public class BicepDecompiler
 
     private static string PrintSyntax(SyntaxBase syntax)
     {
-        return PrettyPrinter.PrintSyntax(syntax, GetPrettyPrintOptions(), EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance);
+        return PrettyPrinter.PrintValidSyntax(syntax, GetPrettyPrintOptions());
     }
 
     private static PrettyPrintOptions GetPrettyPrintOptions() => new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false);

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -139,7 +139,7 @@ public class BicepDecompiler
 
     private static string PrintSyntax(SyntaxBase syntax)
     {
-        return PrettyPrinter.PrintSyntax(syntax, GetPrettyPrintOptions(), new DiagnosticTree(), new DiagnosticTree());
+        return PrettyPrinter.PrintSyntax(syntax, GetPrettyPrintOptions(), EmptyDiagnosticLookup.Instance, EmptyDiagnosticLookup.Instance);
     }
 
     private static PrettyPrintOptions GetPrettyPrintOptions() => new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false);

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -1772,9 +1772,7 @@ namespace Bicep.Decompiler
 
             return new ProgramSyntax(
                 statements.SelectMany(x => new[] { x, SyntaxFactory.NewlineToken }),
-                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""),
-                Enumerable.Empty<IDiagnostic>()
-            );
+                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""));
         }
 
         private T PerformScopedAction<T>(Func<T> action, IEnumerable<string> scopeVariables)

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepBuildCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepBuildCommandHandlerTests.cs
@@ -116,27 +116,29 @@ param accountName string = 'testAccount'
             var bicepBuildCommandHandler = CreateHandler(bicepCompilationManager);
             string expected = await bicepBuildCommandHandler.Handle(documentUri.Path, CancellationToken.None);
 
-            expected.Should().BeEquivalentToIgnoringNewlines(@"Bicep build failed. Please fix below errors:
-/input.bicep(1,1) : Error BCP112: The ""targetScope"" cannot be declared multiple times in one file.
-/input.bicep(1,12) : Error BCP018: Expected the ""="" character at this location.
-/input.bicep(1,12) : Error BCP009: Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.
-/input.bicep(3,2) : Error BCP007: This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration.
-/input.bicep(3,2) : Error BCP001: The following token is not recognized: ""#"".
-/input.bicep(4,1) : Error BCP112: The ""targetScope"" cannot be declared multiple times in one file.
-/input.bicep(4,12) : Error BCP018: Expected the ""="" character at this location.
-/input.bicep(4,12) : Error BCP009: Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.
-/input.bicep(6,2) : Error BCP007: This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration.
-/input.bicep(6,2) : Error BCP001: The following token is not recognized: ""#"".
-/input.bicep(7,1) : Error BCP112: The ""targetScope"" cannot be declared multiple times in one file.
-/input.bicep(7,14) : Error BCP009: Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.
-/input.bicep(10,1) : Error BCP112: The ""targetScope"" cannot be declared multiple times in one file.
-/input.bicep(10,15) : Error BCP033: Expected a value of type ""'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'"" but the provided value is of type ""'asdfds'"".
-/input.bicep(12,1) : Error BCP112: The ""targetScope"" cannot be declared multiple times in one file.
-/input.bicep(12,15) : Error BCP033: Expected a value of type ""'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'"" but the provided value is of type ""object"".
-/input.bicep(14,1) : Error BCP112: The ""targetScope"" cannot be declared multiple times in one file.
-/input.bicep(14,15) : Error BCP033: Expected a value of type ""'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'"" but the provided value is of type ""True"".
-/input.bicep(15,7) : Warning no-unused-params: Parameter ""accountName"" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
-");
+            expected.Should().BeEquivalentToIgnoringNewlines("""
+                Bicep build failed. Please fix below errors:
+                /input.bicep(1,1) : Error BCP112: The "targetScope" cannot be declared multiple times in one file.
+                /input.bicep(1,12) : Error BCP018: Expected the "=" character at this location.
+                /input.bicep(1,12) : Error BCP009: Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.
+                /input.bicep(3,2) : Error BCP001: The following token is not recognized: "#".
+                /input.bicep(3,2) : Error BCP007: This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration.
+                /input.bicep(4,1) : Error BCP112: The "targetScope" cannot be declared multiple times in one file.
+                /input.bicep(4,12) : Error BCP018: Expected the "=" character at this location.
+                /input.bicep(4,12) : Error BCP009: Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.
+                /input.bicep(6,2) : Error BCP001: The following token is not recognized: "#".
+                /input.bicep(6,2) : Error BCP007: This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration.
+                /input.bicep(7,1) : Error BCP112: The "targetScope" cannot be declared multiple times in one file.
+                /input.bicep(7,14) : Error BCP009: Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.
+                /input.bicep(10,1) : Error BCP112: The "targetScope" cannot be declared multiple times in one file.
+                /input.bicep(10,15) : Error BCP033: Expected a value of type "'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'" but the provided value is of type "'asdfds'".
+                /input.bicep(12,1) : Error BCP112: The "targetScope" cannot be declared multiple times in one file.
+                /input.bicep(12,15) : Error BCP033: Expected a value of type "'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'" but the provided value is of type "object".
+                /input.bicep(14,1) : Error BCP112: The "targetScope" cannot be declared multiple times in one file.
+                /input.bicep(14,15) : Error BCP033: Expected a value of type "'managementGroup' | 'resourceGroup' | 'subscription' | 'tenant'" but the provided value is of type "true".
+                /input.bicep(15,7) : Warning no-unused-params: Parameter "accountName" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]
+
+                """);
         }
 
         [TestMethod]

--- a/src/Bicep.LangServer/Handlers/BicepDecompileForPasteCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDecompileForPasteCommandHandler.cs
@@ -216,7 +216,7 @@ namespace Bicep.LanguageServer.Handlers
                 var parser = new Parser("var v = " + json);
                 var program = parser.Program();
 
-                if (!program.LexingErrorLookup.Any() && !program.ParsingErrorLookup.Any())
+                if (!parser.LexingErrorLookup.Any() && !parser.ParsingErrorLookup.Any())
                 {
                     pasteType = PasteType_BicepValue;
                 }

--- a/src/Bicep.LangServer/Handlers/BicepDecompileForPasteCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDecompileForPasteCommandHandler.cs
@@ -213,8 +213,10 @@ namespace Bicep.LanguageServer.Handlers
                 Log(output, String.Format(LangServerResources.Decompile_DecompilationStartMsg, "clipboard text"));
 
                 // Is the input already a valid Bicep expression?
-                Parser parser = new Parser("var v = " + json);
-                if (!parser.Program().HasParseErrors())
+                var parser = new Parser("var v = " + json);
+                var program = parser.Program();
+
+                if (!program.LexingErrorLookup.Any() && !program.ParsingErrorLookup.Any())
                 {
                     pasteType = PasteType_BicepValue;
                 }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentFormattingHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentFormattingHandler.cs
@@ -44,7 +44,9 @@ namespace Bicep.LanguageServer.Handlers
             ProgramSyntax programSyntax = context.ProgramSyntax;
             PrettyPrintOptions options = new PrettyPrintOptions(NewlineOption.Auto, indentKindOption, indentSize, request.Options.InsertFinalNewline);
 
-            string? output = PrettyPrinter.PrintProgram(programSyntax, options);
+            var lexingErrorLookup = context.Compilation.SourceFileGrouping.EntryPoint.LexingErrorLookup;
+            var parsingErrorLookup = context.Compilation.SourceFileGrouping.EntryPoint.ParsingErrorLookup;
+            string? output = PrettyPrinter.PrintProgram(programSyntax, options, lexingErrorLookup, parsingErrorLookup);
 
             if (output == null)
             {

--- a/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
@@ -102,8 +102,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var program = new ProgramSyntax(
                 declarations.SelectMany(x => new SyntaxBase[] { x, SyntaxFactory.DoubleNewlineToken }),
-                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""),
-                Enumerable.Empty<IDiagnostic>());
+                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""));
 
             return PrettyPrinter.PrintProgram(program, new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false));
         }

--- a/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
@@ -104,7 +104,7 @@ namespace Bicep.LanguageServer.Handlers
                 declarations.SelectMany(x => new SyntaxBase[] { x, SyntaxFactory.DoubleNewlineToken }),
                 SyntaxFactory.CreateToken(TokenType.EndOfFile, ""));
 
-            return PrettyPrinter.PrintProgram(program, new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false));
+            return PrettyPrinter.PrintValidProgram(program, new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false));
         }
 
         private static ResourceDeclarationSyntax ProcessResourceYaml(YamlDocument yamlDocument, TelemetryAndErrorHandlingHelper<ImportKubernetesManifestResponse> telemetryHelper)

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -189,8 +189,7 @@ namespace Bicep.LanguageServer.Handlers
             var printOptions = new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false);
             var program = new ProgramSyntax(
                 new[] { resourceDeclaration },
-                SyntaxFactory.CreateToken(TokenType.EndOfFile),
-                ImmutableArray<IDiagnostic>.Empty);
+                SyntaxFactory.CreateToken(TokenType.EndOfFile));
 
             var printed = PrettyPrinter.PrintProgram(program, printOptions);
             var bicepFile = RewriterHelper.RewriteMultiple(

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -191,7 +191,7 @@ namespace Bicep.LanguageServer.Handlers
                 new[] { resourceDeclaration },
                 SyntaxFactory.CreateToken(TokenType.EndOfFile));
 
-            var printed = PrettyPrinter.PrintProgram(program, printOptions);
+            var printed = PrettyPrinter.PrintValidProgram(program, printOptions);
             var bicepFile = RewriterHelper.RewriteMultiple(
                 prevCompilation,
                 SourceFileFactory.CreateBicepFile(new Uri("inmemory:///generated.bicep"), printed),
@@ -199,7 +199,7 @@ namespace Bicep.LanguageServer.Handlers
                 model => new TypeCasingFixerRewriter(model),
                 model => new ReadOnlyPropertyRemovalRewriter(model));
 
-            printed = PrettyPrinter.PrintProgram(bicepFile.ProgramSyntax, printOptions);
+            printed = PrettyPrinter.PrintValidProgram(bicepFile.ProgramSyntax, printOptions);
             if (insertContext.StartWithNewline)
             {
                 printed = "\n" + printed;

--- a/src/Bicep.Tools.Benchmark/PrettyPrint.cs
+++ b/src/Bicep.Tools.Benchmark/PrettyPrint.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Samples;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using System.IO.Abstractions.TestingHelpers;
+using System.IO.Abstractions;
+using System.Collections.Immutable;
+using FluentAssertions;
+using System;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Utils;
+using SharpYaml;
+using Bicep.Core.PrettyPrint;
+using Bicep.Core.PrettyPrint.Options;
+
+namespace Bicep.Tools.Benchmark;
+
+[MemoryDiagnoser]
+public class PrettyPrint
+{
+    private record BenchmarkData(
+        ImmutableArray<DataSet> DataSets,
+        IDependencyHelper BicepService);
+
+    private static BenchmarkData CreateBenchmarkData()
+    {
+        var fileSystem = FileHelper.CreateMockFileSystemForEmbeddedFiles(typeof(DataSet).Assembly, "Files");
+
+        var dataSets = DataSets.AllDataSets
+            .Where(x => !x.IsValid)
+            .ToImmutableArray();
+
+        var bicepService = new ServiceBuilder()
+            .WithRegistration(x => x.AddSingleton(fileSystem)).Build();
+
+        return new(dataSets, bicepService);
+    }
+
+    private BenchmarkData benchmarkData = null!;
+
+    private PrettyPrintOptions printOptions = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        this.benchmarkData = CreateBenchmarkData();
+        this.printOptions = new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, true); 
+    }
+
+    [Benchmark(Description = "Pretty-print the main file of each valid dataset")]
+    public void PrettyPrint_valid_dataset_main_file()
+    {
+        // Reuse a single IBicepService to amortize the cost of instantiating dependencies
+        var (dataSets, service) = benchmarkData;
+
+        foreach (var dataSet in dataSets)
+        {
+            var sourceFileGrouping = service.BuildSourceFileGrouping(new Uri($"file:///{dataSet.Name}/main.bicep"), false);
+            var compilation = service.BuildCompilation(sourceFileGrouping);
+
+            PrettyPrinter.PrintProgram(compilation.GetEntrypointSemanticModel().Root.Syntax, this.printOptions);
+        }
+    }
+}
+

--- a/src/Bicep.Tools.Benchmark/PrettyPrint.cs
+++ b/src/Bicep.Tools.Benchmark/PrettyPrint.cs
@@ -60,7 +60,7 @@ public class PrettyPrint
             var sourceFileGrouping = service.BuildSourceFileGrouping(new Uri($"file:///{dataSet.Name}/main.bicep"), false);
             var compilation = service.BuildCompilation(sourceFileGrouping);
 
-            PrettyPrinter.PrintProgram(compilation.GetEntrypointSemanticModel().Root.Syntax, this.printOptions);
+            PrettyPrinter.PrintValidProgram(compilation.GetEntrypointSemanticModel().Root.Syntax, this.printOptions);
         }
     }
 }


### PR DESCRIPTION
I started this as an experimental optimization on the v2 formatter branch, but as I modified more and more files it soon became unmanageable, so I'm creating the PR to isolate the changes.

The main changes of the PR include:
- Added `IntervalTree` to cache syntax errors, including lexing and parsing errors. The `IntervalTree` is an augumented red-black tree that holds intervals, where each interval has a `start` position and an `end` position, inclusively. Checking if a syntax has errors can now be done in O(lg(n)) instead of O(m) (by calling `syntax.HasParseDiagnostics()`), where n is the number of errors, and m is the number of child nodes of a given syntax + 1.
- Changed `IdentifierNameExceedsLimit` from a parsing error to a lexing error.
- Changed duplicate targetScope, duplicate object keys to be semantic errors instead of parsing errors.

The benchmark results below show that caching does speed up compilation and improves GC a little, so it may be worth keeping the optimization.

## Compilation

### Without caching
![Before](https://user-images.githubusercontent.com/16367959/226258380-15ac8c44-a511-4d19-be8d-6703e8323d63.png)

### With caching
![After](https://user-images.githubusercontent.com/16367959/226258457-189522d8-1eae-4063-9add-646cdf2f7c68.png)

## Formatting

### Without caching
![Print_Before](https://user-images.githubusercontent.com/16367959/226258551-1af98494-f8aa-4481-802f-c6ba506e444f.png)

### With caching
![Print_After](https://user-images.githubusercontent.com/16367959/226258770-445f8e7d-36db-42ee-8396-5c34a8e16ef6.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10162)