### PR TITLE
Fix help info for build-params command 

### DIFF
--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -174,16 +174,15 @@ Usage:
       <file>        The input Bicepparam file 
 
     Options:
-      --bicep-file <file> Verifies if the bicep file reference in the params file using declaration matches the specified file path.
-      --outfile-params <file>  Saves the param output as the specified file path.
-      --outfile-bicep <file>  Saves the bicep output as the specified file path.
-      --stdout          Prints the output to stdout.
-      --no-restore      Builds the bicep file without restoring external modules.
+      --bicep-file <file> Verifies if the specified bicep file path matches the one provided in the params file using declaration
+      --outfile <file>  Saves the param output json as the specified file path.
+      --stdout          Prints the param and bicep json output to stdout.
+      --no-restore      Builds the bicep file (referenced in using declaration) without restoring external modules.
 
     Examples:
       bicep build-params params.bicepparam
       bicep build-params params.bicepparam --stdout
-      bicep build-params params.bicepparam --outfile-params otherParams.json --outfile-bicep otherMain.json 
+      bicep build-params params.bicepparam --outfile otherParams.json
       bicep build-params params.bicepparam --no-restore
 
 


### PR DESCRIPTION
The arguments for `build-params` command were changed as part of [PR #10050](https://github.com/Azure/bicep/pull/10050/files) 
   where `--outfile-params` and `--outfile-bicep` were replaced with `outfile` which only produces params json output. This PR fixes the help for that command.  

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10412)