### PR TITLE
Use the correct bitwise operator for combining flags in JSON model loader

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4545,5 +4545,36 @@ resource watchlist 'Microsoft.SecurityInsights/watchlists@2023-02-01-preview' = 
 
             result.Should().NotHaveAnyDiagnostics();
         }
+
+        // https://github.com/Azure/bicep/issues/10321
+        [TestMethod]
+        public void Test_Issue10321()
+        {
+            var result = CompilationHelper.Compile(
+("main.bicep", @"
+module mod 'mod.json' = {
+  name: 'mod'
+  params: {
+    secret: kv.getSecret('secret')
+  }
+}
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'kv'
+}
+"),
+("mod.json", @"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""secret"": {
+      ""type"": ""secureString""
+    }
+  },
+  ""resources"": []
+}"));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -162,7 +162,7 @@ namespace Bicep.Core.Semantics
                     TemplateParameterType.Array => GetArrayType(resolved),
                     TemplateParameterType.Object => GetObjectType(SourceFile.Template!, resolved),
                     TemplateParameterType.SecureString => GetStringType(resolved,
-                        TypeSymbolValidationFlags.IsSecure & (allowLooseAssignment ? TypeSymbolValidationFlags.AllowLooseAssignment : TypeSymbolValidationFlags.Default)),
+                        TypeSymbolValidationFlags.IsSecure | (allowLooseAssignment ? TypeSymbolValidationFlags.AllowLooseAssignment : TypeSymbolValidationFlags.Default)),
                     TemplateParameterType.SecureObject => GetObjectType(SourceFile.Template!, resolved, TypeSymbolValidationFlags.IsSecure),
                     _ => ErrorType.Empty(),
                 };


### PR DESCRIPTION
Resolves #10321

`ArmTemplateSemanticModel` is using the wrong operator to combine flags on secureString parameters (`&` vs `|`), which results in all flags being dropped. This PR corrects the operator and adds a regression test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10325)