### PR TITLE
Add type and description to symbol completions 

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
@@ -839,6 +839,10 @@
     "label": "fakeFuncP",
     "kind": "field",
     "detail": "fakeFuncP",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fakeFuncP",
@@ -965,6 +969,10 @@
     "label": "funcvarparam",
     "kind": "field",
     "detail": "funcvarparam",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_funcvarparam",

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/Completions/symbols.json
@@ -841,7 +841,7 @@
     "detail": "fakeFuncP",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -971,7 +971,7 @@
     "detail": "funcvarparam",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -3,6 +3,10 @@
     "label": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "kind": "field",
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
@@ -91,6 +95,10 @@
     "label": "badInterpolatedString",
     "kind": "field",
     "detail": "badInterpolatedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString",
@@ -105,6 +113,10 @@
     "label": "badInterpolatedString2",
     "kind": "field",
     "detail": "badInterpolatedString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString2",
@@ -203,6 +215,10 @@
     "label": "boolCompletions",
     "kind": "field",
     "detail": "boolCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_boolCompletions",
@@ -217,6 +233,10 @@
     "label": "commaOne",
     "kind": "field",
     "detail": "commaOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'abc' | 'def'  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_commaOne",
@@ -378,6 +398,10 @@
     "label": "defaultValueOneLinerCompletions",
     "kind": "field",
     "detail": "defaultValueOneLinerCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultValueOneLinerCompletions",
@@ -409,6 +433,10 @@
     "label": "duplicateDecorators",
     "kind": "field",
     "detail": "duplicateDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_duplicateDecorators",
@@ -444,6 +472,10 @@
     "label": "emptyAllowedInt",
     "kind": "field",
     "detail": "emptyAllowedInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedInt",
@@ -458,6 +490,10 @@
     "label": "emptyAllowedString",
     "kind": "field",
     "detail": "emptyAllowedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedString",
@@ -510,6 +546,10 @@
     "label": "expressionInModifier",
     "kind": "field",
     "detail": "expressionInModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInModifier",
@@ -545,6 +585,10 @@
     "label": "fatalErrorInIssue1713",
     "kind": "field",
     "detail": "fatalErrorInIssue1713",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fatalErrorInIssue1713",
@@ -678,6 +722,10 @@
     "label": "incompleteDecorators",
     "kind": "field",
     "detail": "incompleteDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incompleteDecorators",
@@ -755,6 +803,10 @@
     "label": "invalidDefaultWithAllowedArrayDecorator",
     "kind": "field",
     "detail": "invalidDefaultWithAllowedArrayDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDefaultWithAllowedArrayDecorator",
@@ -769,6 +821,10 @@
     "label": "invalidLength",
     "kind": "field",
     "detail": "invalidLength",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLength",
@@ -783,6 +839,10 @@
     "label": "invalidPermutation",
     "kind": "field",
     "detail": "invalidPermutation",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPermutation",
@@ -986,6 +1046,10 @@
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedModifier",
@@ -1000,6 +1064,10 @@
     "label": "malformedType",
     "kind": "field",
     "detail": "malformedType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType",
@@ -1014,6 +1082,10 @@
     "label": "malformedType2",
     "kind": "field",
     "detail": "malformedType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType2",
@@ -1133,6 +1205,10 @@
     "label": "missingType",
     "kind": "field",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -1147,6 +1223,10 @@
     "label": "missingTypeWithSpaceAfter",
     "kind": "field",
     "detail": "missingTypeWithSpaceAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithSpaceAfter",
@@ -1161,6 +1241,10 @@
     "label": "missingTypeWithTabAfter",
     "kind": "field",
     "detail": "missingTypeWithTabAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithTabAfter",
@@ -1175,6 +1259,10 @@
     "label": "myBool",
     "kind": "field",
     "detail": "myBool",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBool",
@@ -1189,6 +1277,10 @@
     "label": "myFalsehood",
     "kind": "field",
     "detail": "myFalsehood",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFalsehood",
@@ -1203,6 +1295,10 @@
     "label": "myInt",
     "kind": "field",
     "detail": "myInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt",
@@ -1217,6 +1313,10 @@
     "label": "myInt2",
     "kind": "field",
     "detail": "myInt2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt2",
@@ -1231,6 +1331,10 @@
     "label": "myString",
     "kind": "field",
     "detail": "myString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString",
@@ -1245,6 +1349,10 @@
     "label": "myString2",
     "kind": "field",
     "detail": "myString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString2",
@@ -1259,6 +1367,10 @@
     "label": "myTruth",
     "kind": "field",
     "detail": "myTruth",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myTruth",
@@ -1290,6 +1402,10 @@
     "label": "noValueAfterColon",
     "kind": "field",
     "detail": "noValueAfterColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noValueAfterColon",
@@ -1304,6 +1420,10 @@
     "label": "nonCompileTimeConstant",
     "kind": "field",
     "detail": "nonCompileTimeConstant",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonCompileTimeConstant",
@@ -1318,6 +1438,10 @@
     "label": "nonConstantInDecorator",
     "kind": "field",
     "detail": "nonConstantInDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonConstantInDecorator",
@@ -1332,6 +1456,10 @@
     "label": "objectCompletions",
     "kind": "field",
     "detail": "objectCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectCompletions",
@@ -1367,6 +1495,10 @@
     "label": "paramAccessingOutput",
     "kind": "field",
     "detail": "paramAccessingOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingOutput",
@@ -1381,6 +1513,10 @@
     "label": "paramAccessingResource",
     "kind": "field",
     "detail": "paramAccessingResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingResource",
@@ -1395,6 +1531,10 @@
     "label": "paramAccessingVar",
     "kind": "field",
     "detail": "paramAccessingVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingVar",
@@ -1409,6 +1549,10 @@
     "label": "paramDefaultOneCycle",
     "kind": "field",
     "detail": "paramDefaultOneCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultOneCycle",
@@ -1423,6 +1567,10 @@
     "label": "paramDefaultTwoCycle1",
     "kind": "field",
     "detail": "paramDefaultTwoCycle1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle1",
@@ -1437,6 +1585,10 @@
     "label": "paramDefaultTwoCycle2",
     "kind": "field",
     "detail": "paramDefaultTwoCycle2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle2",
@@ -1451,6 +1603,10 @@
     "label": "paramModifierSelfCycle",
     "kind": "field",
     "detail": "paramModifierSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramModifierSelfCycle",
@@ -1465,6 +1621,10 @@
     "label": "partialType",
     "kind": "field",
     "detail": "partialType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_partialType",
@@ -1678,6 +1838,10 @@
     "label": "secureInt",
     "kind": "field",
     "detail": "secureInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureInt",
@@ -1713,6 +1877,10 @@
     "label": "someArray",
     "kind": "field",
     "detail": "someArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someArray",
@@ -1727,6 +1895,10 @@
     "label": "someInteger",
     "kind": "field",
     "detail": "someInteger",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someInteger",
@@ -1741,6 +1913,10 @@
     "label": "someString",
     "kind": "field",
     "detail": "someString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someString",
@@ -2042,6 +2218,10 @@
     "label": "tooManyArguments1",
     "kind": "field",
     "detail": "tooManyArguments1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments1",
@@ -2056,6 +2236,10 @@
     "label": "tooManyArguments2",
     "kind": "field",
     "detail": "tooManyArguments2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments2",
@@ -2070,6 +2254,10 @@
     "label": "trailingSpace",
     "kind": "field",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -2105,6 +2293,10 @@
     "label": "unaryMinusOnFunction",
     "kind": "field",
     "detail": "unaryMinusOnFunction",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unaryMinusOnFunction",
@@ -2245,6 +2437,10 @@
     "label": "wrongAssignmentToken",
     "kind": "field",
     "detail": "wrongAssignmentToken",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongAssignmentToken",
@@ -2259,6 +2455,10 @@
     "label": "wrongDefaultValue",
     "kind": "field",
     "detail": "wrongDefaultValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongDefaultValue",
@@ -2273,6 +2473,10 @@
     "label": "wrongIntModifier",
     "kind": "field",
     "detail": "wrongIntModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongIntModifier",
@@ -2287,6 +2491,10 @@
     "label": "wrongMetadataSchema",
     "kind": "field",
     "detail": "wrongMetadataSchema",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongMetadataSchema",
@@ -2301,6 +2509,10 @@
     "label": "wrongType",
     "kind": "field",
     "detail": "wrongType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongType",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -97,7 +97,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -115,7 +115,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -217,7 +217,7 @@
     "detail": "boolCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -235,7 +235,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'  \n"
+      "value": "Type: 'abc' | 'def'"
     },
     "deprecated": false,
     "preselect": false,
@@ -400,7 +400,7 @@
     "detail": "defaultValueOneLinerCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -435,7 +435,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -474,7 +474,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -492,7 +492,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -548,7 +548,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -587,7 +587,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -724,7 +724,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -805,7 +805,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
     },
     "deprecated": false,
     "preselect": false,
@@ -823,7 +823,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -841,7 +841,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
     },
     "deprecated": false,
     "preselect": false,
@@ -1048,7 +1048,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1066,7 +1066,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1084,7 +1084,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1207,7 +1207,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1225,7 +1225,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1243,7 +1243,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1261,7 +1261,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1279,7 +1279,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1297,7 +1297,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1315,7 +1315,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1333,7 +1333,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1351,7 +1351,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1369,7 +1369,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1404,7 +1404,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1422,7 +1422,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1440,7 +1440,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1458,7 +1458,7 @@
     "detail": "objectCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -1497,7 +1497,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1515,7 +1515,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1533,7 +1533,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1551,7 +1551,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1569,7 +1569,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1587,7 +1587,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1605,7 +1605,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1623,7 +1623,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1840,7 +1840,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1879,7 +1879,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +1897,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1915,7 +1915,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2220,7 +2220,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2238,7 +2238,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2256,7 +2256,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -2295,7 +2295,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2439,7 +2439,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2457,7 +2457,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2475,7 +2475,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2493,7 +2493,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2511,7 +2511,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -3,6 +3,10 @@
     "label": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "kind": "field",
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
@@ -59,6 +63,10 @@
     "label": "arrayCompletions",
     "kind": "field",
     "detail": "arrayCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: array  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayCompletions",
@@ -91,6 +99,10 @@
     "label": "badInterpolatedString",
     "kind": "field",
     "detail": "badInterpolatedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString",
@@ -105,6 +117,10 @@
     "label": "badInterpolatedString2",
     "kind": "field",
     "detail": "badInterpolatedString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString2",
@@ -203,6 +219,10 @@
     "label": "commaOne",
     "kind": "field",
     "detail": "commaOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'abc' | 'def'  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_commaOne",
@@ -364,6 +384,10 @@
     "label": "defaultValueOneLinerCompletions",
     "kind": "field",
     "detail": "defaultValueOneLinerCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultValueOneLinerCompletions",
@@ -395,6 +419,10 @@
     "label": "duplicateDecorators",
     "kind": "field",
     "detail": "duplicateDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_duplicateDecorators",
@@ -430,6 +458,10 @@
     "label": "emptyAllowedInt",
     "kind": "field",
     "detail": "emptyAllowedInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedInt",
@@ -444,6 +476,10 @@
     "label": "emptyAllowedString",
     "kind": "field",
     "detail": "emptyAllowedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedString",
@@ -496,6 +532,10 @@
     "label": "expressionInModifier",
     "kind": "field",
     "detail": "expressionInModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInModifier",
@@ -545,6 +585,10 @@
     "label": "fatalErrorInIssue1713",
     "kind": "field",
     "detail": "fatalErrorInIssue1713",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fatalErrorInIssue1713",
@@ -678,6 +722,10 @@
     "label": "incompleteDecorators",
     "kind": "field",
     "detail": "incompleteDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incompleteDecorators",
@@ -755,6 +803,10 @@
     "label": "invalidDefaultWithAllowedArrayDecorator",
     "kind": "field",
     "detail": "invalidDefaultWithAllowedArrayDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDefaultWithAllowedArrayDecorator",
@@ -769,6 +821,10 @@
     "label": "invalidLength",
     "kind": "field",
     "detail": "invalidLength",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLength",
@@ -783,6 +839,10 @@
     "label": "invalidPermutation",
     "kind": "field",
     "detail": "invalidPermutation",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPermutation",
@@ -986,6 +1046,10 @@
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedModifier",
@@ -1000,6 +1064,10 @@
     "label": "malformedType",
     "kind": "field",
     "detail": "malformedType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType",
@@ -1014,6 +1082,10 @@
     "label": "malformedType2",
     "kind": "field",
     "detail": "malformedType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType2",
@@ -1133,6 +1205,10 @@
     "label": "missingType",
     "kind": "field",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -1147,6 +1223,10 @@
     "label": "missingTypeWithSpaceAfter",
     "kind": "field",
     "detail": "missingTypeWithSpaceAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithSpaceAfter",
@@ -1161,6 +1241,10 @@
     "label": "missingTypeWithTabAfter",
     "kind": "field",
     "detail": "missingTypeWithTabAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithTabAfter",
@@ -1175,6 +1259,10 @@
     "label": "myBool",
     "kind": "field",
     "detail": "myBool",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBool",
@@ -1189,6 +1277,10 @@
     "label": "myFalsehood",
     "kind": "field",
     "detail": "myFalsehood",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFalsehood",
@@ -1203,6 +1295,10 @@
     "label": "myInt",
     "kind": "field",
     "detail": "myInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt",
@@ -1217,6 +1313,10 @@
     "label": "myInt2",
     "kind": "field",
     "detail": "myInt2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt2",
@@ -1231,6 +1331,10 @@
     "label": "myString",
     "kind": "field",
     "detail": "myString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString",
@@ -1245,6 +1349,10 @@
     "label": "myString2",
     "kind": "field",
     "detail": "myString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString2",
@@ -1259,6 +1367,10 @@
     "label": "myTruth",
     "kind": "field",
     "detail": "myTruth",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myTruth",
@@ -1290,6 +1402,10 @@
     "label": "noValueAfterColon",
     "kind": "field",
     "detail": "noValueAfterColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noValueAfterColon",
@@ -1304,6 +1420,10 @@
     "label": "nonCompileTimeConstant",
     "kind": "field",
     "detail": "nonCompileTimeConstant",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonCompileTimeConstant",
@@ -1318,6 +1438,10 @@
     "label": "nonConstantInDecorator",
     "kind": "field",
     "detail": "nonConstantInDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonConstantInDecorator",
@@ -1332,6 +1456,10 @@
     "label": "objectCompletions",
     "kind": "field",
     "detail": "objectCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectCompletions",
@@ -1367,6 +1495,10 @@
     "label": "paramAccessingOutput",
     "kind": "field",
     "detail": "paramAccessingOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingOutput",
@@ -1381,6 +1513,10 @@
     "label": "paramAccessingResource",
     "kind": "field",
     "detail": "paramAccessingResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingResource",
@@ -1395,6 +1531,10 @@
     "label": "paramAccessingVar",
     "kind": "field",
     "detail": "paramAccessingVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingVar",
@@ -1409,6 +1549,10 @@
     "label": "paramDefaultOneCycle",
     "kind": "field",
     "detail": "paramDefaultOneCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultOneCycle",
@@ -1423,6 +1567,10 @@
     "label": "paramDefaultTwoCycle1",
     "kind": "field",
     "detail": "paramDefaultTwoCycle1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle1",
@@ -1437,6 +1585,10 @@
     "label": "paramDefaultTwoCycle2",
     "kind": "field",
     "detail": "paramDefaultTwoCycle2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle2",
@@ -1451,6 +1603,10 @@
     "label": "paramModifierSelfCycle",
     "kind": "field",
     "detail": "paramModifierSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramModifierSelfCycle",
@@ -1465,6 +1621,10 @@
     "label": "partialType",
     "kind": "field",
     "detail": "partialType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_partialType",
@@ -1678,6 +1838,10 @@
     "label": "secureInt",
     "kind": "field",
     "detail": "secureInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureInt",
@@ -1713,6 +1877,10 @@
     "label": "someArray",
     "kind": "field",
     "detail": "someArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someArray",
@@ -1727,6 +1895,10 @@
     "label": "someInteger",
     "kind": "field",
     "detail": "someInteger",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someInteger",
@@ -1741,6 +1913,10 @@
     "label": "someString",
     "kind": "field",
     "detail": "someString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someString",
@@ -2042,6 +2218,10 @@
     "label": "tooManyArguments1",
     "kind": "field",
     "detail": "tooManyArguments1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments1",
@@ -2056,6 +2236,10 @@
     "label": "tooManyArguments2",
     "kind": "field",
     "detail": "tooManyArguments2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments2",
@@ -2070,6 +2254,10 @@
     "label": "trailingSpace",
     "kind": "field",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -2119,6 +2307,10 @@
     "label": "unaryMinusOnFunction",
     "kind": "field",
     "detail": "unaryMinusOnFunction",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unaryMinusOnFunction",
@@ -2259,6 +2451,10 @@
     "label": "wrongAssignmentToken",
     "kind": "field",
     "detail": "wrongAssignmentToken",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongAssignmentToken",
@@ -2273,6 +2469,10 @@
     "label": "wrongDefaultValue",
     "kind": "field",
     "detail": "wrongDefaultValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongDefaultValue",
@@ -2287,6 +2487,10 @@
     "label": "wrongIntModifier",
     "kind": "field",
     "detail": "wrongIntModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongIntModifier",
@@ -2301,6 +2505,10 @@
     "label": "wrongMetadataSchema",
     "kind": "field",
     "detail": "wrongMetadataSchema",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongMetadataSchema",
@@ -2315,6 +2523,10 @@
     "label": "wrongType",
     "kind": "field",
     "detail": "wrongType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongType",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -65,7 +65,7 @@
     "detail": "arrayCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: array  \n"
+      "value": "Type: array"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -119,7 +119,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -221,7 +221,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'  \n"
+      "value": "Type: 'abc' | 'def'"
     },
     "deprecated": false,
     "preselect": false,
@@ -386,7 +386,7 @@
     "detail": "defaultValueOneLinerCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -421,7 +421,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -460,7 +460,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -478,7 +478,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -534,7 +534,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -587,7 +587,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -724,7 +724,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -805,7 +805,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
     },
     "deprecated": false,
     "preselect": false,
@@ -823,7 +823,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -841,7 +841,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
     },
     "deprecated": false,
     "preselect": false,
@@ -1048,7 +1048,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1066,7 +1066,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1084,7 +1084,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1207,7 +1207,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1225,7 +1225,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1243,7 +1243,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1261,7 +1261,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1279,7 +1279,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1297,7 +1297,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1315,7 +1315,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1333,7 +1333,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1351,7 +1351,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1369,7 +1369,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1404,7 +1404,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1422,7 +1422,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1440,7 +1440,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1458,7 +1458,7 @@
     "detail": "objectCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -1497,7 +1497,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1515,7 +1515,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1533,7 +1533,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1551,7 +1551,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1569,7 +1569,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1587,7 +1587,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1605,7 +1605,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1623,7 +1623,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1840,7 +1840,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1879,7 +1879,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1897,7 +1897,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1915,7 +1915,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2220,7 +2220,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2238,7 +2238,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2256,7 +2256,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -2309,7 +2309,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2453,7 +2453,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2471,7 +2471,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2489,7 +2489,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2507,7 +2507,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2525,7 +2525,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -3,6 +3,10 @@
     "label": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "kind": "field",
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
@@ -59,6 +63,10 @@
     "label": "arrayCompletions",
     "kind": "field",
     "detail": "arrayCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: array  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayCompletions",
@@ -91,6 +99,10 @@
     "label": "badInterpolatedString",
     "kind": "field",
     "detail": "badInterpolatedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString",
@@ -105,6 +117,10 @@
     "label": "badInterpolatedString2",
     "kind": "field",
     "detail": "badInterpolatedString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString2",
@@ -203,6 +219,10 @@
     "label": "boolCompletions",
     "kind": "field",
     "detail": "boolCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_boolCompletions",
@@ -217,6 +237,10 @@
     "label": "commaOne",
     "kind": "field",
     "detail": "commaOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'abc' | 'def'  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_commaOne",
@@ -395,6 +419,10 @@
     "label": "duplicateDecorators",
     "kind": "field",
     "detail": "duplicateDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_duplicateDecorators",
@@ -430,6 +458,10 @@
     "label": "emptyAllowedInt",
     "kind": "field",
     "detail": "emptyAllowedInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedInt",
@@ -444,6 +476,10 @@
     "label": "emptyAllowedString",
     "kind": "field",
     "detail": "emptyAllowedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedString",
@@ -496,6 +532,10 @@
     "label": "expressionInModifier",
     "kind": "field",
     "detail": "expressionInModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInModifier",
@@ -531,6 +571,10 @@
     "label": "fatalErrorInIssue1713",
     "kind": "field",
     "detail": "fatalErrorInIssue1713",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fatalErrorInIssue1713",
@@ -664,6 +708,10 @@
     "label": "incompleteDecorators",
     "kind": "field",
     "detail": "incompleteDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incompleteDecorators",
@@ -741,6 +789,10 @@
     "label": "invalidDefaultWithAllowedArrayDecorator",
     "kind": "field",
     "detail": "invalidDefaultWithAllowedArrayDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDefaultWithAllowedArrayDecorator",
@@ -755,6 +807,10 @@
     "label": "invalidLength",
     "kind": "field",
     "detail": "invalidLength",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLength",
@@ -769,6 +825,10 @@
     "label": "invalidPermutation",
     "kind": "field",
     "detail": "invalidPermutation",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPermutation",
@@ -972,6 +1032,10 @@
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedModifier",
@@ -986,6 +1050,10 @@
     "label": "malformedType",
     "kind": "field",
     "detail": "malformedType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType",
@@ -1000,6 +1068,10 @@
     "label": "malformedType2",
     "kind": "field",
     "detail": "malformedType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType2",
@@ -1119,6 +1191,10 @@
     "label": "missingType",
     "kind": "field",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -1133,6 +1209,10 @@
     "label": "missingTypeWithSpaceAfter",
     "kind": "field",
     "detail": "missingTypeWithSpaceAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithSpaceAfter",
@@ -1147,6 +1227,10 @@
     "label": "missingTypeWithTabAfter",
     "kind": "field",
     "detail": "missingTypeWithTabAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithTabAfter",
@@ -1161,6 +1245,10 @@
     "label": "myBool",
     "kind": "field",
     "detail": "myBool",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBool",
@@ -1175,6 +1263,10 @@
     "label": "myFalsehood",
     "kind": "field",
     "detail": "myFalsehood",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFalsehood",
@@ -1189,6 +1281,10 @@
     "label": "myInt",
     "kind": "field",
     "detail": "myInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt",
@@ -1203,6 +1299,10 @@
     "label": "myInt2",
     "kind": "field",
     "detail": "myInt2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt2",
@@ -1217,6 +1317,10 @@
     "label": "myString",
     "kind": "field",
     "detail": "myString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString",
@@ -1231,6 +1335,10 @@
     "label": "myString2",
     "kind": "field",
     "detail": "myString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString2",
@@ -1245,6 +1353,10 @@
     "label": "myTruth",
     "kind": "field",
     "detail": "myTruth",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myTruth",
@@ -1276,6 +1388,10 @@
     "label": "noValueAfterColon",
     "kind": "field",
     "detail": "noValueAfterColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noValueAfterColon",
@@ -1290,6 +1406,10 @@
     "label": "nonCompileTimeConstant",
     "kind": "field",
     "detail": "nonCompileTimeConstant",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonCompileTimeConstant",
@@ -1304,6 +1424,10 @@
     "label": "nonConstantInDecorator",
     "kind": "field",
     "detail": "nonConstantInDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonConstantInDecorator",
@@ -1318,6 +1442,10 @@
     "label": "objectCompletions",
     "kind": "field",
     "detail": "objectCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objectCompletions",
@@ -1353,6 +1481,10 @@
     "label": "paramAccessingOutput",
     "kind": "field",
     "detail": "paramAccessingOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingOutput",
@@ -1367,6 +1499,10 @@
     "label": "paramAccessingResource",
     "kind": "field",
     "detail": "paramAccessingResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingResource",
@@ -1381,6 +1517,10 @@
     "label": "paramAccessingVar",
     "kind": "field",
     "detail": "paramAccessingVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingVar",
@@ -1395,6 +1535,10 @@
     "label": "paramDefaultOneCycle",
     "kind": "field",
     "detail": "paramDefaultOneCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultOneCycle",
@@ -1409,6 +1553,10 @@
     "label": "paramDefaultTwoCycle1",
     "kind": "field",
     "detail": "paramDefaultTwoCycle1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle1",
@@ -1423,6 +1571,10 @@
     "label": "paramDefaultTwoCycle2",
     "kind": "field",
     "detail": "paramDefaultTwoCycle2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle2",
@@ -1437,6 +1589,10 @@
     "label": "paramModifierSelfCycle",
     "kind": "field",
     "detail": "paramModifierSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramModifierSelfCycle",
@@ -1451,6 +1607,10 @@
     "label": "partialType",
     "kind": "field",
     "detail": "partialType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_partialType",
@@ -1664,6 +1824,10 @@
     "label": "secureInt",
     "kind": "field",
     "detail": "secureInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureInt",
@@ -1699,6 +1863,10 @@
     "label": "someArray",
     "kind": "field",
     "detail": "someArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someArray",
@@ -1713,6 +1881,10 @@
     "label": "someInteger",
     "kind": "field",
     "detail": "someInteger",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someInteger",
@@ -1727,6 +1899,10 @@
     "label": "someString",
     "kind": "field",
     "detail": "someString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someString",
@@ -2028,6 +2204,10 @@
     "label": "tooManyArguments1",
     "kind": "field",
     "detail": "tooManyArguments1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments1",
@@ -2042,6 +2222,10 @@
     "label": "tooManyArguments2",
     "kind": "field",
     "detail": "tooManyArguments2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments2",
@@ -2056,6 +2240,10 @@
     "label": "trailingSpace",
     "kind": "field",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -2091,6 +2279,10 @@
     "label": "unaryMinusOnFunction",
     "kind": "field",
     "detail": "unaryMinusOnFunction",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unaryMinusOnFunction",
@@ -2231,6 +2423,10 @@
     "label": "wrongAssignmentToken",
     "kind": "field",
     "detail": "wrongAssignmentToken",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongAssignmentToken",
@@ -2245,6 +2441,10 @@
     "label": "wrongDefaultValue",
     "kind": "field",
     "detail": "wrongDefaultValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongDefaultValue",
@@ -2259,6 +2459,10 @@
     "label": "wrongIntModifier",
     "kind": "field",
     "detail": "wrongIntModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongIntModifier",
@@ -2273,6 +2477,10 @@
     "label": "wrongMetadataSchema",
     "kind": "field",
     "detail": "wrongMetadataSchema",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongMetadataSchema",
@@ -2287,6 +2495,10 @@
     "label": "wrongType",
     "kind": "field",
     "detail": "wrongType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongType",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/justSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -65,7 +65,7 @@
     "detail": "arrayCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: array  \n"
+      "value": "Type: array"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -119,7 +119,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -221,7 +221,7 @@
     "detail": "boolCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -239,7 +239,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'  \n"
+      "value": "Type: 'abc' | 'def'"
     },
     "deprecated": false,
     "preselect": false,
@@ -421,7 +421,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -460,7 +460,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -478,7 +478,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -534,7 +534,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -573,7 +573,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -710,7 +710,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -791,7 +791,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
     },
     "deprecated": false,
     "preselect": false,
@@ -809,7 +809,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -827,7 +827,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
     },
     "deprecated": false,
     "preselect": false,
@@ -1034,7 +1034,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1052,7 +1052,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1070,7 +1070,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1193,7 +1193,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1211,7 +1211,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1229,7 +1229,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1247,7 +1247,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1265,7 +1265,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1283,7 +1283,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1301,7 +1301,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1319,7 +1319,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1337,7 +1337,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1355,7 +1355,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1390,7 +1390,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1408,7 +1408,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1426,7 +1426,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1444,7 +1444,7 @@
     "detail": "objectCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -1483,7 +1483,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1501,7 +1501,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1519,7 +1519,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1537,7 +1537,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1555,7 +1555,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1573,7 +1573,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1591,7 +1591,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1609,7 +1609,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1826,7 +1826,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1865,7 +1865,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1883,7 +1883,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1901,7 +1901,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2206,7 +2206,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2224,7 +2224,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2242,7 +2242,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -2281,7 +2281,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2425,7 +2425,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2443,7 +2443,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2461,7 +2461,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2479,7 +2479,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2497,7 +2497,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -3,6 +3,10 @@
     "label": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "kind": "field",
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
@@ -59,6 +63,10 @@
     "label": "arrayCompletions",
     "kind": "field",
     "detail": "arrayCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: array  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_arrayCompletions",
@@ -91,6 +99,10 @@
     "label": "badInterpolatedString",
     "kind": "field",
     "detail": "badInterpolatedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString",
@@ -105,6 +117,10 @@
     "label": "badInterpolatedString2",
     "kind": "field",
     "detail": "badInterpolatedString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_badInterpolatedString2",
@@ -203,6 +219,10 @@
     "label": "boolCompletions",
     "kind": "field",
     "detail": "boolCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_boolCompletions",
@@ -217,6 +237,10 @@
     "label": "commaOne",
     "kind": "field",
     "detail": "commaOne",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'abc' | 'def'  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_commaOne",
@@ -378,6 +402,10 @@
     "label": "defaultValueOneLinerCompletions",
     "kind": "field",
     "detail": "defaultValueOneLinerCompletions",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_defaultValueOneLinerCompletions",
@@ -409,6 +437,10 @@
     "label": "duplicateDecorators",
     "kind": "field",
     "detail": "duplicateDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_duplicateDecorators",
@@ -444,6 +476,10 @@
     "label": "emptyAllowedInt",
     "kind": "field",
     "detail": "emptyAllowedInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedInt",
@@ -458,6 +494,10 @@
     "label": "emptyAllowedString",
     "kind": "field",
     "detail": "emptyAllowedString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_emptyAllowedString",
@@ -510,6 +550,10 @@
     "label": "expressionInModifier",
     "kind": "field",
     "detail": "expressionInModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_expressionInModifier",
@@ -545,6 +589,10 @@
     "label": "fatalErrorInIssue1713",
     "kind": "field",
     "detail": "fatalErrorInIssue1713",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_fatalErrorInIssue1713",
@@ -678,6 +726,10 @@
     "label": "incompleteDecorators",
     "kind": "field",
     "detail": "incompleteDecorators",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_incompleteDecorators",
@@ -755,6 +807,10 @@
     "label": "invalidDefaultWithAllowedArrayDecorator",
     "kind": "field",
     "detail": "invalidDefaultWithAllowedArrayDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidDefaultWithAllowedArrayDecorator",
@@ -769,6 +825,10 @@
     "label": "invalidLength",
     "kind": "field",
     "detail": "invalidLength",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidLength",
@@ -783,6 +843,10 @@
     "label": "invalidPermutation",
     "kind": "field",
     "detail": "invalidPermutation",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_invalidPermutation",
@@ -986,6 +1050,10 @@
     "label": "malformedModifier",
     "kind": "field",
     "detail": "malformedModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedModifier",
@@ -1000,6 +1068,10 @@
     "label": "malformedType",
     "kind": "field",
     "detail": "malformedType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType",
@@ -1014,6 +1086,10 @@
     "label": "malformedType2",
     "kind": "field",
     "detail": "malformedType2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_malformedType2",
@@ -1133,6 +1209,10 @@
     "label": "missingType",
     "kind": "field",
     "detail": "missingType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingType",
@@ -1147,6 +1227,10 @@
     "label": "missingTypeWithSpaceAfter",
     "kind": "field",
     "detail": "missingTypeWithSpaceAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithSpaceAfter",
@@ -1161,6 +1245,10 @@
     "label": "missingTypeWithTabAfter",
     "kind": "field",
     "detail": "missingTypeWithTabAfter",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_missingTypeWithTabAfter",
@@ -1175,6 +1263,10 @@
     "label": "myBool",
     "kind": "field",
     "detail": "myBool",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myBool",
@@ -1189,6 +1281,10 @@
     "label": "myFalsehood",
     "kind": "field",
     "detail": "myFalsehood",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myFalsehood",
@@ -1203,6 +1299,10 @@
     "label": "myInt",
     "kind": "field",
     "detail": "myInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt",
@@ -1217,6 +1317,10 @@
     "label": "myInt2",
     "kind": "field",
     "detail": "myInt2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt2",
@@ -1231,6 +1335,10 @@
     "label": "myString",
     "kind": "field",
     "detail": "myString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString",
@@ -1245,6 +1353,10 @@
     "label": "myString2",
     "kind": "field",
     "detail": "myString2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myString2",
@@ -1259,6 +1371,10 @@
     "label": "myTruth",
     "kind": "field",
     "detail": "myTruth",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myTruth",
@@ -1290,6 +1406,10 @@
     "label": "noValueAfterColon",
     "kind": "field",
     "detail": "noValueAfterColon",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_noValueAfterColon",
@@ -1304,6 +1424,10 @@
     "label": "nonCompileTimeConstant",
     "kind": "field",
     "detail": "nonCompileTimeConstant",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonCompileTimeConstant",
@@ -1318,6 +1442,10 @@
     "label": "nonConstantInDecorator",
     "kind": "field",
     "detail": "nonConstantInDecorator",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_nonConstantInDecorator",
@@ -1353,6 +1481,10 @@
     "label": "paramAccessingOutput",
     "kind": "field",
     "detail": "paramAccessingOutput",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingOutput",
@@ -1367,6 +1499,10 @@
     "label": "paramAccessingResource",
     "kind": "field",
     "detail": "paramAccessingResource",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingResource",
@@ -1381,6 +1517,10 @@
     "label": "paramAccessingVar",
     "kind": "field",
     "detail": "paramAccessingVar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramAccessingVar",
@@ -1395,6 +1535,10 @@
     "label": "paramDefaultOneCycle",
     "kind": "field",
     "detail": "paramDefaultOneCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultOneCycle",
@@ -1409,6 +1553,10 @@
     "label": "paramDefaultTwoCycle1",
     "kind": "field",
     "detail": "paramDefaultTwoCycle1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle1",
@@ -1423,6 +1571,10 @@
     "label": "paramDefaultTwoCycle2",
     "kind": "field",
     "detail": "paramDefaultTwoCycle2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramDefaultTwoCycle2",
@@ -1437,6 +1589,10 @@
     "label": "paramModifierSelfCycle",
     "kind": "field",
     "detail": "paramModifierSelfCycle",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_paramModifierSelfCycle",
@@ -1451,6 +1607,10 @@
     "label": "partialType",
     "kind": "field",
     "detail": "partialType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_partialType",
@@ -1664,6 +1824,10 @@
     "label": "secureInt",
     "kind": "field",
     "detail": "secureInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_secureInt",
@@ -1699,6 +1863,10 @@
     "label": "someArray",
     "kind": "field",
     "detail": "someArray",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someArray",
@@ -1713,6 +1881,10 @@
     "label": "someInteger",
     "kind": "field",
     "detail": "someInteger",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someInteger",
@@ -1727,6 +1899,10 @@
     "label": "someString",
     "kind": "field",
     "detail": "someString",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_someString",
@@ -2028,6 +2204,10 @@
     "label": "tooManyArguments1",
     "kind": "field",
     "detail": "tooManyArguments1",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments1",
@@ -2042,6 +2222,10 @@
     "label": "tooManyArguments2",
     "kind": "field",
     "detail": "tooManyArguments2",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tooManyArguments2",
@@ -2056,6 +2240,10 @@
     "label": "trailingSpace",
     "kind": "field",
     "detail": "trailingSpace",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: any  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_trailingSpace",
@@ -2091,6 +2279,10 @@
     "label": "unaryMinusOnFunction",
     "kind": "field",
     "detail": "unaryMinusOnFunction",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_unaryMinusOnFunction",
@@ -2231,6 +2423,10 @@
     "label": "wrongAssignmentToken",
     "kind": "field",
     "detail": "wrongAssignmentToken",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongAssignmentToken",
@@ -2245,6 +2441,10 @@
     "label": "wrongDefaultValue",
     "kind": "field",
     "detail": "wrongDefaultValue",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongDefaultValue",
@@ -2259,6 +2459,10 @@
     "label": "wrongIntModifier",
     "kind": "field",
     "detail": "wrongIntModifier",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: int  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongIntModifier",
@@ -2273,6 +2477,10 @@
     "label": "wrongMetadataSchema",
     "kind": "field",
     "detail": "wrongMetadataSchema",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongMetadataSchema",
@@ -2287,6 +2495,10 @@
     "label": "wrongType",
     "kind": "field",
     "detail": "wrongType",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: error  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_wrongType",

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -5,7 +5,7 @@
     "detail": "WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -65,7 +65,7 @@
     "detail": "arrayCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: array  \n"
+      "value": "Type: array"
     },
     "deprecated": false,
     "preselect": false,
@@ -101,7 +101,7 @@
     "detail": "badInterpolatedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -119,7 +119,7 @@
     "detail": "badInterpolatedString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -221,7 +221,7 @@
     "detail": "boolCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -239,7 +239,7 @@
     "detail": "commaOne",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: 'abc' | 'def'  \n"
+      "value": "Type: 'abc' | 'def'"
     },
     "deprecated": false,
     "preselect": false,
@@ -404,7 +404,7 @@
     "detail": "defaultValueOneLinerCompletions",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -439,7 +439,7 @@
     "detail": "duplicateDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -478,7 +478,7 @@
     "detail": "emptyAllowedInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -496,7 +496,7 @@
     "detail": "emptyAllowedString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -552,7 +552,7 @@
     "detail": "expressionInModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -591,7 +591,7 @@
     "detail": "fatalErrorInIssue1713",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -728,7 +728,7 @@
     "detail": "incompleteDecorators",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -809,7 +809,7 @@
     "detail": "invalidDefaultWithAllowedArrayDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']  \n"
+      "value": "Type: ['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']"
     },
     "deprecated": false,
     "preselect": false,
@@ -827,7 +827,7 @@
     "detail": "invalidLength",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -845,7 +845,7 @@
     "detail": "invalidPermutation",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]  \n"
+      "value": "Type: ('Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways')[]"
     },
     "deprecated": false,
     "preselect": false,
@@ -1052,7 +1052,7 @@
     "detail": "malformedModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1070,7 +1070,7 @@
     "detail": "malformedType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1088,7 +1088,7 @@
     "detail": "malformedType2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1211,7 +1211,7 @@
     "detail": "missingType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1229,7 +1229,7 @@
     "detail": "missingTypeWithSpaceAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1247,7 +1247,7 @@
     "detail": "missingTypeWithTabAfter",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -1265,7 +1265,7 @@
     "detail": "myBool",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1283,7 +1283,7 @@
     "detail": "myFalsehood",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1301,7 +1301,7 @@
     "detail": "myInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1319,7 +1319,7 @@
     "detail": "myInt2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1337,7 +1337,7 @@
     "detail": "myString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1355,7 +1355,7 @@
     "detail": "myString2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1373,7 +1373,7 @@
     "detail": "myTruth",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1408,7 +1408,7 @@
     "detail": "noValueAfterColon",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1426,7 +1426,7 @@
     "detail": "nonCompileTimeConstant",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1444,7 +1444,7 @@
     "detail": "nonConstantInDecorator",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1483,7 +1483,7 @@
     "detail": "paramAccessingOutput",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1501,7 +1501,7 @@
     "detail": "paramAccessingResource",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1519,7 +1519,7 @@
     "detail": "paramAccessingVar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1537,7 +1537,7 @@
     "detail": "paramDefaultOneCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1555,7 +1555,7 @@
     "detail": "paramDefaultTwoCycle1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1573,7 +1573,7 @@
     "detail": "paramDefaultTwoCycle2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1591,7 +1591,7 @@
     "detail": "paramModifierSelfCycle",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -1609,7 +1609,7 @@
     "detail": "partialType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1826,7 +1826,7 @@
     "detail": "secureInt",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1865,7 +1865,7 @@
     "detail": "someArray",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,
@@ -1883,7 +1883,7 @@
     "detail": "someInteger",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -1901,7 +1901,7 @@
     "detail": "someString",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2206,7 +2206,7 @@
     "detail": "tooManyArguments1",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2224,7 +2224,7 @@
     "detail": "tooManyArguments2",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2242,7 +2242,7 @@
     "detail": "trailingSpace",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: any  \n"
+      "value": "Type: any"
     },
     "deprecated": false,
     "preselect": false,
@@ -2281,7 +2281,7 @@
     "detail": "unaryMinusOnFunction",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2425,7 +2425,7 @@
     "detail": "wrongAssignmentToken",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2443,7 +2443,7 @@
     "detail": "wrongDefaultValue",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2461,7 +2461,7 @@
     "detail": "wrongIntModifier",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: int  \n"
+      "value": "Type: int"
     },
     "deprecated": false,
     "preselect": false,
@@ -2479,7 +2479,7 @@
     "detail": "wrongMetadataSchema",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -2497,7 +2497,7 @@
     "detail": "wrongType",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: error  \n"
+      "value": "Type: error"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2839,6 +2843,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2853,6 +2861,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2884,6 +2896,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4771,6 +4787,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5672,6 +5692,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4789,7 +4789,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5694,7 +5694,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -667,7 +667,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4753,7 +4753,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5658,7 +5658,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -665,6 +665,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2803,6 +2807,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2817,6 +2825,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2848,6 +2860,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4735,6 +4751,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5636,6 +5656,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -724,6 +724,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2831,6 +2835,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2845,6 +2853,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2876,6 +2888,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4763,6 +4779,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5664,6 +5684,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -726,7 +726,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4781,7 +4781,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5686,7 +5686,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -952,6 +952,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3062,6 +3066,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3076,6 +3084,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3107,6 +3119,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4994,6 +5010,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5895,6 +5915,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -954,7 +954,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5012,7 +5012,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5917,7 +5917,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -952,6 +952,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3062,6 +3066,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3076,6 +3084,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3107,6 +3119,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4994,6 +5010,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5895,6 +5915,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -954,7 +954,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5012,7 +5012,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5917,7 +5917,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -952,6 +952,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3062,6 +3066,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3076,6 +3084,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3107,6 +3119,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4994,6 +5010,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5895,6 +5915,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -954,7 +954,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5012,7 +5012,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5917,7 +5917,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -952,6 +952,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3062,6 +3066,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3076,6 +3084,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3107,6 +3119,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4994,6 +5010,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5895,6 +5915,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -954,7 +954,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5012,7 +5012,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5917,7 +5917,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2824,6 +2828,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2838,6 +2846,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2869,6 +2881,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2824,6 +2828,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2838,6 +2846,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2869,6 +2881,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2824,6 +2828,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2838,6 +2846,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2869,6 +2881,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2824,6 +2828,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2838,6 +2846,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2869,6 +2881,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -1188,7 +1188,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5246,7 +5246,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -6151,7 +6151,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -1186,6 +1186,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3310,6 +3314,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3324,6 +3332,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3355,6 +3367,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -5228,6 +5244,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -6129,6 +6149,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -1188,7 +1188,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5246,7 +5246,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -6151,7 +6151,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -1186,6 +1186,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3310,6 +3314,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3324,6 +3332,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3355,6 +3367,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -5228,6 +5244,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -6129,6 +6149,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -1188,7 +1188,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5246,7 +5246,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -6151,7 +6151,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -1186,6 +1186,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3310,6 +3314,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3324,6 +3332,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3355,6 +3367,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -5228,6 +5244,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -6129,6 +6149,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -1188,7 +1188,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -5246,7 +5246,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -6151,7 +6151,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -1186,6 +1186,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -3310,6 +3314,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -3324,6 +3332,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -3355,6 +3367,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -5228,6 +5244,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -6129,6 +6149,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -710,6 +710,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2817,6 +2821,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2831,6 +2839,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2862,6 +2874,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4749,6 +4765,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5650,6 +5670,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -712,7 +712,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4767,7 +4767,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5672,7 +5672,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -710,6 +710,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2817,6 +2821,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2831,6 +2839,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2862,6 +2874,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4749,6 +4765,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5650,6 +5670,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -712,7 +712,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4767,7 +4767,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5672,7 +5672,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -710,6 +710,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2817,6 +2821,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2831,6 +2839,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2862,6 +2874,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4749,6 +4765,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5650,6 +5670,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -712,7 +712,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4767,7 +4767,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5672,7 +5672,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -710,6 +710,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2817,6 +2821,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2831,6 +2839,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2862,6 +2874,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4749,6 +4765,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5650,6 +5670,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -712,7 +712,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4767,7 +4767,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5672,7 +5672,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2810,6 +2814,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2824,6 +2832,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2855,6 +2867,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2810,6 +2814,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2824,6 +2832,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2855,6 +2867,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2810,6 +2814,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2824,6 +2832,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2855,6 +2867,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -702,7 +702,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4760,7 +4760,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5665,7 +5665,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -700,6 +700,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2810,6 +2814,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2824,6 +2832,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2855,6 +2867,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4742,6 +4758,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5643,6 +5663,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -682,6 +682,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2789,6 +2793,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2803,6 +2811,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2834,6 +2846,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4721,6 +4737,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5622,6 +5642,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -684,7 +684,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4739,7 +4739,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5644,7 +5644,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -684,7 +684,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4769,7 +4769,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5674,7 +5674,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -682,6 +682,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2789,6 +2793,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2803,6 +2811,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2834,6 +2846,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4751,6 +4767,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5652,6 +5672,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -810,7 +810,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4865,7 +4865,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5770,7 +5770,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -808,6 +808,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2932,6 +2936,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2946,6 +2954,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2977,6 +2989,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4847,6 +4863,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5748,6 +5768,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -682,6 +682,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2806,6 +2810,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2820,6 +2828,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2851,6 +2863,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4738,6 +4754,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5639,6 +5659,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbols.json
@@ -684,7 +684,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4756,7 +4756,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5661,7 +5661,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4753,7 +4753,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5658,7 +5658,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2820,6 +2824,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2834,6 +2842,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2865,6 +2877,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4735,6 +4751,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5636,6 +5656,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4753,7 +4753,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5658,7 +5658,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2820,6 +2824,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2834,6 +2842,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2865,6 +2877,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4735,6 +4751,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5636,6 +5656,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2820,6 +2824,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2834,6 +2842,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2865,6 +2877,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4752,6 +4768,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5681,6 +5701,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4770,7 +4770,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5703,7 +5703,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4820,7 +4820,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5725,7 +5725,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2856,6 +2860,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2870,6 +2878,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2901,6 +2913,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4802,6 +4818,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5703,6 +5723,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4784,7 +4784,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5689,7 +5689,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2820,6 +2824,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2834,6 +2842,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2865,6 +2877,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4766,6 +4782,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5667,6 +5687,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -698,7 +698,7 @@
     "detail": "dataCollectionRule",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,
@@ -4770,7 +4770,7 @@
     "detail": "resrefpar",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: string  \n"
+      "value": "Type: string"
     },
     "deprecated": false,
     "preselect": false,
@@ -5689,7 +5689,7 @@
     "detail": "tags",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: object  \n"
+      "value": "Type: object"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -696,6 +696,10 @@
     "label": "dataCollectionRule",
     "kind": "field",
     "detail": "dataCollectionRule",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_dataCollectionRule",
@@ -2820,6 +2824,10 @@
     "label": "issue4668_identity",
     "kind": "field",
     "detail": "issue4668_identity",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe identity that will be used to execute the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_identity",
@@ -2834,6 +2842,10 @@
     "label": "issue4668_kind",
     "kind": "field",
     "detail": "issue4668_kind",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: 'AzureCLI' | 'AzurePowerShell'  \nThe language of the Deployment Script. AzurePowerShell or AzureCLI."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_kind",
@@ -2865,6 +2877,10 @@
     "label": "issue4668_properties",
     "kind": "field",
     "detail": "issue4668_properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \nThe properties of the Deployment Script."
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_issue4668_properties",
@@ -4752,6 +4768,10 @@
     "label": "resrefpar",
     "kind": "field",
     "detail": "resrefpar",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: string  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_resrefpar",
@@ -5667,6 +5687,10 @@
     "label": "tags",
     "kind": "field",
     "detail": "tags",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: object  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_tags",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -783,6 +783,10 @@
     "label": "equals",
     "kind": "field",
     "detail": "equals",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_equals",
@@ -1638,6 +1642,10 @@
     "label": "mod",
     "kind": "field",
     "detail": "mod",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_mod",
@@ -1890,6 +1898,10 @@
     "label": "myInt",
     "kind": "variable",
     "detail": "myInt",
+    "documentation": {
+      "kind": "markdown",
+      "value": "an int variable"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myInt",
@@ -1918,6 +1930,10 @@
     "label": "myObj",
     "kind": "variable",
     "detail": "myObj",
+    "documentation": {
+      "kind": "markdown",
+      "value": "a object variable"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myObj",
@@ -1946,6 +1962,10 @@
     "label": "myStr",
     "kind": "variable",
     "detail": "myStr",
+    "documentation": {
+      "kind": "markdown",
+      "value": "a string variable"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myStr",
@@ -1960,6 +1980,10 @@
     "label": "myTruth",
     "kind": "variable",
     "detail": "myTruth",
+    "documentation": {
+      "kind": "markdown",
+      "value": "a bool variable"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_myTruth",
@@ -2086,6 +2110,10 @@
     "label": "objWithInterp",
     "kind": "variable",
     "detail": "objWithInterp",
+    "documentation": {
+      "kind": "markdown",
+      "value": "a object with interp"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_objWithInterp",
@@ -2135,6 +2163,10 @@
     "label": "parameters",
     "kind": "field",
     "detail": "parameters",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: bool  \n"
+    },
     "deprecated": false,
     "preselect": false,
     "sortText": "2_parameters",

--- a/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/Variables_LF/Completions/symbolsPlusTypes.json
@@ -785,7 +785,7 @@
     "detail": "equals",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -1644,7 +1644,7 @@
     "detail": "mod",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,
@@ -2165,7 +2165,7 @@
     "detail": "parameters",
     "documentation": {
       "kind": "markdown",
-      "value": "Type: bool  \n"
+      "value": "Type: bool"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -304,6 +304,50 @@ output baz object = {|
             await RunCompletionScenarioTest(this.TestContext, ServerWithBuiltInTypes, fileWithCursors, AssertAllCompletionsEmpty, '|');
         }
 
+    [DataRow(
+@"
+@allowed(
+    [
+        0
+        1
+    ]
+)
+@description('this is an int value')
+param myInt int
+
+@allowed(
+    [
+        'value1'
+        'value2'
+    ]
+)
+@description('this is a string value')
+param myStr string
+
+@description('this is a bool value')
+param myBool bool
+
+resource storageAct 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: |
+}
+", 
+new[] {"myInt", "myStr", "myBool"}, 
+new[] {"[Markdown] Type: 0 | 1  \nthis is an int value",
+       "[Markdown] Type: 'value1' | 'value2'  \nthis is a string value",
+       "[Markdown] Type: bool  \nthis is a bool value"})]
+        [DataTestMethod]
+        public async Task Parameter_type_description_should_be_shown_for_bicep_symbol_completions(string bicepTextWithCursor, string[] expectedLabels, string[] expectedDocumentation)
+        {
+            await RunCompletionScenarioTest(this.TestContext, DefaultServer, bicepTextWithCursor, completions => {
+              
+              completions.Count().Should().Be(1);
+              var symbolCompletions = completions.First().Items.Where(x => x.Kind == CompletionItemKind.Field);
+              
+              symbolCompletions.Select(completion => completion.Label).Should().Equal(expectedLabels);
+              symbolCompletions.Select(completion => completion.Documentation!.MarkupContent!.ToString()).Should().Equal(expectedDocumentation);
+            }, '|');
+        }
+
         [TestMethod]
         public async Task Completions_are_not_offered_inside_comments()
         {

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -305,7 +305,7 @@ output baz object = {|
         }
 
         [TestMethod]
-        public async Task Parameter_type_description_should_be_shown_for_bicep_symbol_completions()
+        public async Task Documentation_should_be_shown_for_bicep_symbol_completions()
         {
             var bicepTextWithCursor = @"
 @allowed(
@@ -329,34 +329,99 @@ param myStr string
 @description('this is a bool value')
 param myBool bool
 
+param myArray array 
+
+@description('this is a variable')
+var myVar = 'foobar'
+
+@description('this is a storage account resource')
 resource storageAct 'Microsoft.Storage/storageAccounts@2022-09-01' = {
-  name: |
+  name: 'foorbar'
+  location: 'westus2'
+  sku: {
+    name: 'standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+@description('this is a bicep module')
+module myMod './myMod.bicep' = {
+  name: 'myModule'
+}
+
+resource service 'Microsoft.Storage/storageAccounts/fileServices@2021-02-01' = {
+  name: 'default'
+  parent:  |
 }
 ";
 
-            await RunCompletionScenarioTest(this.TestContext, DefaultServer, bicepTextWithCursor, completions => {
-              
-              completions.Count().Should().Be(1);
-              var symbolCompletions = completions.First().Items.Where(x => x.Kind == CompletionItemKind.Field);
+            var (text, cursor) = ParserHelper.GetFileWithSingleCursor(bicepTextWithCursor, '|');
+            Uri mainUri = new Uri("file:///main.bicep");
+            var files = new Dictionary<Uri, string>
+            {
+                [new Uri("file:///myMod.bicep")] = "",
+                [mainUri] = text
+            };
 
-              symbolCompletions.Should().SatisfyRespectively(
-                x =>
-                {
-                    x.Label.Should().Be("myInt");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: 0 | 1  \nthis is an int value");
-                },
-                x =>
-                {
-                    x.Label.Should().Be("myStr");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: 'value1' | 'value2'  \nthis is a string value");
-                },
-                x =>
-                {
-                    x.Label.Should().Be("myBool");
-                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: bool  \nthis is a bool value");
-                }
-              );              
-            }, '|');
+            var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
+            using var helper = await LanguageServerHelper.StartServerWithText(
+                this.TestContext,
+                files,
+                bicepFile.FileUri
+            );
+
+            var file = new FileRequestHelper(helper.Client, bicepFile);
+            var completions = await file.RequestCompletion(cursor);
+
+            var symbolCompletions = completions.Items.Where(x => x.Kind == CompletionItemKind.Field ||
+                                                                 x.Kind == CompletionItemKind.Variable ||
+                                                                 x.Kind == CompletionItemKind.Interface ||
+                                                                 x.Kind == CompletionItemKind.Module);
+
+            symbolCompletions.Should().SatisfyRespectively(
+              x =>
+              {
+                  x.Label.Should().Be("myInt");
+                  x.Kind.Should().Be(CompletionItemKind.Field);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: 0 | 1  \nthis is an int value");
+              },
+              x =>
+              {
+                  x.Label.Should().Be("myStr");
+                  x.Kind.Should().Be(CompletionItemKind.Field);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: 'value1' | 'value2'  \nthis is a string value");
+              },
+              x =>
+              {
+                  x.Label.Should().Be("myBool");
+                  x.Kind.Should().Be(CompletionItemKind.Field);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: bool  \nthis is a bool value");
+              },
+              x =>
+              {
+                  x.Label.Should().Be("myArray");
+                  x.Kind.Should().Be(CompletionItemKind.Field);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("Type: array");
+              },
+              x =>
+              {
+                  x.Label.Should().Be("myVar");
+                  x.Kind.Should().Be(CompletionItemKind.Variable);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a variable");
+              },
+              x =>
+              {
+                  x.Label.Should().Be("storageAct");
+                  x.Kind.Should().Be(CompletionItemKind.Interface);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a storage account resource");
+              },
+              x =>
+              {
+                  x.Label.Should().Be("myMod");
+                  x.Kind.Should().Be(CompletionItemKind.Module);
+                  x.Documentation!.MarkupContent!.Value.Should().Be("this is a bicep module");
+              }
+            ); 
         }
 
         [TestMethod]

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -336,7 +336,7 @@ new[] {"[Markdown] Type: bool  \nthis is a bool value",
        "[Markdown] Type: 0 | 1  \nthis is an int value",
        "[Markdown] Type: 'value1' | 'value2'  \nthis is a string value"})]
         [DataTestMethod]
-        public async Task Documentation_showing_should_be_shown_with_symbol_completions(string paramTextWithCursor, string bicepText, string[] expectedLabels, string[] expectedDocumentation)
+        public async Task Parameter_type_description_should_be_shown_for_params_symbol_completions(string paramTextWithCursor, string bicepText, string[] expectedLabels, string[] expectedDocumentation)
         {
             var fileTextsByUri = new Dictionary<Uri, string>
             {

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -334,6 +334,8 @@ param myStr string
 
 @description('this is a bool value')
 param myBool bool
+
+param myArray array
 ";
             var fileTextsByUri = new Dictionary<Uri, string>
             {
@@ -343,6 +345,12 @@ param myBool bool
             var completions = await RunCompletionScenario(paramTextWithCursor , fileTextsByUri.ToImmutableDictionary(), '|');
 
             completions.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Label.Should().Be("myArray");
+                    x.Documentation!.MarkupContent!.Value.Should().Be("Type: array");
+                    x.Kind.Should().Be(CompletionItemKind.Field);
+                },
                 x =>
                 {
                     x.Label.Should().Be("myBool");
@@ -360,7 +368,8 @@ param myBool bool
                     x.Label.Should().Be("myStr");
                     x.Documentation!.MarkupContent!.Value.Should().Be("Type: 'value1' | 'value2'  \nthis is a string value");
                     x.Kind.Should().Be(CompletionItemKind.Field);
-                });
+                }
+                );
         }
 
         private async Task<IEnumerable<CompletionItem>> RunCompletionScenario(string paramTextWithCursors, ImmutableDictionary<Uri, string> fileTextsByUri, char cursorInsertionMarker)

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -104,7 +104,7 @@ namespace Bicep.LanguageServer.Completions
                 {
                     if (!IsParamAssigned(declaration))
                     {
-                        yield return CreateSymbolCompletion(declaration, paramsCompletionContext.ReplacementRange, null, null, bicepSemanticModel);
+                        yield return CreateSymbolCompletion(declaration, paramsCompletionContext.ReplacementRange, bicepSemanticModel);
                     }
                 }
             }
@@ -946,7 +946,7 @@ namespace Bicep.LanguageServer.Completions
                         // - the symbol is different than the enclosing declaration (avoids suggesting cycles)
                         // - the symbol name is different than the name of the enclosing declaration (avoids suggesting a duplicate identifier)
                         var priority = GetContextualCompletionPriority(symbol, model, context, enclosingDeclarationSymbol);
-                        result.Add(symbol.Name, CreateSymbolCompletion(symbol, context.ReplacementRange, priority: priority, bicepModel: model));
+                        result.Add(symbol.Name, CreateSymbolCompletion(symbol, context.ReplacementRange, priority: priority, model: model));
                     }
                 }
             }
@@ -1021,12 +1021,12 @@ namespace Bicep.LanguageServer.Completions
                         // either there is a declaration with the same name as the function or the function is ambiguous between the imported namespaces
                         // either way the function must be fully qualified in the completion
                         var fullyQualifiedFunctionName = $"{symbol.Name}.{function.Name}";
-                        completions.Add(fullyQualifiedFunctionName, CreateSymbolCompletion(function, context.ReplacementRange, insertText: fullyQualifiedFunctionName));
+                        completions.Add(fullyQualifiedFunctionName, CreateSymbolCompletion(function, context.ReplacementRange, model, insertText: fullyQualifiedFunctionName));
                     }
                     else
                     {
                         // function does not have to be fully qualified
-                        completions.Add(function.Name, CreateSymbolCompletion(function, context.ReplacementRange));
+                        completions.Add(function.Name, CreateSymbolCompletion(function, context.ReplacementRange, model));
                     }
                 }
             }
@@ -1070,14 +1070,14 @@ namespace Bicep.LanguageServer.Completions
             }
 
             var declaredType = compilation.GetEntrypointSemanticModel().GetDeclaredType(context.PropertyAccess.BaseExpression);
+            var model = compilation.GetEntrypointSemanticModel();
 
             if (context.Kind.HasFlag(BicepCompletionContextKind.DecoratorName) && declaredType is NamespaceType namespaceType)
             {
-                var model = compilation.GetEntrypointSemanticModel();
                 var enclosingDeclarationSymbol = context.EnclosingDeclaration is null ? null : model.GetSymbolInfo(context.EnclosingDeclaration);
 
                 return GetAccessibleDecoratorFunctions(namespaceType, enclosingDeclarationSymbol)
-                    .Select(symbol => CreateSymbolCompletion(symbol, context.ReplacementRange));
+                    .Select(symbol => CreateSymbolCompletion(symbol, context.ReplacementRange, model));
             }
 
             if (declaredType is not null && TypeHelper.TryRemoveNullability(declaredType) is TypeSymbol nonNullable)
@@ -1089,7 +1089,7 @@ namespace Bicep.LanguageServer.Completions
                 .Where(p => !p.Flags.HasFlag(TypePropertyFlags.WriteOnly))
                 .Select(p => CreatePropertyAccessCompletion(p, compilation.SourceFileGrouping.EntryPoint, context.PropertyAccess, context.ReplacementRange))
                 .Concat(GetMethods(declaredType)
-                    .Select(m => CreateSymbolCompletion(m, context.ReplacementRange)));
+                .Select(m => CreateSymbolCompletion(m, context.ReplacementRange, model)));
         }
 
         private IEnumerable<CompletionItem> GetResourceAccessCompletions(Compilation compilation, BicepCompletionContext context)
@@ -1104,13 +1104,14 @@ namespace Bicep.LanguageServer.Completions
             {
                 return Enumerable.Empty<CompletionItem>();
             }
+            var model = compilation.GetEntrypointSemanticModel();
 
             // Find child resources
             var children = symbol.DeclaringResource.TryGetBody()?.Resources ?? Enumerable.Empty<ResourceDeclarationSyntax>();
             return children
                 .Select(r => new { resource = r, symbol = compilation.GetEntrypointSemanticModel().GetSymbolInfo(r) as ResourceSymbol, })
                 .Where(entry => entry.symbol != null)
-                .Select(entry => CreateSymbolCompletion(entry.symbol!, context.ReplacementRange));
+                .Select(entry => CreateSymbolCompletion(entry.symbol!, context.ReplacementRange, model));
         }
 
         private IEnumerable<CompletionItem> GetArrayIndexCompletions(Compilation compilation, BicepCompletionContext context)
@@ -1710,7 +1711,7 @@ namespace Bicep.LanguageServer.Completions
                 .WithSortText(GetSortText(label, priority))
                 .Build();
 
-        private static CompletionItem CreateSymbolCompletion(Symbol symbol, Range replacementRange, string? insertText = null, CompletionPriority? priority = null, SemanticModel? bicepModel = null)
+        private static CompletionItem CreateSymbolCompletion(Symbol symbol, Range replacementRange, SemanticModel model, string? insertText = null, CompletionPriority? priority = null)
         {
             insertText ??= symbol.Name;
             var kind = GetCompletionItemKind(symbol);
@@ -1766,18 +1767,10 @@ namespace Bicep.LanguageServer.Completions
                     .Build();
             }
 
-            if(symbol is ParameterSymbol parameterSymbol)
+            if(TryGetSymbolDocumentationMarkdown(symbol, model) is {} documentation)
             {
-                var description = bicepModel is {} ? SemanticModelHelper.TryGetDescription(bicepModel, parameterSymbol.DeclaringParameter) : null;
-                var documentation = $"Type: {parameterSymbol.Type.ToString() + MarkdownNewLine + description}";
-
-                return completion
-                .WithDetail(insertText)
-                .WithDocumentation(documentation)
-                .WithPlainTextEdit(replacementRange, insertText)
-                .Build();
+                completion.WithDocumentation(documentation);
             }
-
 
             return completion
                 .WithDetail(insertText)
@@ -1901,6 +1894,17 @@ namespace Bicep.LanguageServer.Completions
             }
 
             return buffer.ToString();
+        }
+
+        private static string? TryGetSymbolDocumentationMarkdown(Symbol symbol, SemanticModel model)
+        {   
+            if(symbol is DeclaredSymbol declaredSymbol && declaredSymbol.DeclaringSyntax is DecorableSyntax decorableSyntax)
+            {
+                var description = SemanticModelHelper.TryGetDescription(model, decorableSyntax);
+                var documentation = declaredSymbol is ParameterSymbol? $"Type: {declaredSymbol.Type.ToString() + MarkdownNewLine + description}" : description;
+                return documentation;
+            }
+            return null;
         }
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1900,8 +1900,11 @@ namespace Bicep.LanguageServer.Completions
         {   
             if(symbol is DeclaredSymbol declaredSymbol && declaredSymbol.DeclaringSyntax is DecorableSyntax decorableSyntax)
             {
-                var description = SemanticModelHelper.TryGetDescription(model, decorableSyntax);
-                var documentation = declaredSymbol is ParameterSymbol? $"Type: {declaredSymbol.Type.ToString() + MarkdownNewLine + description}" : description;
+                var documentation = SemanticModelHelper.TryGetDescription(model, decorableSyntax);
+                if(declaredSymbol is ParameterSymbol)
+                {
+                    documentation = $"Type: {declaredSymbol.Type}" + (documentation is null ? "" : $"{MarkdownNewLine}{documentation}"); 
+                }
                 return documentation;
             }
             return null;

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1781,7 +1781,6 @@ namespace Bicep.LanguageServer.Completions
 
             return completion
                 .WithDetail(insertText)
-                .WithDocumentation("fancy boi")
                 .WithPlainTextEdit(replacementRange, insertText)
                 .Build();
         }


### PR DESCRIPTION
closes #9574 

Similar to property value completion, we are utilizing the `Documentation` field in LSP to show type and description of parameters when a completion item is shown in both `.bicepparam` and `.bicep` files

<img width="1153" alt="completion" src="https://user-images.githubusercontent.com/27924869/228317467-3372ba67-e0d3-4d3f-9614-04d9829d561c.png">


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10243)