### PR TITLE
Dciborow/brm nuget generate

### DIFF
--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -393,9 +393,11 @@ namespace Bicep.Core.Semantics
 
         private TypeSymbol GetType(TemplateOutputParameter output)
         {
-            return output.Type.Value switch
+            var resolved = TemplateEngine.ResolveSchemaReferences(SourceFile.Template, output);
+
+            return resolved.Type.Value switch
             {
-                TemplateParameterType.String when TryCreateUnboundResourceTypeParameter(output.Metadata?.Value, out var resourceType) =>
+                TemplateParameterType.String when TryCreateUnboundResourceTypeParameter(resolved.Metadata?.Value, out var resourceType) =>
                     resourceType,
 
                 _ => GetType((ITemplateSchemaNode)output),

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -398,9 +398,21 @@ namespace Bicep.Core.Semantics
                 TemplateParameterType.String when TryCreateUnboundResourceTypeParameter(output.Metadata?.Value, out var resourceType) =>
                     resourceType,
 
-                _ => GetType((ITemplateSchemaNode)output),
+                _ => GetType((TemplateParameter)output),
             };
         }
+
+        private static TypeSymbol GetType(TemplateParameter parameterOrOutput) => parameterOrOutput.Type.Value switch
+        {
+            TemplateParameterType.String => LanguageConstants.LooseString,
+            TemplateParameterType.Int => LanguageConstants.Int,
+            TemplateParameterType.Bool => LanguageConstants.Bool,
+            TemplateParameterType.Array => LanguageConstants.Array,
+            TemplateParameterType.Object => LanguageConstants.Object,
+            TemplateParameterType.SecureString => LanguageConstants.SecureString,
+            TemplateParameterType.SecureObject => LanguageConstants.SecureObject,
+            _ => ErrorType.Empty(),
+        };
 
         private static bool TryCreateUnboundResourceTypeParameter(JToken? metadataToken, [NotNullWhen(true)] out TypeSymbol? type)
         {

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -391,28 +391,16 @@ namespace Bicep.Core.Semantics
             _ => GetType(schemaNode) switch { TypeSymbol concreteType => (concreteType, concreteType.Name) },
         };
 
-        private static TypeSymbol GetType(TemplateOutputParameter output)
+        private TypeSymbol GetType(TemplateOutputParameter output)
         {
             return output.Type.Value switch
             {
                 TemplateParameterType.String when TryCreateUnboundResourceTypeParameter(output.Metadata?.Value, out var resourceType) =>
                     resourceType,
 
-                _ => GetType((TemplateParameter)output),
+                _ => GetType((ITemplateSchemaNode)output),
             };
         }
-
-        private static TypeSymbol GetType(TemplateParameter parameterOrOutput) => parameterOrOutput.Type.Value switch
-        {
-            TemplateParameterType.String => LanguageConstants.LooseString,
-            TemplateParameterType.Int => LanguageConstants.Int,
-            TemplateParameterType.Bool => LanguageConstants.Bool,
-            TemplateParameterType.Array => LanguageConstants.Array,
-            TemplateParameterType.Object => LanguageConstants.Object,
-            TemplateParameterType.SecureString => LanguageConstants.SecureString,
-            TemplateParameterType.SecureObject => LanguageConstants.SecureObject,
-            _ => ErrorType.Empty(),
-        };
 
         private static bool TryCreateUnboundResourceTypeParameter(JToken? metadataToken, [NotNullWhen(true)] out TypeSymbol? type)
         {

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -398,21 +398,9 @@ namespace Bicep.Core.Semantics
                 TemplateParameterType.String when TryCreateUnboundResourceTypeParameter(output.Metadata?.Value, out var resourceType) =>
                     resourceType,
 
-                _ => GetType((TemplateParameter)output),
+                _ => GetType((ITemplateSchemaNode)output),
             };
         }
-
-        private static TypeSymbol GetType(TemplateParameter parameterOrOutput) => parameterOrOutput.Type.Value switch
-        {
-            TemplateParameterType.String => LanguageConstants.LooseString,
-            TemplateParameterType.Int => LanguageConstants.Int,
-            TemplateParameterType.Bool => LanguageConstants.Bool,
-            TemplateParameterType.Array => LanguageConstants.Array,
-            TemplateParameterType.Object => LanguageConstants.Object,
-            TemplateParameterType.SecureString => LanguageConstants.SecureString,
-            TemplateParameterType.SecureObject => LanguageConstants.SecureObject,
-            _ => ErrorType.Empty(),
-        };
 
         private static bool TryCreateUnboundResourceTypeParameter(JToken? metadataToken, [NotNullWhen(true)] out TypeSymbol? type)
         {

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/GenerateCommandTests.cs
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/GenerateCommandTests.cs
@@ -23,6 +23,7 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
     {
         [DataTestMethod]
         [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetExperimentalData), DynamicDataSourceType.Method)]
         public void Invoke_OnSuccess_ReturnsZero(MockFileSystem fileSystemBeforeGeneration, MockFileSystem fileSystemAfterGeneration)
         {
             var mockMainArmTemplateFileData = fileSystemAfterGeneration.GetFile(MainArmTemplateFile.FileName);
@@ -35,6 +36,7 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
 
         [DataTestMethod]
         [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
+        // [DynamicData(nameof(GetExperimentalData), DynamicDataSourceType.Method)] // This fails because the main.bicep that is prodcued does not include the custom type
         public void Invoke_OnSuccess_ProducesExpectedFiles(MockFileSystem fileSystemBeforeGeneration, MockFileSystem fileSystemAfterGeneration)
         {
             var mockMainArmTemplateFileData = fileSystemAfterGeneration.GetFile(MainArmTemplateFile.FileName);
@@ -47,6 +49,7 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
 
         [DataTestMethod]
         [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
+        // [DynamicData(nameof(GetExperimentalData), DynamicDataSourceType.Method)] // This fails because the main.bicep that is prodcued does not include the custom type
         public void Invoke_RepeatOnSuccess_ProducesSameFiles(MockFileSystem fileSystemBeforeGeneration, MockFileSystem fileSystemAfterGeneration)
         {
             var mockMainArmTemplateFileData = fileSystemAfterGeneration.GetFile(MainArmTemplateFile.FileName);
@@ -95,6 +98,16 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
             {
                 MockFileSystemFactory.CreateFileSystemWithModifiedFiles(),
                 MockFileSystemFactory.CreateFileSystemWithValidFiles(),
+            };
+        }
+
+        private static IEnumerable<object[]> GetExperimentalData()
+        {
+
+            yield return new object[]
+            {
+                MockFileSystemFactory.CreateFileSystemWithModifiedFiles(),
+                MockFileSystemFactory.CreateFileSystemWithExperimentalFiles(),
             };
         }
 

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/GenerateCommandTests.cs
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/GenerateCommandTests.cs
@@ -22,7 +22,7 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
     public class GenerateCommandTests
     {
         [DataTestMethod]
-        // [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
         [DynamicData(nameof(GetExperimentalData), DynamicDataSourceType.Method)]
         public void Invoke_OnSuccess_ReturnsZero(MockFileSystem fileSystemBeforeGeneration, MockFileSystem fileSystemAfterGeneration)
         {

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/GenerateCommandTests.cs
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/GenerateCommandTests.cs
@@ -22,7 +22,7 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
     public class GenerateCommandTests
     {
         [DataTestMethod]
-        [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
+        // [DynamicData(nameof(GetSuccessData), DynamicDataSourceType.Method)]
         [DynamicData(nameof(GetExperimentalData), DynamicDataSourceType.Method)]
         public void Invoke_OnSuccess_ReturnsZero(MockFileSystem fileSystemBeforeGeneration, MockFileSystem fileSystemAfterGeneration)
         {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/MockFactories/MockFileSystemFactory.cs
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/MockFactories/MockFileSystemFactory.cs
@@ -21,6 +21,8 @@ namespace Bicep.RegistryModuleTool.TestFixtures.MockFactories
 
         public static MockFileSystem CreateFileSystemWithInvalidFiles() => CreateFileSystem(SampleFiles.Invalid);
 
+        public static MockFileSystem CreateFileSystemWithExperimentalFiles() => CreateFileSystem(SampleFiles.Experimental);
+
         private static MockFileSystem CreateFileSystem(IEnumerable<(string, string)> sampleFiles)
         {
             var assembly = Assembly.GetExecutingAssembly();
@@ -49,8 +51,10 @@ namespace Bicep.RegistryModuleTool.TestFixtures.MockFactories
             public static IEnumerable<(string, string)> Modified { get; } = LoadSampleFiles();
 
             public static IEnumerable<(string, string)> Valid { get; } = LoadSampleFiles();
-            
+
             public static IEnumerable<(string, string)> Invalid { get; } = LoadSampleFiles();
+
+            public static IEnumerable<(string, string)> Experimental { get; } = LoadSampleFiles();
 
             private static IEnumerable<(string, string)> LoadSampleFiles([CallerMemberName] string? category = null)
             {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
@@ -25,10 +25,10 @@ The quick brown fox jumps over the lazy dog.
 
 ## Outputs
 
-| Name             | Type   | Description                                                                     |
-| :--------------- | :----: | :------------------------------------------------------------------------------ |
-| controlPlaneFQDN | string | The control plane FQDN                                                          |
-| osDiskSizeGB     |  int | The OS disk size (in GB)<br />- Minimum value is 0<br />- Maximum value is 1023 |
+| Name             | Type   | Description                   |
+| :--------------- | :----: | :---------------------------- |
+| controlPlaneFQDN | string | The control plane FQDN        |
+| osDiskSizeGB     |  int | Override the type description |
 
 ## Examples
 

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
@@ -1,0 +1,49 @@
+# Sample module
+
+Sample summary
+
+## Description
+
+The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.
+The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.
+The quick brown fox jumps over the lazy dog.
+
+## Parameters
+
+| Name                           | Type           | Required | Description                                                                     |
+| :----------------------------- | :------------: | :------: | :------------------------------------------------------------------------------ |
+| `dnsPrefix`                    | `string`       | Yes      | The dns prefix                                                                  |
+| `linuxAdminUsername`           | `string`       | Yes      | The linux administrator username                                                |
+| `sshRSAPublicKey`              | `string`       | Yes      | The RSA public key for SSH                                                      |
+| `servicePrincipalClientId`     | `string`       | Yes      | The service principal client ID                                                 |
+| `servicePrincipalClientSecret` | `securestring` | Yes      | The service principal client secret                                             |
+| `clusterName`                  | `string`       | No       | The cluster name                                                                |
+| `location`                     | `string`       | No       | The deployment location                                                         |
+| `osDiskSizeGB`                 | `int`          | Yes      | The OS disk size (in GB)<br />- Minimum value is 0<br />- Maximum value is 1023 |
+| `agentCount`                   | `int`          | No       | The agent count                                                                 |
+| `agentVMSize`                  | `string`       | No       | The agent VM size                                                               |
+
+## Outputs
+
+| Name             | Type   | Description                                                                     |
+| :--------------- | :----: | :------------------------------------------------------------------------------ |
+| controlPlaneFQDN | string | The control plane FQDN                                                          |
+| osDiskSizeGB     |  int | The OS disk size (in GB)<br />- Minimum value is 0<br />- Maximum value is 1023 |
+
+## Examples
+
+### Example 1
+
+```bicep
+module mod 'br/public:test/testmodule:1.1.1' = {
+  name: 'mod'
+  params: {
+    dnsPrefix: ''
+    linuxAdminUsername: ''
+    sshRSAPublicKey: ''
+    servicePrincipalClientId: ''
+    servicePrincipalClientSecret: ''
+    osDiskSizeGB: 1
+  }
+}
+```

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
@@ -16,7 +16,7 @@ The quick brown fox jumps over the lazy dog.
 | `linuxAdminUsername`           | `string`       | Yes      | The linux administrator username                                                |
 | `sshRSAPublicKey`              | `string`       | Yes      | The RSA public key for SSH                                                      |
 | `servicePrincipalClientId`     | `string`       | Yes      | The service principal client ID                                                 |
-| `servicePrincipalClientSecret` | `securestring` | Yes      | The service principal client secret                                             |
+| `servicePrincipalClientSecret` | `string`       | Yes      | The service principal client secret                                             |
 | `clusterName`                  | `string`       | No       | The cluster name                                                                |
 | `location`                     | `string`       | No       | The deployment location                                                         |
 | `osDiskSizeGB`                 | `int`          | Yes      | The OS disk size (in GB)<br />- Minimum value is 0<br />- Maximum value is 1023 |

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/README.md
@@ -16,7 +16,7 @@ The quick brown fox jumps over the lazy dog.
 | `linuxAdminUsername`           | `string`       | Yes      | The linux administrator username                                                |
 | `sshRSAPublicKey`              | `string`       | Yes      | The RSA public key for SSH                                                      |
 | `servicePrincipalClientId`     | `string`       | Yes      | The service principal client ID                                                 |
-| `servicePrincipalClientSecret` | `string`       | Yes      | The service principal client secret                                             |
+| `servicePrincipalClientSecret` | `securestring` | Yes      | The service principal client secret                                             |
 | `clusterName`                  | `string`       | No       | The cluster name                                                                |
 | `location`                     | `string`       | No       | The deployment location                                                         |
 | `osDiskSizeGB`                 | `int`          | Yes      | The OS disk size (in GB)<br />- Minimum value is 0<br />- Maximum value is 1023 |

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/bicepconfig.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/bicepconfig.json
@@ -1,0 +1,6 @@
+{
+    "experimentalFeaturesEnabled": {
+      "userDefinedTypes": true,
+      "extensibility": true
+    }
+  }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -25,11 +25,6 @@ param location string = resourceGroup().location
 @maxValue(1023)
 type DiskSizeGB = int
 
-@description('''
-The OS disk size (in GB)
-- Minimum value is 0
-- Maximum value is 1023
-''')
 param osDiskSizeGB DiskSizeGB
 
 @description('The agent count')
@@ -76,9 +71,5 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
 @description('The control plane FQDN')
 output controlPlaneFQDN string = aks.properties.fqdn
 
-@description('''
-The OS disk size (in GB)
-- Minimum value is 0
-- Maximum value is 1023
-''')
+@description('Override the type description')
 output osDiskSizeGB DiskSizeGB = osDiskSizeGB

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -40,6 +40,7 @@ param osDiskSizeGB DiskSizeGB
 param agentCount int = 1
 
 @description('The agent VM size')
+@allowed(['Standard_DS2_v2', 'Standard_DS4_v2'])
 param agentVMSize string = 'Standard_DS2_v2'
 // osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test
 
@@ -78,5 +79,4 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
 @description('The control plane FQDN')
 output controlPlaneFQDN string = aks.properties.fqdn
 
-@description('Override the type description')
 output osDiskSizeGB DiskSizeGB = osDiskSizeGB

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -80,4 +80,4 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
 output controlPlaneFQDN string = aks.properties.fqdn
 
 @description('Override default describtion')
-output osDiskSizeGB DiskSizeGB = osDiskSizeGB
+output osDiskSizeGB MinDiskSizeGB = osDiskSizeGB

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -11,7 +11,6 @@ param sshRSAPublicKey string
 param servicePrincipalClientId string
 
 @description('The service principal client secret')
-@secure()
 param servicePrincipalClientSecret string
 
 // optional params

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -28,7 +28,9 @@ The OS disk size (in GB)
 ''')
 @minValue(0)
 @maxValue(1023)
-type DiskSizeGB = int
+type MinDiskSizeGB = int
+
+type DiskSizeGB = MinDiskSizeGB
 
 param osDiskSizeGB DiskSizeGB
 

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -1,0 +1,84 @@
+@description('The dns prefix')
+param dnsPrefix string
+
+@description('The linux administrator username')
+param linuxAdminUsername string
+
+@description('The RSA public key for SSH')
+param sshRSAPublicKey string
+
+@description('The service principal client ID')
+param servicePrincipalClientId string
+
+@description('The service principal client secret')
+@secure()
+param servicePrincipalClientSecret string
+
+// optional params
+@description('The cluster name')
+param clusterName string = 'aks101cluster'
+
+@description('The deployment location')
+param location string = resourceGroup().location
+
+@minValue(0)
+@maxValue(1023)
+type DiskSizeGB = int
+
+@description('''
+The OS disk size (in GB)
+- Minimum value is 0
+- Maximum value is 1023
+''')
+param osDiskSizeGB DiskSizeGB
+
+@description('The agent count')
+@minValue(1)
+@maxValue(50)
+param agentCount int = 1
+
+@description('The agent VM size')
+param agentVMSize string = 'Standard_DS2_v2'
+// osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test
+
+resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
+  name: clusterName
+  location: location
+  properties: {
+    dnsPrefix: dnsPrefix
+    agentPoolProfiles: [
+      {
+        name: 'agentpool'
+        osDiskSizeGB: osDiskSizeGB
+        count: agentCount
+        vmSize: agentVMSize
+        osType: 'Linux'
+        mode: 'System'
+      }
+    ]
+    linuxProfile: {
+      adminUsername: linuxAdminUsername
+      ssh: {
+        publicKeys: [
+          {
+            keyData: sshRSAPublicKey
+          }
+        ]
+      }
+    }
+    servicePrincipalProfile: {
+      clientId: servicePrincipalClientId
+      secret: servicePrincipalClientSecret
+    }
+  }
+}
+
+@description('The control plane FQDN')
+output controlPlaneFQDN string = aks.properties.fqdn
+
+@description('''
+The OS disk size (in GB)
+- Minimum value is 0
+- Maximum value is 1023
+''')
+output osDiskSizeGB DiskSizeGB = osDiskSizeGB

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -79,4 +79,5 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
 @description('The control plane FQDN')
 output controlPlaneFQDN string = aks.properties.fqdn
 
+@description('Override default describtion')
 output osDiskSizeGB DiskSizeGB = osDiskSizeGB

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -11,6 +11,7 @@ param sshRSAPublicKey string
 param servicePrincipalClientId string
 
 @description('The service principal client secret')
+@secure()
 param servicePrincipalClientSecret string
 
 // optional params

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.bicep
@@ -21,6 +21,11 @@ param clusterName string = 'aks101cluster'
 @description('The deployment location')
 param location string = resourceGroup().location
 
+@description('''
+The OS disk size (in GB)
+- Minimum value is 0
+- Maximum value is 1023
+''')
 @minValue(0)
 @maxValue(1023)
 type DiskSizeGB = int

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "3660759329895993454"
+      "templateHash": "15984918200177464288"
     }
   },
   "definitions": {
@@ -49,7 +49,7 @@
       }
     },
     "servicePrincipalClientSecret": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "The service principal client secret"
       }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "18159476262841631239"
+      "templateHash": "15984918200177464288"
     }
   },
   "definitions": {
@@ -137,6 +137,9 @@
     },
     "osDiskSizeGB": {
       "$ref": "#/definitions/DiskSizeGB",
+      "metadata": {
+        "description": "Override default describtion"
+      },
       "value": "[parameters('osDiskSizeGB')]"
     }
   }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,17 +7,20 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "8659056611366475969"
+      "templateHash": "16423119646313264968"
     }
   },
   "definitions": {
-    "DiskSizeGB": {
+    "MinDiskSizeGB": {
       "type": "int",
       "maxValue": 1023,
       "minValue": 0,
       "metadata": {
         "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
       }
+    },
+    "DiskSizeGB": {
+      "$ref": "#/definitions/MinDiskSizeGB"
     }
   },
   "parameters": {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "16423119646313264968"
+      "templateHash": "18159476262841631239"
     }
   },
   "definitions": {
@@ -83,6 +83,10 @@
     "agentVMSize": {
       "type": "string",
       "defaultValue": "Standard_DS2_v2",
+      "allowedValues": [
+        "Standard_DS2_v2",
+        "Standard_DS4_v2"
+      ],
       "metadata": {
         "description": "The agent VM size"
       }
@@ -133,9 +137,6 @@
     },
     "osDiskSizeGB": {
       "$ref": "#/definitions/DiskSizeGB",
-      "metadata": {
-        "description": "Override the type description"
-      },
       "value": "[parameters('osDiskSizeGB')]"
     }
   }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "15984918200177464288"
+      "templateHash": "3660759329895993454"
     }
   },
   "definitions": {
@@ -49,7 +49,7 @@
       }
     },
     "servicePrincipalClientSecret": {
-      "type": "securestring",
+      "type": "string",
       "metadata": {
         "description": "The service principal client secret"
       }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "15984918200177464288"
+      "templateHash": "12093730562573377845"
     }
   },
   "definitions": {
@@ -136,7 +136,7 @@
       "value": "[reference('aks').fqdn]"
     },
     "osDiskSizeGB": {
-      "$ref": "#/definitions/DiskSizeGB",
+      "$ref": "#/definitions/MinDiskSizeGB",
       "metadata": {
         "description": "Override default describtion"
       },

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "4990425821140341644"
+      "templateHash": "5060076073504053920"
     }
   },
   "definitions": {
@@ -63,10 +63,7 @@
       }
     },
     "osDiskSizeGB": {
-      "$ref": "#/definitions/DiskSizeGB",
-      "metadata": {
-        "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
-      }
+      "$ref": "#/definitions/DiskSizeGB"
     },
     "agentCount": {
       "type": "int",
@@ -131,7 +128,7 @@
     "osDiskSizeGB": {
       "$ref": "#/definitions/DiskSizeGB",
       "metadata": {
-        "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
+        "description": "Override the type description"
       },
       "value": "[parameters('osDiskSizeGB')]"
     }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.10-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+    "_generator": {
+      "name": "bicep",
+      "version": "0.16.1.55165",
+      "templateHash": "4990425821140341644"
+    }
+  },
+  "definitions": {
+    "DiskSizeGB": {
+      "type": "int",
+      "maxValue": 1023,
+      "minValue": 0
+    }
+  },
+  "parameters": {
+    "dnsPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The dns prefix"
+      }
+    },
+    "linuxAdminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The linux administrator username"
+      }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The RSA public key for SSH"
+      }
+    },
+    "servicePrincipalClientId": {
+      "type": "string",
+      "metadata": {
+        "description": "The service principal client ID"
+      }
+    },
+    "servicePrincipalClientSecret": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The service principal client secret"
+      }
+    },
+    "clusterName": {
+      "type": "string",
+      "defaultValue": "aks101cluster",
+      "metadata": {
+        "description": "The cluster name"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The deployment location"
+      }
+    },
+    "osDiskSizeGB": {
+      "$ref": "#/definitions/DiskSizeGB",
+      "metadata": {
+        "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
+      }
+    },
+    "agentCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "maxValue": 50,
+      "minValue": 1,
+      "metadata": {
+        "description": "The agent count"
+      }
+    },
+    "agentVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS2_v2",
+      "metadata": {
+        "description": "The agent VM size"
+      }
+    }
+  },
+  "resources": {
+    "aks": {
+      "type": "Microsoft.ContainerService/managedClusters",
+      "apiVersion": "2020-09-01",
+      "name": "[parameters('clusterName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "dnsPrefix": "[parameters('dnsPrefix')]",
+        "agentPoolProfiles": [
+          {
+            "name": "agentpool",
+            "osDiskSizeGB": "[parameters('osDiskSizeGB')]",
+            "count": "[parameters('agentCount')]",
+            "vmSize": "[parameters('agentVMSize')]",
+            "osType": "Linux",
+            "mode": "System"
+          }
+        ],
+        "linuxProfile": {
+          "adminUsername": "[parameters('linuxAdminUsername')]",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "[parameters('sshRSAPublicKey')]"
+              }
+            ]
+          }
+        },
+        "servicePrincipalProfile": {
+          "clientId": "[parameters('servicePrincipalClientId')]",
+          "secret": "[parameters('servicePrincipalClientSecret')]"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "controlPlaneFQDN": {
+      "type": "string",
+      "metadata": {
+        "description": "The control plane FQDN"
+      },
+      "value": "[reference('aks').fqdn]"
+    },
+    "osDiskSizeGB": {
+      "$ref": "#/definitions/DiskSizeGB",
+      "metadata": {
+        "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
+      },
+      "value": "[parameters('osDiskSizeGB')]"
+    }
+  }
+}

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/main.json
@@ -7,14 +7,17 @@
     "_generator": {
       "name": "bicep",
       "version": "0.16.1.55165",
-      "templateHash": "5060076073504053920"
+      "templateHash": "8659056611366475969"
     }
   },
   "definitions": {
     "DiskSizeGB": {
       "type": "int",
       "maxValue": 1023,
-      "minValue": 0
+      "minValue": 0,
+      "metadata": {
+        "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
+      }
     }
   },
   "parameters": {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/metadata.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/metadata.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-metadata-file-schema-v2#",
+  "name": "Sample module",
+  "summary": "Sample summary",
+  "owner": "test"
+}

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/test/main.test.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/test/main.test.bicep
@@ -1,0 +1,11 @@
+module testMain '../main.bicep' = {
+  name: 'testMain'
+  params: {
+    sshRSAPublicKey: ''
+    dnsPrefix: ''
+    linuxAdminUsername: ''
+    servicePrincipalClientSecret: ''
+    servicePrincipalClientId: ''
+    osDiskSizeGB: 1 
+  }
+}

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/version.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Experimental/version.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://aka.ms/bicep-registry-module-version-file-schema#",
+  "version": "1.1",
+  "pathFilters": [
+    "./main.json",
+    "./metadata.json"
+  ]
+}

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -101,6 +101,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             string type = GetTypeFromDefinition(parameterProperty.Value);
             bool required = !parameterProperty.Value.TryGetProperty("defaultValue", out _);
             string? description = TryGetDescription(parameterProperty.Value);
+
             return new(name, type, required, description);
         }
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -40,6 +40,9 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             this.lazyParameters = new(() => !lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement)
                 ? Enumerable.Empty<MainArmTemplateParameter>()
                 : parametersElement.EnumerateObject().Select(ToParameter));
+            this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
+                    ? Enumerable.Empty<MainArmTemplateOutput>()
+                    : outputsElement.EnumerateObject().Select(ToOutput));
             this.lazyTemplateHash = new(() => lazyRootElement.Value.GetPropertyByPath("metadata._generator.templateHash").ToNonNullString());
         }
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -130,7 +130,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             }
 
             // The order of the checks allow the user to optionally override the default description for a user defined type
-            if(element.TryGetProperty("$ref", out var _))
+            if (element.TryGetProperty("$ref", out var _))
             {
                 return TryGetDescription(LookupRef(element));
             }

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -122,12 +122,16 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private string? TryGetDescription(JsonElement element)
         {
-            if(element.TryGetProperty("metadata", out _) && element.GetProperty("metadata").TryGetProperty("description", out var descriptionElement)){
+            if(element.TryGetProperty("metadata", out var metdataElement) &&
+                metdataElement.TryGetProperty("description", out var descriptionElement)){
                 return descriptionElement.ToNonNullString();
             }
+
+            // The order of the checks, allow the user to optionally override the default description for a user defined type
             if(element.TryGetProperty("$ref", out var refElement)){
               return this.lazyRootElement.Value.GetPropertyByPath("definitions." + refElement.ToNonNullString().Split('/')[2] + ".type").ToNonNullString();
             }
+
             return null;
         }
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -140,7 +140,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private JsonElement LookupRef(JsonElement element)
         {
-            return this.lazyRootElement.Value.GetPropertyByPath("definitions." + element.GetProperty("$ref").ToNonNullString().Split('/')[2]);
+            return this.lazyRootElement.Value.GetProperty("definitions").GetProperty(element.GetProperty("$ref").ToNonNullString().Split('/')[2]);
         }
 
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -3,6 +3,9 @@
 
 using Bicep.Core.Extensions;
 using Bicep.Core.Json;
+using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.Workspaces;
 using Bicep.RegistryModuleTool.Extensions;
 using Bicep.RegistryModuleTool.ModuleValidators;
 using Bicep.RegistryModuleTool.Proxies;
@@ -37,14 +40,42 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             this.Content = content;
 
             this.lazyRootElement = new(() => JsonElementFactory.CreateElement(content));
-            this.lazyParameters = new(() => !lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement)
-                ? Enumerable.Empty<MainArmTemplateParameter>()
-                : parametersElement.EnumerateObject().Select(ToParameter));
-            this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
-                    ? Enumerable.Empty<MainArmTemplateOutput>()
-                    : outputsElement.EnumerateObject().Select(ToOutput));
+            // this.lazyParameters = new(() => !lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement)
+            //     ? Enumerable.Empty<MainArmTemplateParameter>()
+            //     : parametersElement.EnumerateObject().Select(ToParameter));
+            // this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
+            //         ? Enumerable.Empty<MainArmTemplateOutput>()
+            //         : outputsElement.EnumerateObject().Select(ToOutput));
             this.lazyTemplateHash = new(() => lazyRootElement.Value.GetPropertyByPath("metadata._generator.templateHash").ToNonNullString());
+
+            var armTemplate = new ArmTemplateSemanticModel(SourceFileFactory.CreateArmTemplateFile(new Uri(System.IO.Path.GetFullPath(path)), content));
+
+            this.lazyParameters = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateParameter>>(() =>
+            {
+                return armTemplate.Parameters.Select(kv =>
+                    new MainArmTemplateParameter(kv.Value.Name, GetPrimitiveTypeName(kv.Value.TypeReference), kv.Value.IsRequired, kv.Value.Description));
+            });
+            this.lazyOutputs = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateOutput>>(() =>
+            {
+                return armTemplate.Outputs.Select(kv =>
+                    new MainArmTemplateOutput(kv.Name, GetPrimitiveTypeName(kv.TypeReference), kv.Description));
+            });
         }
+
+        private static string GetPrimitiveTypeName(ITypeReference typeRef) => typeRef.Type switch {
+            StringType or StringLiteralType => "string",
+            UnionType unionOfStrings when unionOfStrings.Members.All(m => m.Type is StringLiteralType || m.Type is StringType)
+                => "string",
+            IntegerType or IntegerLiteralType => "int",
+            UnionType unionOfInts when unionOfInts.Members.All(m => m.Type is IntegerLiteralType || m.Type is IntegerType)
+                => "int",
+            BooleanType or BooleanLiteralType => "bool",
+            UnionType unionOfBools when unionOfBools.Members.All(m => m.Type is BooleanLiteralType || m.Type is BooleanType)
+                => "bool",
+            ObjectType => "object",
+            ArrayType => "array",
+            TypeSymbol otherwise => throw new InvalidOperationException($"Unable to determine primitive type of {otherwise.Name}"),
+        };
 
         public string Content { get; }
 
@@ -93,25 +124,6 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             fileSystem.File.WriteAllText(this.Path, this.Content);
 
             return this;
-        }
-
-        private MainArmTemplateParameter ToParameter(JsonProperty parameterProperty)
-        {
-            string name = parameterProperty.Name;
-            string type = GetTypeFromDefinition(parameterProperty.Value);
-            bool required = !parameterProperty.Value.TryGetProperty("defaultValue", out _);
-            string? description = TryGetDescription(parameterProperty.Value);
-
-            return new(name, type, required, description);
-        }
-
-        private MainArmTemplateOutput ToOutput(JsonProperty outputProperty)
-        {
-            string name = outputProperty.Name;
-            string type = GetTypeFromDefinition(outputProperty.Value);
-            string? description = TryGetDescription(outputProperty.Value);
-
-            return new(name, type, description);
         }
 
         private string GetTypeFromDefinition(JsonElement element)

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -122,7 +122,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private string? TryGetDescription(JsonElement element)
         {
-            if(element.TryGetProperty("metadata", out var metdataElement) &&
+            if (element.TryGetProperty("metadata", out var metdataElement) &&
                 metdataElement.TryGetProperty("description", out var descriptionElement))
             {
                 return descriptionElement.ToNonNullString();

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -129,7 +129,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
             // The order of the checks, allow the user to optionally override the default description for a user defined type
             if(element.TryGetProperty("$ref", out var refElement)){
-              return this.lazyRootElement.Value.GetPropertyByPath("definitions." + refElement.ToNonNullString().Split('/')[2] + ".type").ToNonNullString();
+              return this.lazyRootElement.Value.GetPropertyByPath("definitions." + refElement.ToNonNullString().Split('/')[2] + ".metadata.description").ToNonNullString();
             }
 
             return null;

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -117,17 +117,17 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
         {
             return element.TryGetProperty("type", out _)
             ? element.GetProperty("type").ToNonNullString()
-            :this.lazyRootElement.Value.GetPropertyByPath("definitions." + element.GetProperty("$ref").ToNonNullString().Split('/')[2] + ".type").ToNonNullString();
+            : this.lazyRootElement.Value.GetPropertyByPath("definitions." + element.GetProperty("$ref").ToNonNullString().Split('/')[2] + ".type").ToNonNullString();
         }
 
-        private static string? TryGetDescription(JsonElement element)
+        private string? TryGetDescription(JsonElement element)
         {
-            if (element.TryGetProperty("metadata", out var metdataElement) &&
-                metdataElement.TryGetProperty("description", out var descriptionElement))
-            {
+            if(element.TryGetProperty("metadata", out _) && element.GetProperty("metadata").TryGetProperty("description", out var descriptionElement)){
                 return descriptionElement.ToNonNullString();
             }
-
+            if(element.TryGetProperty("$ref", out var refElement)){
+              return this.lazyRootElement.Value.GetPropertyByPath("definitions." + refElement.ToNonNullString().Split('/')[2] + ".type").ToNonNullString();
+            }
             return null;
         }
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -40,12 +40,6 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             this.lazyParameters = new(() => !lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement)
                 ? Enumerable.Empty<MainArmTemplateParameter>()
                 : parametersElement.EnumerateObject().Select(ToParameter));
-            this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
-                    ? Enumerable.Empty<MainArmTemplateOutput>()
-                    : outputsElement.EnumerateObject().Select(ToOutput));
-            this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
-                    ? Enumerable.Empty<MainArmTemplateOutput>()
-                    : outputsElement.EnumerateObject().Select(ToOutput));
             this.lazyTemplateHash = new(() => lazyRootElement.Value.GetPropertyByPath("metadata._generator.templateHash").ToNonNullString());
         }
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -140,7 +140,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private JsonElement LookupRef(JsonElement element)
         {
-            return this.lazyRootElement.Value.GetProperty("definitions").GetProperty(element.GetProperty("$ref").ToNonNullString().Split('/')[2]);
+            return this.RootElement.GetProperty("definitions").GetProperty(element.GetProperty("$ref").ToNonNullString().Split('/')[2]);
         }
 
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -130,7 +130,8 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             }
 
             // The order of the checks allow the user to optionally override the default description for a user defined type
-            if(element.TryGetProperty("$ref", out var _)){
+            if(element.TryGetProperty("$ref", out var _))
+            {
                 return TryGetDescription(LookupRef(element));
             }
 

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -40,42 +40,51 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             this.Content = content;
 
             this.lazyRootElement = new(() => JsonElementFactory.CreateElement(content));
-            // this.lazyParameters = new(() => !lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement)
-            //     ? Enumerable.Empty<MainArmTemplateParameter>()
-            //     : parametersElement.EnumerateObject().Select(ToParameter));
-            // this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
-            //         ? Enumerable.Empty<MainArmTemplateOutput>()
-            //         : outputsElement.EnumerateObject().Select(ToOutput));
+            this.lazyParameters = new(() => !lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement)
+                ? Enumerable.Empty<MainArmTemplateParameter>()
+                : parametersElement.EnumerateObject().Select(ToParameter));
+            this.lazyOutputs = new(() => !lazyRootElement.Value.TryGetProperty("outputs", out var outputsElement)
+                    ? Enumerable.Empty<MainArmTemplateOutput>()
+                    : outputsElement.EnumerateObject().Select(ToOutput));
             this.lazyTemplateHash = new(() => lazyRootElement.Value.GetPropertyByPath("metadata._generator.templateHash").ToNonNullString());
 
-            var armTemplate = new ArmTemplateSemanticModel(SourceFileFactory.CreateArmTemplateFile(new Uri(System.IO.Path.GetFullPath(path)), content));
+            // var armTemplate = new ArmTemplateSemanticModel(SourceFileFactory.CreateArmTemplateFile(new Uri(System.IO.Path.GetFullPath(path)), content));
 
-            this.lazyParameters = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateParameter>>(() =>
-            {
-                return armTemplate.Parameters.Select(kv =>
-                    new MainArmTemplateParameter(kv.Value.Name, GetPrimitiveTypeName(kv.Value.TypeReference), kv.Value.IsRequired, kv.Value.Description));
-            });
-            this.lazyOutputs = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateOutput>>(() =>
-            {
-                return armTemplate.Outputs.Select(kv =>
-                    new MainArmTemplateOutput(kv.Name, GetPrimitiveTypeName(kv.TypeReference), kv.Description));
-            });
+            // this.lazyParameters = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateParameter>>(() =>
+            // {
+            //     return armTemplate.Parameters.Select(kv =>
+            //         new MainArmTemplateParameter(kv.Value.Name, GetPrimitiveTypeName(kv.Value.TypeReference), kv.Value.IsRequired, kv.Value.Description));
+            // });
+
+            // this.lazyParameters = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateParameter>>(() =>
+            // {
+            //     var parameters = armTemplate.Parameters;
+            //     lazyRootElement.Value.TryGetProperty("parameters", out var parametersElement);
+            //     return parametersElement.EnumerateObject().Select(parameter =>
+            //          new MainArmTemplateParameter(parameters[parameter.Name].Name, GetPrimitiveTypeName(parameters[parameter.Name].TypeReference), parameters[parameter.Name].IsRequired, parameters[parameter.Name].Description));
+            // });
+            // this.lazyOutputs = new Lazy<IEnumerable<Bicep.RegistryModuleTool.ModuleFiles.MainArmTemplateOutput>>(() =>
+            // {
+            //     return armTemplate.Outputs.Select(kv =>
+            //         new MainArmTemplateOutput(kv.Name, GetPrimitiveTypeName(kv.TypeReference), kv.Description));
+            // });
         }
 
-        private static string GetPrimitiveTypeName(ITypeReference typeRef) => typeRef.Type switch {
-            StringType or StringLiteralType => "string",
-            UnionType unionOfStrings when unionOfStrings.Members.All(m => m.Type is StringLiteralType || m.Type is StringType)
-                => "string",
-            IntegerType or IntegerLiteralType => "int",
-            UnionType unionOfInts when unionOfInts.Members.All(m => m.Type is IntegerLiteralType || m.Type is IntegerType)
-                => "int",
-            BooleanType or BooleanLiteralType => "bool",
-            UnionType unionOfBools when unionOfBools.Members.All(m => m.Type is BooleanLiteralType || m.Type is BooleanType)
-                => "bool",
-            ObjectType => "object",
-            ArrayType => "array",
-            TypeSymbol otherwise => throw new InvalidOperationException($"Unable to determine primitive type of {otherwise.Name}"),
-        };
+        // private static string GetPrimitiveTypeName(ITypeReference typeRef) => typeRef.Type switch {
+        //     StringType or StringLiteralType
+        //         => typeRef.Type.ValidationFlags.HasFlag(TypeSymbolValidationFlags.IsSecure) ? "securestring" : "string",
+        //     UnionType unionOfStrings when unionOfStrings.Members.All(m => m.Type is StringLiteralType || m.Type is StringType)
+        //         => "string",
+        //     IntegerType or IntegerLiteralType => "int",
+        //     UnionType unionOfInts when unionOfInts.Members.All(m => m.Type is IntegerLiteralType || m.Type is IntegerType)
+        //         => "int",
+        //     BooleanType or BooleanLiteralType => "bool",
+        //     UnionType unionOfBools when unionOfBools.Members.All(m => m.Type is BooleanLiteralType || m.Type is BooleanType)
+        //         => "bool",
+        //     ObjectType => "object",
+        //     ArrayType => "array",
+        //     TypeSymbol otherwise => throw new InvalidOperationException($"Unable to determine primitive type of {otherwise.Name}"),
+        // };
 
         public string Content { get; }
 
@@ -124,6 +133,25 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
             fileSystem.File.WriteAllText(this.Path, this.Content);
 
             return this;
+        }
+
+        private MainArmTemplateParameter ToParameter(JsonProperty parameterProperty)
+        {
+            string name = parameterProperty.Name;
+            string type = GetTypeFromDefinition(parameterProperty.Value);
+            bool required = !parameterProperty.Value.TryGetProperty("defaultValue", out _);
+            string? description = TryGetDescription(parameterProperty.Value);
+
+            return new(name, type, required, description);
+        }
+
+        private MainArmTemplateOutput ToOutput(JsonProperty outputProperty)
+        {
+            string name = outputProperty.Name;
+            string type = GetTypeFromDefinition(outputProperty.Value);
+            string? description = TryGetDescription(outputProperty.Value);
+
+            return new(name, type, description);
         }
 
         private string GetTypeFromDefinition(JsonElement element)

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -123,7 +123,8 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
         private string? TryGetDescription(JsonElement element)
         {
             if(element.TryGetProperty("metadata", out var metdataElement) &&
-                metdataElement.TryGetProperty("description", out var descriptionElement)){
+                metdataElement.TryGetProperty("description", out var descriptionElement))
+            {
                 return descriptionElement.ToNonNullString();
             }
 


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10395)