### PR TITLE
Flag resource non-deploy time constant usage in for body expressions as errors.

### DIFF
--- a/src/Bicep.Core.IntegrationTests/DeployTimeConstantTests.cs
+++ b/src/Bicep.Core.IntegrationTests/DeployTimeConstantTests.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Linq;
+using System.Text;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.IntegrationTests
@@ -41,7 +45,7 @@ resource appPlan 'Microsoft.Web/serverfarms@2020-12-01' = if (dnsZone::aRecord !
 resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
   name: 'dnsZone'
   location: 'global'
-  
+
   resource aRecord 'A' = {
     name: 'aRecord'
   }
@@ -73,7 +77,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2022-07-01' existing = {
 
 resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2022-07-01' = {
   name: 'subnet2'
-  parent: vnet 
+  parent: vnet
   properties: {
     addressPrefix: '10.0.2.0/24'
   }
@@ -125,6 +129,98 @@ resource appPlan 'Microsoft.Web/serverfarms@2020-12-01' = {
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"tags\" property of the \"Microsoft.Web/serverfarms\" type, which requires a value that can be calculated at the start of the deployment."),
                 ("BCP120", DiagnosticLevel.Error, "This expression is being used in an assignment to the \"tags\" property of the \"Microsoft.Web/serverfarms\" type, which requires a value that can be calculated at the start of the deployment. Properties of dnsZone which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\"."),
             });
+        }
+
+
+        [TestMethod]
+        public void DtcValidation_RuntimeValue_ForBodyExpression_Resource_ProducesDiagnostics()
+        {
+            const string text = @"
+resource foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: 'foo'
+  location: 'westus'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+var ok1 = [for i in range(0, 2): foo.id]
+var ok2 = [for i in range(0, 2): {
+  id: foo.id
+}]
+var bad1 = [for i in range(0, 2): foo.properties]
+var bad2 = [for i in range(0, 2): foo.properties.accessTier]
+var bad3 = [for i in range(0, 2): {
+  accessTier: foo.properties.accessTier
+}]
+";
+            var result = CompilationHelper.Compile(text);
+
+            const int badCount = 3;
+            var expectedDiagnostics = Enumerable
+                .Range(1, badCount)
+                .Select(i => ("BCP182", DiagnosticLevel.Error, $"This expression is being used in the for-body of the variable \"bad{i}\", which requires values that can be calculated at the start of the deployment. Properties of foo which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\"."));
+
+            result.WithFilteredDiagnostics(d => d.Level == DiagnosticLevel.Error).Should().HaveDiagnostics(expectedDiagnostics);
+        }
+
+        [TestMethod]
+        public void DtcValidation_RuntimeValue_ForBodyExpression_ResourceCollection_ProducesDiagnostics()
+        {
+            StringBuilder textSb = new(@"
+resource foos 'Microsoft.Storage/storageAccounts@2022-09-01' = [for i in range(0, 2): {
+  name: 'foo-${i}'
+  location: 'westus'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+");
+
+            var arrayAccessors = new[] { "0", "i", "i + 2" };
+
+            // iterate the ok cases
+            var okNumber = 0;
+            var okCollectionAccessExpressions = new[] { ".id" };
+
+            foreach (var arrayAccessor in arrayAccessors)
+            {
+                foreach (var okExp in okCollectionAccessExpressions)
+                {
+                    textSb.AppendLine($"var ok{++okNumber} = [for i in range(0, 2): foos[{arrayAccessor}]{okExp}]");
+                    textSb.AppendLine($@"var ok{++okNumber} = [for i in range(0, 2): {{
+  name: foos[{arrayAccessor}]{okExp}
+}}]");
+                }
+            }
+            okNumber.Should().Be(arrayAccessors.Length * okCollectionAccessExpressions.Length * 2);
+
+            // iterate the bad cases
+            var badNumber = 0;
+            var badCollectionAccessExpressions = new[] { ".properties", ".properties.accessTier" };
+
+            foreach (var arrayAccessor in arrayAccessors)
+            {
+                foreach (var badExp in badCollectionAccessExpressions)
+                {
+                    textSb.AppendLine($"var bad{++badNumber} = [for i in range(0, 2): foos[{arrayAccessor}]{badExp}]");
+                    textSb.AppendLine($@"var bad{++badNumber} = [for i in range(0, 2): {{
+  name: foos[{arrayAccessor}]{badExp}
+}}]");
+                }
+            }
+            badNumber.Should().Be(arrayAccessors.Length * badCollectionAccessExpressions.Length * 2);
+
+            var finalText = textSb.ToString();
+            var result = CompilationHelper.Compile(finalText);
+
+            var expectedDiagnostics = Enumerable
+                .Range(1, badNumber)
+                .Select(i => ("BCP182", DiagnosticLevel.Error, $"This expression is being used in the for-body of the variable \"bad{i}\", which requires values that can be calculated at the start of the deployment. Properties of foos which can be calculated at the start include \"apiVersion\", \"id\", \"name\", \"type\"."));
+
+            result.WithFilteredDiagnostics(d => d.Level == DiagnosticLevel.Error).Should().HaveDiagnostics(expectedDiagnostics);
         }
     }
 }

--- a/src/Bicep.Core/TypeSystem/ResourceTypeResolver.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceTypeResolver.cs
@@ -1,18 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.Analyzers.Linter.Rules;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem.Az;
-using JetBrains.Annotations;
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Bicep.Core.TypeSystem
 {
@@ -59,7 +54,7 @@ namespace Bicep.Core.TypeSystem
         }
 
         public (DeclaredSymbol?, ObjectType?) TryResolveResourceOrModuleSymbolAndBodyType(SyntaxBase resourceOrModuleAccessSyntax) =>
-            resourceOrModuleAccessSyntax is ArrayAccessSyntax { IndexExpression: IntegerLiteralSyntax, BaseExpression: var baseAccessSyntax }
+            resourceOrModuleAccessSyntax is ArrayAccessSyntax { BaseExpression: var baseAccessSyntax }
                 ? TryResolveResourceOrModuleSymbolAndBodyType(baseAccessSyntax, true)
                 : TryResolveResourceOrModuleSymbolAndBodyType(resourceOrModuleAccessSyntax, false);
 


### PR DESCRIPTION
Improves the current behavior associated with #9440.

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature
