### PR TITLE
Resource Type parameters should generate BCP120

### DIFF
--- a/src/Bicep.Core/Semantics/ParameterSymbol.cs
+++ b/src/Bicep.Core/Semantics/ParameterSymbol.cs
@@ -31,6 +31,8 @@ namespace Bicep.Core.Semantics
             }
         }
 
+        public bool IsCollection => this.Type is ArrayType;
+
         public ResourceType? TryGetResourceType() => ResourceType.TryUnwrap(this.Type);
 
         public ResourceTypeReference? TryGetResourceTypeReference() => this.TryGetResourceType()?.TypeReference;

--- a/src/Bicep.Core/TypeSystem/ResourceTypeResolver.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceTypeResolver.cs
@@ -73,6 +73,8 @@ namespace Bicep.Core.TypeSystem
                 (resourceSymbol, this.existingResourceBodyTypeOverrides.GetValueOrDefault(resourceSymbol) ?? resourceSymbol.TryGetBodyObjectType()),
             ModuleSymbol moduleSymbol when moduleSymbol.IsCollection == isCollection =>
                 (moduleSymbol, moduleSymbol.TryGetBodyObjectType()),
+            ParameterSymbol parameterSymbol when parameterSymbol.IsCollection == isCollection =>
+                    (parameterSymbol, parameterSymbol.TryGetBodyObjectType()),
             _ => (null, null),
         };
 


### PR DESCRIPTION
Fixes https://github.com/Azure/bicep/issues/10400

Technically since the resource already exists there might be a way to avoid generating BCP120. This seemed like the correct thing to do without some ARM voodoo. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10401)