### PR TITLE
Fix for decompiler to support templatespec

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     },
     "yaml.schemas": {
         "https://json.schemastore.org/github-workflow.json": "/.github/workflows/*.yml"
-    }
+    },
+    "dotnet-test-explorer.testProjectPath": "src/Bicep.Decompiler.IntegrationTests/*Tests.csproj",
+    "dotnet-test-explorer.enableTelemetry": false
+    
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,5 @@
     },
     "yaml.schemas": {
         "https://json.schemastore.org/github-workflow.json": "/.github/workflows/*.yml"
-    },
-    "dotnet-test-explorer.testProjectPath": "src/Bicep.Decompiler.IntegrationTests/*Tests.csproj",
-    "dotnet-test-explorer.enableTelemetry": false
-    
+    }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
@@ -1,0 +1,6 @@
+module foo 'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2' = {
+//@[11:93) [BCP190 (Error)] The module with reference "ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2" has not been restored. (CodeDescription: none) |'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2'|
+  name: 'foo'
+  params: {
+  }
+}

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
@@ -1,6 +1,4 @@
 module foo 'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2' = {
-//@[11:93) [BCP190 (Error)] The module with reference "ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2" has not been restored. (CodeDescription: none) |'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2'|
   name: 'foo'
-  params: {
-  }
+  params: {}
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
@@ -1,4 +1,5 @@
 module foo 'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2' = {
+//@[11:93) [BCP190 (Error)] The module with reference "ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2" has not been restored. (CodeDescription: none) |'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2'|
   name: 'foo'
   params: {}
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "resources": [
+        {
+            "name": "foo",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2020-10-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "id": "/subscriptions/28cbf98f-381d-4425-9ac4-cf342dab9753/resourceGroups/StacksTestRG34xu72emdafmq/providers/Microsoft.Resources/templateSpecs/ABetterSpec/versions/V2"
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -151,17 +151,14 @@ public class BicepDecompiler
 
         // force enumeration here with .ToImmutableArray() as we're going to be modifying the sourceFileGrouping collection as we iterate
         var sourceFiles = compilation.SourceFileGrouping.SourceFiles.ToImmutableArray();
-        foreach (var sourceFile in sourceFiles)
+        foreach (var bicepFile in sourceFiles.OfType<BicepFile>())
         {
-            var bicepFile = sourceFile as BicepFile ??
-                throw new InvalidOperationException($"Failed to find a bicep source file for URI {sourceFile.FileUri}.");
-
             var newProgramSyntax = rewriteVisitorBuilder(compilation.GetSemanticModel(bicepFile)).Rewrite(bicepFile.ProgramSyntax);
 
             if (!object.ReferenceEquals(bicepFile.ProgramSyntax, newProgramSyntax))
             {
                 hasChanges = true;
-                var newFile = SourceFileFactory.CreateBicepFile(sourceFile.FileUri, newProgramSyntax.ToText());
+                var newFile = SourceFileFactory.CreateBicepFile(bicepFile.FileUri, newProgramSyntax.ToText());
                 workspace.UpsertSourceFile(newFile);
 
                 compilation = await bicepCompiler.CreateCompilation(entryUri, skipRestore: true, workspace);

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -25,6 +25,7 @@ using Bicep.Decompiler.Exceptions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using static Bicep.Core.Emit.ResourceDependencyVisitor;
+using Azure.Deployments.Core.Definitions.Identifiers;
 
 namespace Bicep.Decompiler
 {
@@ -1016,6 +1017,20 @@ namespace Bicep.Decompiler
             return (SyntaxFactory.CreateStringLiteral(moduleFilePath), nestedUri);
         }
 
+        /// <summary>
+        /// Used to generate the module's templateSpec format from the id parameter.
+        /// </summary>
+        private SyntaxBase GetModuleFromId(string templateID, JObject resource)
+        {   
+            // eg for modules templateSpec - ts:<subscription-ID>/<resource-group-name>/<Template-spec-name>:<version>   
+            ResourceGroupLevelResourceId id;
+            var templateSpec = "";
+            if (ResourceGroupLevelResourceId.TryParse(templateID, out id) is not true) {
+               throw  new ConversionFailedException($"Unable to parse resourceId {templateID}", resource);
+            }          
+            templateSpec = "ts:" + id.SubscriptionId + "/" + id.ResourceGroup + "/" + id.NameHierarchy.First() + ":" + id.NameHierarchy.Last();
+            return SyntaxFactory.CreateStringLiteral(templateSpec);
+        }
 
         /// <summary>
         /// Used to generate a for-expression for a copy loop, where the copyIndex does not accept a 'name' parameter.
@@ -1388,13 +1403,16 @@ namespace Bicep.Decompiler
             }
             else
             {
-                var pathProperty = TemplateHelpers.GetNestedProperty(resource, "properties", "templateLink", "uri") ??
-                    TemplateHelpers.GetNestedProperty(resource, "properties", "templateLink", "relativePath");
+                var pathProperty = TemplateHelpers.GetNestedProperty(resource, "properties", "templateLink", "uri") 
+                                ?? TemplateHelpers.GetNestedProperty(resource, "properties", "templateLink", "relativePath");
+                                
+                var idProperty = TemplateHelpers.GetNestedProperty(resource, "properties", "templateLink", "id");
 
-                if (pathProperty?.Value<string>() is not string templatePathString)
+                if ((pathProperty?.Value<string>() is not string  && idProperty?.Value<string>() is not string ))
                 {
-                    throw new ConversionFailedException($"Unable to find \"uri\" or \"relativePath\" properties under {resource["name"]}.properties.templateLink for linked template.", resource);
+                    throw new ConversionFailedException($"Unable to find \"uri\" or \"relativePath\" or \"id\" properties under {resource["name"]}.properties.templateLink for linked template.", resource);
                 }
+                var templatePathString = idProperty?.Value<string>() ?? pathProperty?.Value<string>() ?? "";
 
                 // Metadata/description should be first
                 var decoratorsAndNewLines = ProcessMetadataDescription(name => resource[name]).ToList();
@@ -1403,7 +1421,16 @@ namespace Bicep.Decompiler
                 decoratorsAndNewLines.AddRange(resourceCopyDecorators);
                 var value = ProcessCondition(resource, body);
 
-                var (modulePath, jsonTemplateUri) = GetModuleFilePath(templatePathString);
+                SyntaxBase modulePath;
+                Uri? jsonTemplateUri = null;
+                if ( idProperty is not null )
+                {
+                    modulePath = GetModuleFromId(templatePathString,resource);
+                } else 
+                {
+                    (modulePath, jsonTemplateUri) = GetModuleFilePath(templatePathString);                  
+                }
+                //
                 var module = new ModuleDeclarationSyntax(
                     decoratorsAndNewLines,
                     SyntaxFactory.CreateToken(TokenType.Identifier, LanguageConstants.ModuleKeyword),

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -1421,6 +1421,7 @@ namespace Bicep.Decompiler
                 decoratorsAndNewLines.AddRange(resourceCopyDecorators);
                 var value = ProcessCondition(resource, body);
 
+                // fetch the module templatespec if the id property set else fetch the module path
                 SyntaxBase modulePath;
                 Uri? jsonTemplateUri = null;
                 if ( idProperty is not null )
@@ -1430,7 +1431,7 @@ namespace Bicep.Decompiler
                 {
                     (modulePath, jsonTemplateUri) = GetModuleFilePath(templatePathString);                  
                 }
-                //
+                
                 var module = new ModuleDeclarationSyntax(
                     decoratorsAndNewLines,
                     SyntaxFactory.CreateToken(TokenType.Identifier, LanguageConstants.ModuleKeyword),


### PR DESCRIPTION
This PR adds support for template spec while decompiling [#3246 ].

It add supports for the case where the id has the resourceId which is not parameterized.
```
            "type": "Microsoft.Resources/deployments",
            "apiVersion": "2020-10-01",
            "name": "test",
            "properties": {
                "mode": "Incremental",
                "templateLink": {
                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testRg/providers/Microsoft.Resources/templateSpecs/testSpec/versions/V2"
                }
            }
```
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing a feature

* [X] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [X] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [X] I have appropriate test coverage of my new feature



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10329)