### PR TITLE
Formatter v2 part 3: Get static token texts with a switch expression

### DIFF
--- a/src/Bicep.Core.UnitTests/Parsing/LexerTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/LexerTests.cs
@@ -32,7 +32,7 @@ namespace Bicep.Core.UnitTests.Parsing
         [DataRow(@"'\u{D801}\u{DC37}'", "\uD801\uDC37")]
         public void TryGetStringValue_ValidStringLiteralToken_ShouldCalculateValueCorrectly(string literalText, string expectedValue)
         {
-            var token = new Token(TokenType.StringComplete, new TextSpan(0, literalText.Length), literalText, Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
+            var token = new FreeformToken(TokenType.StringComplete, new TextSpan(0, literalText.Length), literalText, Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
 
             var actual = Lexer.TryGetStringValue(token);
 
@@ -42,7 +42,7 @@ namespace Bicep.Core.UnitTests.Parsing
         [TestMethod]
         public void TryGetStringValue_WrongTokenType_ShouldReturnNull()
         {
-            var token = new Token(TokenType.Integer, new TextSpan(0, 2), "12", Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
+            var token = new FreeformToken(TokenType.Integer, new TextSpan(0, 2), "12", Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
 
             Lexer.TryGetStringValue(token).Should().BeNull();
         }
@@ -70,7 +70,7 @@ namespace Bicep.Core.UnitTests.Parsing
         [DataRow(@"'prefix\u{FFFFFFFFsufffix'")]
         public void GetStringValue_InvalidStringLiteralToken_ShouldReturnNull(string literalText)
         {
-            var token = new Token(TokenType.StringComplete, new TextSpan(0, literalText.Length), literalText, Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
+            var token = new FreeformToken(TokenType.StringComplete, new TextSpan(0, literalText.Length), literalText, Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
 
             Lexer.TryGetStringValue(token).Should().BeNull();
         }

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxFactsTests.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxFactsTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+using Bicep.Core.Syntax;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.UnitTests.Syntax
+{
+    [TestClass]
+    public class SyntaxFactsTests
+    {
+        [TestMethod]
+        public void GetText_FreeformTokenType_ReturnsNull()
+        {
+            var texts = Enum.GetValues<TokenType>()
+                .Where(SyntaxFacts.IsFreeform)
+                .Select(SyntaxFacts.GetText);
+
+            texts.Should().AllBe(null);
+        }
+
+        [TestMethod]
+        public void GetText_NonFreeformTokenType_ReturnsText()
+        {
+            var texts = Enum.GetValues<TokenType>()
+                .Where(x => !SyntaxFacts.IsFreeform(x))
+                .Select(SyntaxFacts.GetText);
+
+            texts.Should().AllSatisfy(x => x.Should().NotBe(null));
+        }
+    }
+}

--- a/src/Bicep.Core.UnitTests/TypeSystem/OperatorTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/OperatorTests.cs
@@ -21,12 +21,6 @@ namespace Bicep.Core.UnitTests.TypeSystem
         }
 
         [TestMethod]
-        public void AllBinaryOperatorsShouldHaveValidText()
-        {
-            RunTextTest(Operators.BinaryOperatorToText);
-        }
-
-        [TestMethod]
         public void AllUnaryOperatorsShouldMapToTokens()
         {
             RunTokenTest(Operators.TokenTypeToUnaryOperator);

--- a/src/Bicep.Core.UnitTests/Utils/TestSyntaxFactory.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestSyntaxFactory.cs
@@ -38,7 +38,9 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static UnaryOperationSyntax CreateUnaryMinus(SyntaxBase operand) => new(CreateToken(TokenType.Minus), operand);
 
-        public static Token CreateToken(TokenType type, string text = "") => new(type, TextSpan.Nil, text, ImmutableArray.Create<SyntaxTrivia>(), ImmutableArray.Create<SyntaxTrivia>());
+        public static Token CreateToken(TokenType type) => new(type, TextSpan.Nil, ImmutableArray.Create<SyntaxTrivia>(), ImmutableArray.Create<SyntaxTrivia>());
+
+        public static FreeformToken CreateToken(TokenType type, string text) => new(type, TextSpan.Nil, text, ImmutableArray.Create<SyntaxTrivia>(), ImmutableArray.Create<SyntaxTrivia>());
 
         private static IEnumerable<SyntaxBase> CreateChildrenWithNewLines(IEnumerable<SyntaxBase> children)
         {

--- a/src/Bicep.Core/Parsing/FreeformToken.cs
+++ b/src/Bicep.Core/Parsing/FreeformToken.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Parsing
+{
+    public class FreeformToken : Token
+    {
+        public FreeformToken(TokenType type, TextSpan span, string text, IEnumerable<SyntaxTrivia> leadingTrivia, IEnumerable<SyntaxTrivia> trailingTrivia)
+            : base(type, span, leadingTrivia, trailingTrivia)
+        {
+            this.Text = text;
+        }
+
+        public override string Text { get; }
+    }
+}

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -462,7 +462,7 @@ namespace Bicep.Core.Parsing
 
             if (!string.IsNullOrWhiteSpace(text))
             {
-                return new Token(TokenType.StringComplete, textWindow.GetSpan(), textWindow.GetText(), Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
+                return new FreeformToken(TokenType.StringComplete, textWindow.GetSpan(), textWindow.GetText(), Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
             }
 
             return null;
@@ -498,7 +498,10 @@ namespace Bicep.Core.Parsing
             var includeComments = tokenType.GetCommentStickiness() >= CommentStickiness.Trailing;
             var trailingTrivia = ScanTrailingTrivia(includeComments).ToImmutableArray();
 
-            var token = new Token(tokenType, tokenSpan, tokenText, leadingTrivia, trailingTrivia);
+            var token = SyntaxFacts.GetText(tokenType) is not null
+                ? new Token(tokenType, tokenSpan, leadingTrivia, trailingTrivia)
+                : new FreeformToken(tokenType, tokenSpan, tokenText, leadingTrivia, trailingTrivia);
+
             this.tokens.Add(token);
         }
 

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -348,7 +348,7 @@ namespace Bicep.Core.Parsing
             int start = span.Position;
             int end = span.GetEndPosition();
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             sb.Append(textWindow.GetText());
 
             textWindow.Reset();
@@ -460,9 +460,9 @@ namespace Bicep.Core.Parsing
         {
             var text = textWindow.GetText();
 
-            if (!string.IsNullOrWhiteSpace(text))
+            if (text.Length > 0)
             {
-                return new FreeformToken(TokenType.StringComplete, textWindow.GetSpan(), textWindow.GetText(), Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
+                return new FreeformToken(TokenType.StringComplete, textWindow.GetSpan(), text.ToString(), Enumerable.Empty<SyntaxTrivia>(), Enumerable.Empty<SyntaxTrivia>());
             }
 
             return null;
@@ -482,13 +482,15 @@ namespace Bicep.Core.Parsing
 
             if (tokenType == TokenType.Unrecognized)
             {
-                if (tokenText == "\"")
+                var text = tokenText.ToString();
+
+                if (text == "\"")
                 {
-                    AddDiagnostic(b => b.DoubleQuoteToken(tokenText));
+                    AddDiagnostic(b => b.DoubleQuoteToken(text));
                 }
                 else
                 {
-                    AddDiagnostic(b => b.UnrecognizedToken(tokenText));
+                    AddDiagnostic(b => b.UnrecognizedToken(text));
                 }
             }
 
@@ -498,9 +500,9 @@ namespace Bicep.Core.Parsing
             var includeComments = tokenType.GetCommentStickiness() >= CommentStickiness.Trailing;
             var trailingTrivia = ScanTrailingTrivia(includeComments).ToImmutableArray();
 
-            var token = SyntaxFacts.GetText(tokenType) is not null
-                ? new Token(tokenType, tokenSpan, leadingTrivia, trailingTrivia)
-                : new FreeformToken(tokenType, tokenSpan, tokenText, leadingTrivia, trailingTrivia);
+            var token = SyntaxFacts.IsFreeform(tokenType)
+                ? new FreeformToken(tokenType, tokenSpan, tokenText.ToString(), leadingTrivia, trailingTrivia)
+                : new Token(tokenType, tokenSpan, leadingTrivia, trailingTrivia);
 
             this.tokens.Add(token);
         }
@@ -523,7 +525,7 @@ namespace Bicep.Core.Parsing
                 break;
             }
 
-            return new SyntaxTrivia(SyntaxTriviaType.Whitespace, textWindow.GetSpan(), textWindow.GetText());
+            return new SyntaxTrivia(SyntaxTriviaType.Whitespace, textWindow.GetSpan(), textWindow.GetText().ToString());
         }
 
         private SyntaxTrivia ScanSingleLineComment()
@@ -544,7 +546,7 @@ namespace Bicep.Core.Parsing
                 textWindow.Advance();
             }
 
-            return new SyntaxTrivia(SyntaxTriviaType.SingleLineComment, textWindow.GetSpan(), textWindow.GetText());
+            return new SyntaxTrivia(SyntaxTriviaType.SingleLineComment, textWindow.GetSpan(), textWindow.GetText().ToString());
         }
 
         private SyntaxTrivia ScanMultiLineComment()
@@ -583,7 +585,7 @@ namespace Bicep.Core.Parsing
                 }
             }
 
-            return new SyntaxTrivia(SyntaxTriviaType.MultiLineComment, textWindow.GetSpan(), textWindow.GetText());
+            return new SyntaxTrivia(SyntaxTriviaType.MultiLineComment, textWindow.GetSpan(), textWindow.GetText().ToString());
         }
 
         private void ScanNewLine()
@@ -812,7 +814,7 @@ namespace Bicep.Core.Parsing
 
         private TokenType GetIdentifierTokenType()
         {
-            var identifier = textWindow.GetText();
+            var identifier = textWindow.GetText().ToString();
 
             if (LanguageConstants.Keywords.TryGetValue(identifier, out var tokenType))
             {

--- a/src/Bicep.Core/Parsing/SlidingTextWindow.cs
+++ b/src/Bicep.Core/Parsing/SlidingTextWindow.cs
@@ -59,8 +59,8 @@ namespace Bicep.Core.Parsing
         /// </summary>
         public int GetAbsolutePosition() => position + offset;
 
-        public string GetText()
-            => text.Substring(position, offset);
+        public ReadOnlySpan<char> GetText()
+            => text.AsSpan(position, offset);
 
         private int position;
 

--- a/src/Bicep.Core/Parsing/Token.cs
+++ b/src/Bicep.Core/Parsing/Token.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -11,11 +12,10 @@ namespace Bicep.Core.Parsing
     [DebuggerDisplay("{Type} = {Text}")]
     public class Token : SyntaxBase
     {
-        public Token(TokenType type, TextSpan span, string text, IEnumerable<SyntaxTrivia> leadingTrivia, IEnumerable<SyntaxTrivia> trailingTrivia)
+        public Token(TokenType type, TextSpan span, IEnumerable<SyntaxTrivia> leadingTrivia, IEnumerable<SyntaxTrivia> trailingTrivia)
         {
             Type = type;
             Span = span;
-            Text = text;
             LeadingTrivia = leadingTrivia.ToImmutableArray();
             TrailingTrivia = trailingTrivia.ToImmutableArray();
         }
@@ -26,7 +26,7 @@ namespace Bicep.Core.Parsing
 
         public override TextSpan Span { get; }
 
-        public string Text { get; }
+        public virtual string Text => SyntaxFacts.GetText(this.Type) ?? throw new InvalidOperationException($"Unable to get text of token type '{this.Type}'.");
 
         public ImmutableArray<SyntaxTrivia> LeadingTrivia { get; }
 

--- a/src/Bicep.Core/Syntax/Operators.cs
+++ b/src/Bicep.Core/Syntax/Operators.cs
@@ -28,26 +28,6 @@ namespace Bicep.Core.Syntax
             [TokenType.DoubleQuestion] = BinaryOperator.Coalesce
         }.ToImmutableDictionary();
 
-        public static readonly ImmutableDictionary<BinaryOperator, string> BinaryOperatorToText = new Dictionary<BinaryOperator, string>
-        {
-            [BinaryOperator.LogicalOr] = "||",
-            [BinaryOperator.LogicalAnd] = "&&",
-            [BinaryOperator.Equals] = "==",
-            [BinaryOperator.NotEquals] = "!=",
-            [BinaryOperator.EqualsInsensitive] = "=~",
-            [BinaryOperator.NotEqualsInsensitive] = "!~",
-            [BinaryOperator.LessThan] = "<",
-            [BinaryOperator.LessThanOrEqual] = "<=",
-            [BinaryOperator.GreaterThan] = ">",
-            [BinaryOperator.GreaterThanOrEqual] = ">=",
-            [BinaryOperator.Add] = "+",
-            [BinaryOperator.Subtract] = "-",
-            [BinaryOperator.Multiply] = "*",
-            [BinaryOperator.Divide] = "/",
-            [BinaryOperator.Modulo] = "%",
-            [BinaryOperator.Coalesce] = "??"
-        }.ToImmutableDictionary();
-
         public static readonly ImmutableDictionary<TokenType, UnaryOperator> TokenTypeToUnaryOperator = new Dictionary<TokenType, UnaryOperator>
         {
             [TokenType.Exclamation] = UnaryOperator.Not,

--- a/src/Bicep.Core/Syntax/SyntaxBase.cs
+++ b/src/Bicep.Core/Syntax/SyntaxBase.cs
@@ -74,7 +74,8 @@ namespace Bicep.Core.Syntax
             }
 
             var syntaxType = syntax.GetType();
-            if (expectedTypes.Any(expectedType => syntaxType == expectedType) == false)
+
+            if (expectedTypes.Any(syntaxType.IsAssignableTo) == false)
             {
                 throw new ArgumentException($"{parameterName} is of an unexpected type {syntaxType.Name}. Expected types: {expectedTypes.Select(t => t.Name).ConcatString(", ")}");
             }

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -20,16 +20,26 @@ namespace Bicep.Core.Syntax
 
         public static readonly SkippedTriviaSyntax EmptySkippedTrivia = new(TextSpan.Nil, Enumerable.Empty<SyntaxBase>());
 
-        public static Token CreateToken(TokenType tokenType, string text = "", IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null)
+        public static Token CreateToken(TokenType tokenType, IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null)
         {
-            text = string.IsNullOrEmpty(text) ? TryGetTokenText(tokenType) : text;
+            leadingTrivia ??= EmptyTrivia;
+            trailingTrivia ??= EmptyTrivia;
+
+            return new(tokenType, TextSpan.Nil, leadingTrivia, trailingTrivia);
+        }
+
+        public static FreeformToken CreateFreeformToken(TokenType tokenType, string text, IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null)
+        {
             leadingTrivia ??= EmptyTrivia;
             trailingTrivia ??= EmptyTrivia;
 
             return new(tokenType, TextSpan.Nil, text, leadingTrivia, trailingTrivia);
         }
 
-        public static IdentifierSyntax CreateIdentifier(string text) => new(CreateToken(TokenType.Identifier, text));
+        public static FreeformToken CreateIdentifierToken(string text, IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null) =>
+            CreateFreeformToken(TokenType.Identifier, text, leadingTrivia, trailingTrivia);
+
+        public static IdentifierSyntax CreateIdentifier(string text) => new(CreateFreeformToken(TokenType.Identifier, text));
 
         public static VariableAccessSyntax CreateVariableAccess(string text) => new(CreateIdentifier(text));
 
@@ -39,54 +49,54 @@ namespace Bicep.Core.Syntax
                 Interleave(variables.Select(x => new LocalVariableSyntax(x)), () => CommaToken),
                 SyntaxFactory.RightParenToken);
 
-        public static Token DoubleNewlineToken => CreateToken(TokenType.NewLine, Environment.NewLine + Environment.NewLine);
-        public static Token NewlineToken => CreateToken(TokenType.NewLine, Environment.NewLine);
+        public static Token DoubleNewlineToken => CreateFreeformToken(TokenType.NewLine, Environment.NewLine + Environment.NewLine);
+        public static Token NewlineToken => CreateFreeformToken(TokenType.NewLine, Environment.NewLine);
         public static Token GetNewlineToken(IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null)
-            => CreateToken(TokenType.NewLine, Environment.NewLine, leadingTrivia, trailingTrivia);
-        public static Token AtToken => CreateToken(TokenType.At, "@");
-        public static Token LeftBraceToken => CreateToken(TokenType.LeftBrace, "{");
-        public static Token RightBraceToken => CreateToken(TokenType.RightBrace, "}");
-        public static Token LeftParenToken => CreateToken(TokenType.LeftParen, "(");
-        public static Token RightParenToken => CreateToken(TokenType.RightParen, ")");
-        public static Token LeftSquareToken => CreateToken(TokenType.LeftSquare, "[");
-        public static Token RightSquareToken => CreateToken(TokenType.RightSquare, "]");
+            => CreateFreeformToken(TokenType.NewLine, Environment.NewLine, leadingTrivia, trailingTrivia);
+        public static Token AtToken => CreateToken(TokenType.At);
+        public static Token LeftBraceToken => CreateToken(TokenType.LeftBrace);
+        public static Token RightBraceToken => CreateToken(TokenType.RightBrace);
+        public static Token LeftParenToken => CreateToken(TokenType.LeftParen);
+        public static Token RightParenToken => CreateToken(TokenType.RightParen);
+        public static Token LeftSquareToken => CreateToken(TokenType.LeftSquare);
+        public static Token RightSquareToken => CreateToken(TokenType.RightSquare);
         public static Token CommaToken => GetCommaToken();
         public static Token GetCommaToken(IEnumerable<SyntaxTrivia>? leadingTrivia = null, IEnumerable<SyntaxTrivia>? trailingTrivia = null)
-            => CreateToken(TokenType.Comma, ",", leadingTrivia, trailingTrivia);
-        public static Token DotToken => CreateToken(TokenType.Dot, ".");
-        public static Token QuestionToken => CreateToken(TokenType.Question, "?");
-        public static Token ColonToken => CreateToken(TokenType.Colon, ":");
-        public static Token SemicolonToken => CreateToken(TokenType.Semicolon, ";");
-        public static Token AssignmentToken => CreateToken(TokenType.Assignment, "=");
-        public static Token PlusToken => CreateToken(TokenType.Plus, "+");
-        public static Token MinusToken => CreateToken(TokenType.Minus, "-");
-        public static Token AsteriskToken => CreateToken(TokenType.Asterisk, "*");
-        public static Token SlashToken => CreateToken(TokenType.Slash, "/");
-        public static Token ModuloToken => CreateToken(TokenType.Modulo, "%");
-        public static Token ExclamationToken => CreateToken(TokenType.Exclamation, "!");
-        public static Token LessThanToken => CreateToken(TokenType.LessThan, "<");
-        public static Token GreaterThanToken => CreateToken(TokenType.GreaterThan, ">");
-        public static Token LessThanOrEqualToken => CreateToken(TokenType.LessThanOrEqual, "<=");
-        public static Token GreaterThanOrEqualToken => CreateToken(TokenType.GreaterThanOrEqual, ">=");
-        public static Token EqualsToken => CreateToken(TokenType.Equals, "==");
-        public static Token NotEqualsToken => CreateToken(TokenType.NotEquals, "!=");
-        public static Token EqualsInsensitiveToken => CreateToken(TokenType.EqualsInsensitive, "=~");
-        public static Token NotEqualsInsensitiveToken => CreateToken(TokenType.NotEqualsInsensitive, "!~");
-        public static Token LogicalAndToken => CreateToken(TokenType.LogicalAnd, "&&");
-        public static Token LogicalOrToken => CreateToken(TokenType.LogicalOr, "||");
-        public static Token TrueKeywordToken => CreateToken(TokenType.TrueKeyword, "true");
-        public static Token FalseKeywordToken => CreateToken(TokenType.FalseKeyword, "false");
-        public static Token NullKeywordToken => CreateToken(TokenType.NullKeyword, "null");
-        public static Token ArrowToken => CreateToken(TokenType.Arrow, "=>");
+            => CreateToken(TokenType.Comma, leadingTrivia, trailingTrivia);
+        public static Token DotToken => CreateToken(TokenType.Dot);
+        public static Token QuestionToken => CreateToken(TokenType.Question);
+        public static Token ColonToken => CreateToken(TokenType.Colon);
+        public static Token SemicolonToken => CreateToken(TokenType.Semicolon);
+        public static Token AssignmentToken => CreateToken(TokenType.Assignment);
+        public static Token PlusToken => CreateToken(TokenType.Plus);
+        public static Token MinusToken => CreateToken(TokenType.Minus);
+        public static Token AsteriskToken => CreateToken(TokenType.Asterisk);
+        public static Token SlashToken => CreateToken(TokenType.Slash);
+        public static Token ModuloToken => CreateToken(TokenType.Modulo);
+        public static Token ExclamationToken => CreateToken(TokenType.Exclamation);
+        public static Token LessThanToken => CreateToken(TokenType.LessThan);
+        public static Token GreaterThanToken => CreateToken(TokenType.GreaterThan);
+        public static Token LessThanOrEqualToken => CreateToken(TokenType.LessThanOrEqual);
+        public static Token GreaterThanOrEqualToken => CreateToken(TokenType.GreaterThanOrEqual);
+        public static Token EqualsToken => CreateToken(TokenType.Equals);
+        public static Token NotEqualsToken => CreateToken(TokenType.NotEquals);
+        public static Token EqualsInsensitiveToken => CreateToken(TokenType.EqualsInsensitive);
+        public static Token NotEqualsInsensitiveToken => CreateToken(TokenType.NotEqualsInsensitive);
+        public static Token LogicalAndToken => CreateToken(TokenType.LogicalAnd);
+        public static Token LogicalOrToken => CreateToken(TokenType.LogicalOr);
+        public static Token TrueKeywordToken => CreateToken(TokenType.TrueKeyword);
+        public static Token FalseKeywordToken => CreateToken(TokenType.FalseKeyword);
+        public static Token NullKeywordToken => CreateToken(TokenType.NullKeyword);
+        public static Token ArrowToken => CreateToken(TokenType.Arrow);
 
         public static ObjectPropertySyntax CreateObjectProperty(string key, SyntaxBase value)
         {
             if (value is SkippedTriviaSyntax)
             {
-                return new ObjectPropertySyntax(CreateObjectPropertyKey(key), CreateToken(TokenType.Colon, ":", EmptyTrivia), value);
+                return new ObjectPropertySyntax(CreateObjectPropertyKey(key), CreateToken(TokenType.Colon, EmptyTrivia), value);
             }
 
-            return new ObjectPropertySyntax(CreateObjectPropertyKey(key), CreateToken(TokenType.Colon, ":", EmptyTrivia, SingleSpaceTrivia), value);
+            return new ObjectPropertySyntax(CreateObjectPropertyKey(key), CreateToken(TokenType.Colon, EmptyTrivia, SingleSpaceTrivia), value);
         }
 
         public static ObjectSyntax CreateObject(IEnumerable<ObjectPropertySyntax> properties)
@@ -115,7 +125,7 @@ namespace Bicep.Core.Syntax
                 CreateIdentifier("range"),
                 LeftParenToken,
                 new SyntaxBase[] {
-                    new FunctionArgumentSyntax(new IntegerLiteralSyntax(CreateToken(TokenType.Integer, "0"), 0)),
+                    new FunctionArgumentSyntax(new IntegerLiteralSyntax(CreateFreeformToken(TokenType.Integer, "0"), 0)),
                     CommaToken,
                     new FunctionArgumentSyntax(count),
                 },
@@ -129,9 +139,9 @@ namespace Bicep.Core.Syntax
             // generates "[for <identifier> in <inSyntax>: <body>]"
             return new(
                 LeftSquareToken,
-                CreateToken(TokenType.Identifier, "for"),
-                new LocalVariableSyntax(new IdentifierSyntax(CreateToken(TokenType.Identifier, indexIdentifier))),
-                CreateToken(TokenType.Identifier, "in"),
+                CreateFreeformToken(TokenType.Identifier, "for"),
+                new LocalVariableSyntax(new IdentifierSyntax(CreateFreeformToken(TokenType.Identifier, indexIdentifier))),
+                CreateFreeformToken(TokenType.Identifier, "in"),
                 inSyntax,
                 ColonToken,
                 body,
@@ -172,7 +182,7 @@ namespace Bicep.Core.Syntax
             return CreateStringLiteral(text);
         }
 
-        public static IntegerLiteralSyntax CreateIntegerLiteral(ulong value) => new(CreateToken(TokenType.Integer, value.ToString()), value);
+        public static IntegerLiteralSyntax CreateIntegerLiteral(ulong value) => new(CreateFreeformToken(TokenType.Integer, value.ToString()), value);
 
         public static UnaryOperationSyntax CreateNegativeIntegerLiteral(ulong value) => new(MinusToken, CreateIntegerLiteral(value));
 
@@ -219,14 +229,14 @@ namespace Bicep.Core.Syntax
         public static StringSyntax CreateStringLiteralWithComment(string value, string comment)
         {
             var trailingTrivia = new SyntaxTrivia(SyntaxTriviaType.MultiLineComment, TextSpan.Nil, $"/*{comment.Replace("*/", "*\\/")}*/");
-            var stringToken = CreateToken(TokenType.StringComplete, $"'{EscapeBicepString(value)}'", EmptyTrivia, trailingTrivia.AsEnumerable());
+            var stringToken = CreateFreeformToken(TokenType.StringComplete, $"'{EscapeBicepString(value)}'", EmptyTrivia, trailingTrivia.AsEnumerable());
 
             return new StringSyntax(stringToken.AsEnumerable(), Enumerable.Empty<SyntaxBase>(), value.AsEnumerable());
         }
 
         public static Token CreateStringLiteralToken(string value)
         {
-            return CreateToken(TokenType.StringComplete, $"'{EscapeBicepString(value)}'");
+            return CreateFreeformToken(TokenType.StringComplete, $"'{EscapeBicepString(value)}'");
         }
 
         public static StringSyntax CreateInterpolatedKey(SyntaxBase syntax)
@@ -244,10 +254,10 @@ namespace Bicep.Core.Syntax
         {
             return (isStart, isEnd) switch
             {
-                (true, true) => CreateToken(TokenType.StringComplete, $"'{EscapeBicepString(value)}'"),
-                (true, false) => CreateToken(TokenType.StringLeftPiece, $"'{EscapeBicepString(value)}${{"),
-                (false, false) => CreateToken(TokenType.StringMiddlePiece, $"}}{EscapeBicepString(value)}${{"),
-                (false, true) => CreateToken(TokenType.StringRightPiece, $"}}{EscapeBicepString(value)}'"),
+                (true, true) => CreateFreeformToken(TokenType.StringComplete, $"'{EscapeBicepString(value)}'"),
+                (true, false) => CreateFreeformToken(TokenType.StringLeftPiece, $"'{EscapeBicepString(value)}${{"),
+                (false, false) => CreateFreeformToken(TokenType.StringMiddlePiece, $"}}{EscapeBicepString(value)}${{"),
+                (false, true) => CreateFreeformToken(TokenType.StringRightPiece, $"}}{EscapeBicepString(value)}'"),
             };
         }
 
@@ -281,43 +291,6 @@ namespace Bicep.Core.Syntax
             .Replace("\t", "\\t")
             .Replace("${", "\\${")
             .Replace("'", "\\'");
-
-        private static string TryGetTokenText(TokenType tokenType) => tokenType switch
-        {
-            TokenType.At => "@",
-            TokenType.LeftBrace => "{",
-            TokenType.RightBrace => "}",
-            TokenType.LeftParen => "(",
-            TokenType.RightParen => ")",
-            TokenType.LeftSquare => "[",
-            TokenType.RightSquare => "]",
-            TokenType.Comma => ",",
-            TokenType.Dot => ".",
-            TokenType.Question => "?",
-            TokenType.Colon => ":",
-            TokenType.Semicolon => ";",
-            TokenType.Assignment => "=",
-            TokenType.Plus => "+",
-            TokenType.Minus => "-",
-            TokenType.Asterisk => "*",
-            TokenType.Slash => "/",
-            TokenType.Modulo => "%",
-            TokenType.Exclamation => "!",
-            TokenType.LessThan => "<",
-            TokenType.GreaterThan => ">",
-            TokenType.LessThanOrEqual => "<=",
-            TokenType.GreaterThanOrEqual => ">=",
-            TokenType.Equals => "==",
-            TokenType.NotEquals => "!=",
-            TokenType.EqualsInsensitive => "=~",
-            TokenType.NotEqualsInsensitive => "!~",
-            TokenType.LogicalAnd => "&&",
-            TokenType.LogicalOr => "||",
-            TokenType.TrueKeyword => "true",
-            TokenType.FalseKeyword => "false",
-            TokenType.NullKeyword => "null",
-            _ => ""
-        };
 
         public static SyntaxBase FlattenStringOperations(SyntaxBase original)
         {

--- a/src/Bicep.Core/Syntax/SyntaxFacts.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFacts.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Syntax
+{
+    public static class SyntaxFacts
+    {
+        public static string? GetText(TokenType type) => type switch
+        {
+            TokenType.At => "@",
+            TokenType.LeftBrace => "{",
+            TokenType.RightBrace => "}",
+            TokenType.LeftParen => "(",
+            TokenType.RightParen => ")",
+            TokenType.LeftSquare => "[",
+            TokenType.RightSquare => "]",
+            TokenType.Comma => ",",
+            TokenType.Dot => ".",
+            TokenType.Question => "?",
+            TokenType.Colon => ":",
+            TokenType.Semicolon => ";",
+            TokenType.Assignment => "=",
+            TokenType.Plus => "+",
+            TokenType.Minus => "-",
+            TokenType.Asterisk => "*",
+            TokenType.Slash => "/",
+            TokenType.Modulo => "%",
+            TokenType.Exclamation => "!",
+            TokenType.LessThan => "<",
+            TokenType.GreaterThan => ">",
+            TokenType.LessThanOrEqual => "<=",
+            TokenType.GreaterThanOrEqual => ">=",
+            TokenType.Equals => "==",
+            TokenType.NotEquals => "!=",
+            TokenType.EqualsInsensitive => "=~",
+            TokenType.NotEqualsInsensitive => "!~",
+            TokenType.LogicalAnd => "&&",
+            TokenType.LogicalOr => "||",
+            TokenType.TrueKeyword => "true",
+            TokenType.FalseKeyword => "false",
+            TokenType.NullKeyword => "null",
+            TokenType.EndOfFile => "",
+            TokenType.DoubleQuestion => "??",
+            TokenType.DoubleColon => "::",
+            TokenType.Arrow => "=>",
+            TokenType.Pipe => "|",
+            TokenType.WithKeyword => "with",
+            TokenType.AsKeyword => "as",
+            _ => null,
+        };
+    }
+}

--- a/src/Bicep.Core/Syntax/SyntaxFacts.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFacts.cs
@@ -12,6 +12,20 @@ namespace Bicep.Core.Syntax
 {
     public static class SyntaxFacts
     {
+        public static bool IsFreeform(TokenType type) => type switch
+        {
+            TokenType.NewLine or
+            TokenType.Identifier or
+            TokenType.Integer or
+            TokenType.StringLeftPiece or
+            TokenType.StringMiddlePiece or
+            TokenType.StringRightPiece or
+            TokenType.StringComplete or
+            TokenType.MultilineString or
+            TokenType.Unrecognized => true,
+            _ => false,
+        };
+
         public static string? GetText(TokenType type) => type switch
         {
             TokenType.At => "@",

--- a/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
+++ b/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
@@ -142,7 +142,7 @@ internal static class OperationReturnTypeEvaluator
 
     private class NotEqualsEvaluator : BinaryEvaluator
     {
-        internal NotEqualsEvaluator() : base(BinaryOperator.NotEquals, LanguageConstants.Any, LanguageConstants.Any, Operators.BinaryOperatorToText[BinaryOperator.NotEquals], LanguageConstants.Bool) {}
+        internal NotEqualsEvaluator() : base(BinaryOperator.NotEquals, LanguageConstants.Any, LanguageConstants.Any, "", LanguageConstants.Bool) {}
 
         internal override TypeSymbol Evaluate(SyntaxBase expressionSyntax, out IEnumerable<IDiagnostic> evaluationDiagnostics, params TypeSymbol[] operandTypes)
         {
@@ -162,7 +162,7 @@ internal static class OperationReturnTypeEvaluator
     {
         private readonly bool negated;
 
-        internal InsensitiveEqualityEvaluator(BinaryOperator op, bool negated = false) : base(op, LanguageConstants.String, LanguageConstants.String, Operators.BinaryOperatorToText[op], LanguageConstants.Bool)
+        internal InsensitiveEqualityEvaluator(BinaryOperator op, bool negated = false) : base(op, LanguageConstants.String, LanguageConstants.String, "", LanguageConstants.Bool)
         {
             this.negated = negated;
         }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1076,7 +1076,7 @@ namespace Bicep.Core.TypeSystem
 
                 // we do not have a match
                 // operand types didn't match available operators
-                return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).BinaryOperatorInvalidType(Operators.BinaryOperatorToText[syntax.Operator], operandType1, operandType2, additionalInfo: additionalInfo));
+                return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).BinaryOperatorInvalidType(syntax.OperatorToken.Text, operandType1, operandType2, additionalInfo: additionalInfo));
             });
 
         public override void VisitUnaryOperationSyntax(UnaryOperationSyntax syntax)

--- a/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
+++ b/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
@@ -136,7 +136,7 @@ namespace Bicep.Decompiler.BicepHelpers
         {
             var trailingTrivia = new SyntaxTrivia(SyntaxTriviaType.MultiLineComment, TextSpan.Nil, $"/* {trailingComment} */");
 
-            return SyntaxFactory.CreateToken(tokenType, "?", SyntaxFactory.EmptyTrivia, trailingTrivia.AsEnumerable());
+            return SyntaxFactory.CreateFreeformToken(tokenType, "?", SyntaxFactory.EmptyTrivia, trailingTrivia.AsEnumerable());
         }
     }
 }

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -203,7 +203,7 @@ namespace Bicep.Decompiler
                 return null;
             }
 
-            return new VariableAccessSyntax(new(SyntaxFactory.CreateToken(TokenType.Identifier, typeString.ToLowerInvariant())));
+            return new VariableAccessSyntax(new(SyntaxFactory.CreateIdentifierToken(typeString.ToLowerInvariant())));
         }
 
         private string? TryLookupResource(LanguageExpression expression)
@@ -292,14 +292,14 @@ namespace Bicep.Decompiler
 
                 var binaryOperation = new BinaryOperationSyntax(
                     ParseLanguageExpression(leftParameter),
-                    SyntaxFactory.CreateToken(binaryTokenType, Operators.BinaryOperatorToText[binaryOperator]),
+                    SyntaxFactory.CreateToken(binaryTokenType),
                     ParseLanguageExpression(rightParameter));
 
                 foreach (var parameter in expression.Parameters.Skip(2))
                 {
                     binaryOperation = new BinaryOperationSyntax(
                         binaryOperation,
-                        SyntaxFactory.CreateToken(binaryTokenType, Operators.BinaryOperatorToText[binaryOperator]),
+                        SyntaxFactory.CreateToken(binaryTokenType),
                         ParseLanguageExpression(parameter));
                 }
 
@@ -884,7 +884,7 @@ namespace Bicep.Decompiler
             List<SyntaxBase> leadingNodes = new();
             return new MetadataDeclarationSyntax(
                 leadingNodes,
-                SyntaxFactory.CreateToken(TokenType.Identifier, "metadata"),
+                SyntaxFactory.CreateIdentifierToken("metadata"),
                 SyntaxFactory.CreateIdentifier(value.Name),
                 SyntaxFactory.AssignmentToken,
                 ParseJToken(value.Value)
@@ -918,12 +918,12 @@ namespace Bicep.Decompiler
             switch (typeSyntax.Name.IdentifierName)
             {
                 case "securestring":
-                    typeSyntax = new VariableAccessSyntax(new(SyntaxFactory.CreateToken(TokenType.Identifier, "string")));
+                    typeSyntax = new VariableAccessSyntax(new(SyntaxFactory.CreateIdentifierToken("string")));
                     decoratorsAndNewLines.Add(SyntaxFactory.CreateDecorator(LanguageConstants.ParameterSecurePropertyName));
                     decoratorsAndNewLines.Add(SyntaxFactory.NewlineToken);
                     break;
                 case "secureobject":
-                    typeSyntax = new VariableAccessSyntax(new(SyntaxFactory.CreateToken(TokenType.Identifier, "object")));
+                    typeSyntax = new VariableAccessSyntax(new(SyntaxFactory.CreateIdentifierToken("object")));
                     decoratorsAndNewLines.Add(SyntaxFactory.CreateDecorator(LanguageConstants.ParameterSecurePropertyName));
                     decoratorsAndNewLines.Add(SyntaxFactory.NewlineToken);
                     break;
@@ -946,7 +946,7 @@ namespace Bicep.Decompiler
 
             return new ParameterDeclarationSyntax(
                 leadingNodes,
-                SyntaxFactory.CreateToken(TokenType.Identifier, "param"),
+                SyntaxFactory.CreateIdentifierToken("param"),
                 SyntaxFactory.CreateIdentifier(identifier),
                 typeSyntax,
                 modifier);
@@ -975,7 +975,7 @@ namespace Bicep.Decompiler
             }
 
             return new VariableDeclarationSyntax(
-                SyntaxFactory.CreateToken(TokenType.Identifier, "var"),
+                SyntaxFactory.CreateIdentifierToken("var"),
                 SyntaxFactory.CreateIdentifier(identifier),
                 SyntaxFactory.AssignmentToken,
                 variableValue);
@@ -1215,7 +1215,7 @@ namespace Bicep.Decompiler
             }
 
             return new IfConditionSyntax(
-                SyntaxFactory.CreateToken(TokenType.Identifier, "if"),
+                SyntaxFactory.CreateIdentifierToken("if"),
                 conditionExpression,
                 body);
         }
@@ -1393,7 +1393,7 @@ namespace Bicep.Decompiler
 
                 return new ModuleDeclarationSyntax(
                     decoratorsAndNewLines,
-                    SyntaxFactory.CreateToken(TokenType.Identifier, LanguageConstants.ModuleKeyword),
+                    SyntaxFactory.CreateIdentifierToken(LanguageConstants.ModuleKeyword),
                     SyntaxFactory.CreateIdentifier(identifier),
                     SyntaxFactory.CreateStringLiteral(filePath),
                     SyntaxFactory.AssignmentToken,
@@ -1430,7 +1430,7 @@ namespace Bicep.Decompiler
                 }
                 var module = new ModuleDeclarationSyntax(
                     decoratorsAndNewLines,
-                    SyntaxFactory.CreateToken(TokenType.Identifier, LanguageConstants.ModuleKeyword),
+                    SyntaxFactory.CreateIdentifierToken(LanguageConstants.ModuleKeyword),
                     SyntaxFactory.CreateIdentifier(identifier),
                     modulePath,
                     SyntaxFactory.AssignmentToken,
@@ -1540,7 +1540,7 @@ namespace Bicep.Decompiler
 
             return new ResourceDeclarationSyntax(
                 decoratorsAndNewLines,
-                SyntaxFactory.CreateToken(TokenType.Identifier, "resource"),
+                SyntaxFactory.CreateIdentifierToken("resource"),
                 SyntaxFactory.CreateIdentifier(identifier),
                 SyntaxFactory.CreateStringLiteral($"{typeString}@{apiVersionString}"),
                 null,
@@ -1652,7 +1652,7 @@ namespace Bicep.Decompiler
 
             return new OutputDeclarationSyntax(
                 decoratorsAndNewLines,
-                SyntaxFactory.CreateToken(TokenType.Identifier, "output"),
+                SyntaxFactory.CreateIdentifierToken("output"),
                 SyntaxFactory.CreateIdentifier(identifier),
                 typeSyntax,
                 SyntaxFactory.AssignmentToken,
@@ -1671,17 +1671,17 @@ namespace Bicep.Decompiler
             {
                 case "/schemas/2019-08-01/tenantDeploymentTemplate.json":
                     return new TargetScopeSyntax(
-                        SyntaxFactory.CreateToken(TokenType.Identifier, "targetScope"),
+                        SyntaxFactory.CreateIdentifierToken("targetScope"),
                         SyntaxFactory.AssignmentToken,
                         SyntaxFactory.CreateStringLiteral("tenant"));
                 case "/schemas/2019-08-01/managementGroupDeploymentTemplate.json":
                     return new TargetScopeSyntax(
-                        SyntaxFactory.CreateToken(TokenType.Identifier, "targetScope"),
+                        SyntaxFactory.CreateIdentifierToken("targetScope"),
                         SyntaxFactory.AssignmentToken,
                         SyntaxFactory.CreateStringLiteral("managementGroup"));
                 case "/schemas/2018-05-01/subscriptionDeploymentTemplate.json":
                     return new TargetScopeSyntax(
-                        SyntaxFactory.CreateToken(TokenType.Identifier, "targetScope"),
+                        SyntaxFactory.CreateIdentifierToken("targetScope"),
                         SyntaxFactory.AssignmentToken,
                         SyntaxFactory.CreateStringLiteral("subscription"));
                 case "/schemas/2014-04-01-preview/deploymentTemplate.json":
@@ -1796,7 +1796,7 @@ namespace Bicep.Decompiler
 
             return new ProgramSyntax(
                 statements.SelectMany(x => new[] { x, SyntaxFactory.NewlineToken }),
-                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""));
+                SyntaxFactory.CreateToken(TokenType.EndOfFile));
         }
 
         private T PerformScopedAction<T>(Func<T> action, IEnumerable<string> scopeVariables)

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -389,7 +389,7 @@ namespace Bicep.LanguageServer.Completions
                     {
                         // An unterminated string will result in skipped trivia containing an unterminated token.
                         // Compensate here by building the expected token before lexing it.
-                        token = SyntaxFactory.CreateToken(token.Type, $"{token.Text}'");
+                        token = SyntaxFactory.CreateFreeformToken(token.Type, $"{token.Text}'");
                     }
 
                     return Lexer.TryGetStringValue(token);

--- a/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
@@ -53,30 +53,31 @@ namespace Bicep.LanguageServer.Handlers
 
         public static string Decompile(string manifestContents, TelemetryAndErrorHandlingHelper<ImportKubernetesManifestResponse> telemetryHelper)
         {
-            var declarations = new List<SyntaxBase>();
+            var declarations = new List<SyntaxBase>
+            {
+                new ParameterDeclarationSyntax(
+                    new SyntaxBase[] {
+                        SyntaxFactory.CreateDecorator("secure"),
+                        SyntaxFactory.NewlineToken,
+                    },
+                    SyntaxFactory.CreateIdentifierToken("param"),
+                    SyntaxFactory.CreateIdentifier("kubeConfig"),
+                    new VariableAccessSyntax(new(SyntaxFactory.CreateIdentifierToken("string"))),
+                    null),
 
-            declarations.Add(new ParameterDeclarationSyntax(
-                new SyntaxBase[] {
-                    SyntaxFactory.CreateDecorator("secure"),
-                    SyntaxFactory.NewlineToken,
-                },
-                SyntaxFactory.CreateToken(Core.Parsing.TokenType.Identifier, "param"),
-                SyntaxFactory.CreateIdentifier("kubeConfig"),
-                new VariableAccessSyntax(new(SyntaxFactory.CreateToken(TokenType.Identifier, "string"))),
-                null));
-
-            declarations.Add(new ImportDeclarationSyntax(
-                Enumerable.Empty<SyntaxBase>(),
-                SyntaxFactory.CreateToken(TokenType.Identifier, "import"),
-                SyntaxFactory.CreateStringLiteral("kubernetes@1.0.0"),
-                new ImportWithClauseSyntax(
-                    SyntaxFactory.CreateToken(TokenType.WithKeyword, LanguageConstants.WithKeyword), 
-                    SyntaxFactory.CreateObject(new []
-                    {
-                        SyntaxFactory.CreateObjectProperty("namespace", SyntaxFactory.CreateStringLiteral("default")),
-                        SyntaxFactory.CreateObjectProperty("kubeConfig", SyntaxFactory.CreateIdentifier("kubeConfig"))
-                    })),
-                asClause: SyntaxFactory.EmptySkippedTrivia));
+                new ImportDeclarationSyntax(
+                    Enumerable.Empty<SyntaxBase>(),
+                    SyntaxFactory.CreateIdentifierToken("import"),
+                    SyntaxFactory.CreateStringLiteral("kubernetes@1.0.0"),
+                    new ImportWithClauseSyntax(
+                        SyntaxFactory.CreateToken(TokenType.WithKeyword),
+                        SyntaxFactory.CreateObject(new[]
+                        {
+                            SyntaxFactory.CreateObjectProperty("namespace", SyntaxFactory.CreateStringLiteral("default")),
+                            SyntaxFactory.CreateObjectProperty("kubeConfig", SyntaxFactory.CreateIdentifier("kubeConfig"))
+                        })),
+                    asClause: SyntaxFactory.EmptySkippedTrivia)
+            };
 
             try
             {
@@ -102,7 +103,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var program = new ProgramSyntax(
                 declarations.SelectMany(x => new SyntaxBase[] { x, SyntaxFactory.DoubleNewlineToken }),
-                SyntaxFactory.CreateToken(TokenType.EndOfFile, ""));
+                SyntaxFactory.CreateToken(TokenType.EndOfFile));
 
             return PrettyPrinter.PrintValidProgram(program, new PrettyPrintOptions(NewlineOption.LF, IndentKindOption.Space, 2, false));
         }
@@ -144,7 +145,7 @@ namespace Bicep.LanguageServer.Handlers
 
             return new ResourceDeclarationSyntax(
                 Enumerable.Empty<SyntaxBase>(),
-                SyntaxFactory.CreateToken(Core.Parsing.TokenType.Identifier, "resource"),
+                SyntaxFactory.CreateIdentifierToken("resource"),
                 SyntaxFactory.CreateIdentifier(symbolName),
                 SyntaxFactory.CreateStringLiteral($"{type}@{apiVersion}"),
                 null,

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -244,7 +244,7 @@ namespace Bicep.LanguageServer.Handlers
 
             return new ResourceDeclarationSyntax(
                 new SyntaxBase[] { description, SyntaxFactory.NewlineToken, },
-                SyntaxFactory.CreateToken(TokenType.Identifier, "resource"),
+                SyntaxFactory.CreateIdentifierToken("resource"),
                 SyntaxFactory.CreateIdentifier(Regex.Replace(resourceId.UnqualifiedName, "[^a-zA-Z]", "")),
                 SyntaxFactory.CreateStringLiteral(typeReference.FormatName()),
                 null,

--- a/src/Bicep.Tools.Benchmark/PrettyPrint.cs
+++ b/src/Bicep.Tools.Benchmark/PrettyPrint.cs
@@ -29,7 +29,7 @@ public class PrettyPrint
         var fileSystem = FileHelper.CreateMockFileSystemForEmbeddedFiles(typeof(DataSet).Assembly, "Files");
 
         var dataSets = DataSets.AllDataSets
-            .Where(x => !x.IsValid)
+            .Where(x => x.IsValid)
             .ToImmutableArray();
 
         var bicepService = new ServiceBuilder()


### PR DESCRIPTION
Yet another simple optimization that I did for the Bicep v2 formatter to make it allocate less memory and run faster. The main change is to avoid storing texts in `Token.Text` for tokens whose text is not determined by users, such as `TokenType.At`. Instead, a switch expression is used to dynamically map `Token.TokenType` to a text when `Token.Text` is accessed. Although the changes are originally made for the v2 formatter, benchmarks show that it also benefits bicep compilation in general:

### Before
![Before](https://user-images.githubusercontent.com/16367959/231618984-cb790723-362b-47bb-bd0e-4e117d9b89f4.png)

### After
![After](https://user-images.githubusercontent.com/16367959/231618998-8a63f255-4fc3-46ca-b926-9dadf5cf9a1a.png)






###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10408)