### PR TITLE
Use decorators to determine output type

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4576,5 +4576,36 @@ resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
         }
+
+        // https://github.com/Azure/bicep/issues/10398
+        [TestMethod]
+        public void Test_Issue10398()
+        {
+            var result = CompilationHelper.Compile(
+("main.bicep", @"
+module mod1 'module1.bicep' = {
+  name: 'example-mod1'
+}
+
+module mod2 'module2.bicep' = {
+  name: 'example-mod2'
+  params: {
+    name: mod1.outputs.name
+  }
+}
+"),
+("module1.bicep", @"
+@minLength(3)
+@maxLength(24)
+output name string = uniqueString(resourceGroup().name)
+"),
+("module2.bicep", @"
+@minLength(3)
+@maxLength(24)
+param name string
+"));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -407,7 +407,7 @@ namespace Bicep.Core.TypeSystem
             var declaredType = TryGetTypeFromTypeSyntax(syntax.Type, allowNamespaceReferences: false) ??
                 ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidOutputType());
 
-            return new(declaredType, syntax);
+            return new(ApplyTypeModifyingDecorators(declaredType.Type, syntax), syntax);
         }
 
         private ITypeReference GetTypeFromTypeSyntax(SyntaxBase syntax, bool allowNamespaceReferences) => TryGetTypeFromTypeSyntax(syntax, allowNamespaceReferences)


### PR DESCRIPTION
Resolves #10398

This PR updates output type inference to take constraint decorators into account.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10418)