### PR TITLE
Output type inference

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4576,5 +4576,43 @@ resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
         }
+
+        // https://github.com/Azure/bicep/discussions/10354
+        [TestMethod]
+        public void Test_Issue10354()
+        {
+            var result = CompilationHelper.Compile(
+("main.bicep", @"
+module name 'name.bicep' = {
+  name: 'create-a-name'
+}
+
+module storage 'storage.bicep' = {
+  name: 'create-storage'
+  params: {
+    storageAccountName: name.outputs.name
+  }
+}
+
+module storage2 'storage.bicep' = {
+  name: 'create-another-storage'
+  params: {
+    storageAccountName: storage.outputs.name
+  }
+}
+"),
+("name.bicep", @"
+output name string = 'somestring'
+"),
+("storage.bicep", @"
+@minLength(3)
+@maxLength(24)
+param storageAccountName string
+
+output name string = storageAccountName
+"));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4638,7 +4638,7 @@ module mod2 'module2.bicep' = {
 param name string
 ";
 
-            var result = CompilationHelper.Compile(("main.bicep", main), ("module2.bicep", mod2), ("module1.bicep", @"output name string = uniqueString(resourceGroup().name)"));
+            var result = CompilationHelper.Compile(("main.bicep", main), ("module2.bicep", mod2), ("module1.bicep", @"output name string = resourceGroup().name"));
 
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
             {
@@ -4650,7 +4650,7 @@ param name string
             result = CompilationHelper.Compile(("main.bicep", main), ("module2.bicep", mod2), ("module1.bicep", @"
 @minLength(3)
 @maxLength(24)
-output name string = uniqueString(resourceGroup().name)
+output name string = resourceGroup().name
 "));
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();

--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -125,7 +125,7 @@ output incorrectTypeOutput2 int = myRes.properties.nestedObj.readOnlyProp
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"writeOnlyProp\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"properties\" does not contain property \"missingOutput\". Available properties include \"additionalProps\", \"nestedObj\", \"readOnlyProp\", \"requiredProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"missingOutput\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\"."),
-                x => x.Should().HaveCodeAndSeverity("BCP026", DiagnosticLevel.Error).And.HaveMessage("The output expects a value of type \"int\" but the provided value is of type \"string\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP033", DiagnosticLevel.Error).And.HaveMessage("Expected a value of type \"int\" but the provided value is of type \"string\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"readOnlyProp\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\".")
             );
         }

--- a/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Dependencies_LF/main.symbols.bicep
@@ -22,7 +22,7 @@ var resourceDependency = {
 }
 
 output resourceAType string = resA.type
-//@[7:20) Output resourceAType. Type: string. Declaration start char: 0, length: 39
+//@[7:20) Output resourceAType. Type: 'My.Rp/myResourceType'. Declaration start char: 0, length: 39
 resource resA 'My.Rp/myResourceType@2020-01-01' = {
 //@[9:13) Resource resA. Type: My.Rp/myResourceType@2020-01-01. Declaration start char: 0, length: 134
   name: 'resA'

--- a/src/Bicep.Core.Samples/Files/InvalidLambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidLambdas_LF/main.symbols.bicep
@@ -121,20 +121,20 @@ resource stg 'Microsoft.Storage/storageAccounts@2021-09-01' = [for i in range(0,
 
 output stgKeys array = map(range(0, 2), i => stg[i].listKeys().keys[0].value)
 //@[40:41) Local i. Type: int. Declaration start char: 40, length: 1
-//@[07:14) Output stgKeys. Type: array. Declaration start char: 0, length: 77
+//@[07:14) Output stgKeys. Type: string[]. Declaration start char: 0, length: 77
 output stgKeys2 array = map(range(0, 2), j => stg[((j + 2) % 123)].listKeys().keys[0].value)
 //@[41:42) Local j. Type: int. Declaration start char: 41, length: 1
-//@[07:15) Output stgKeys2. Type: array. Declaration start char: 0, length: 92
+//@[07:15) Output stgKeys2. Type: string[]. Declaration start char: 0, length: 92
 output stgKeys3 array = map(ids, id => listKeys(id, stg[0].apiVersion).keys[0].value)
 //@[33:35) Local id. Type: any. Declaration start char: 33, length: 2
 //@[07:15) Output stgKeys3. Type: array. Declaration start char: 0, length: 85
 output accessTiers array = map(range(0, 2), k => stg[k].properties.accessTier)
 //@[44:45) Local k. Type: int. Declaration start char: 44, length: 1
-//@[07:18) Output accessTiers. Type: array. Declaration start char: 0, length: 78
+//@[07:18) Output accessTiers. Type: ('Cool' | 'Hot' | 'Premium')[]. Declaration start char: 0, length: 78
 output accessTiers2 array = map(range(0, 2), x => map(range(0, 2), y => stg[x / y].properties.accessTier))
 //@[67:68) Local y. Type: int. Declaration start char: 67, length: 1
 //@[45:46) Local x. Type: int. Declaration start char: 45, length: 1
-//@[07:19) Output accessTiers2. Type: array. Declaration start char: 0, length: 106
+//@[07:19) Output accessTiers2. Type: ('Cool' | 'Hot' | 'Premium')[][]. Declaration start char: 0, length: 106
 output accessTiers3 array = map(ids, foo => reference('${foo}').accessTier)
 //@[37:40) Local foo. Type: any. Declaration start char: 37, length: 3
 //@[07:19) Output accessTiers3. Type: array. Declaration start char: 0, length: 75

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -90,32 +90,32 @@ output foo string =
 // wrong string output values
 output str string = true
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:24) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[20:24) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "true". (CodeDescription: none) |true|
 output str string = false
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:25) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[20:25) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "false". (CodeDescription: none) |false|
 output str string = [
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:24) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[20:24) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output str string = {
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:24) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
+//@[20:24) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
 }
 output str string = 52
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:22) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "52". (CodeDescription: none) |52|
+//@[20:22) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "52". (CodeDescription: none) |52|
 
 // wrong int output values
 output i int = true
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:19) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[15:19) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "true". (CodeDescription: none) |true|
 output i int = false
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:20) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[15:20) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "false". (CodeDescription: none) |false|
 output i int = [
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:19) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[15:19) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output i int = }
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
@@ -124,65 +124,65 @@ output i int = }
 //@[00:01) [BCP007 (Error)] This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration. (CodeDescription: none) |}|
 output i int = 'test'
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:21) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "'test'". (CodeDescription: none) |'test'|
+//@[15:21) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "'test'". (CodeDescription: none) |'test'|
 
 // wrong bool output values
 output b bool = [
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:20) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[16:20) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output b bool = {
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:20) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
+//@[16:20) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
 }
 output b bool = 32
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:18) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "32". (CodeDescription: none) |32|
+//@[16:18) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "32". (CodeDescription: none) |32|
 output b bool = 'str'
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:21) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
+//@[16:21) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
 
 // wrong array output values
 output arr array = 32
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:21) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "32". (CodeDescription: none) |32|
+//@[19:21) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "32". (CodeDescription: none) |32|
 output arr array = true
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:23) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[19:23) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "true". (CodeDescription: none) |true|
 output arr array = false
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:24) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[19:24) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "false". (CodeDescription: none) |false|
 output arr array = {
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:23) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
+//@[19:23) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
 }
 output arr array = 'str'
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:24) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
+//@[19:24) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
 
 // wrong object output values
 output o object = 32
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:20) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "32". (CodeDescription: none) |32|
+//@[18:20) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "32". (CodeDescription: none) |32|
 output o object = true
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:22) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[18:22) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "true". (CodeDescription: none) |true|
 output o object = false
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:23) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[18:23) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "false". (CodeDescription: none) |false|
 output o object = [
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:22) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[18:22) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output o object = 'str'
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:23) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
+//@[18:23) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
 
 // a few expression cases
 output exp string = 2 + 3
-//@[20:25) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "5". (CodeDescription: none) |2 + 3|
+//@[20:25) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "5". (CodeDescription: none) |2 + 3|
 output union string = true ? 's' : 1
-//@[22:36) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "'s' | 1". (CodeDescription: none) |true ? 's' : 1|
+//@[22:36) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "'s' | 1". (CodeDescription: none) |true ? 's' : 1|
 output bad int = true && !4
 //@[25:27) [BCP044 (Error)] Cannot apply operator "!" to operand of type "4". (CodeDescription: none) |!4|
 output deeper bool = true ? -true : (14 && 's') + 10

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -197,6 +197,7 @@ var attemptToReferenceAnOutput = myOutput
 @sys.maxValue(20)
 @minValue(10)
 output notAttachableDecorators int = 32
+//@[37:39) [BCP327 (Error)] The provided value (which will always be greater than or equal to 32) is too large to assign to a target for which the maximum allowable value is 20. (CodeDescription: none) |32|
 
 // nested loops inside output loops are not supported
 output noNestedLoops array = [for thing in things: {

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.symbols.bicep
@@ -153,14 +153,14 @@ output deeper bool = true ? -true : (14 && 's') + 10
 //@[07:13) Output deeper. Type: bool. Declaration start char: 0, length: 52
 
 output myOutput string = 'hello'
-//@[07:15) Output myOutput. Type: string. Declaration start char: 0, length: 32
+//@[07:15) Output myOutput. Type: 'hello'. Declaration start char: 0, length: 32
 var attemptToReferenceAnOutput = myOutput
 //@[04:30) Variable attemptToReferenceAnOutput. Type: error. Declaration start char: 0, length: 41
 
 @sys.maxValue(20)
 @minValue(10)
 output notAttachableDecorators int = 32
-//@[07:30) Output notAttachableDecorators. Type: int. Declaration start char: 0, length: 73
+//@[07:30) Output notAttachableDecorators. Type: 32. Declaration start char: 0, length: 73
 
 // nested loops inside output loops are not supported
 output noNestedLoops array = [for thing in things: {
@@ -202,11 +202,11 @@ output keyVaultSecretObjectOutput object = {
   secret: kv.getSecret('mySecret')
 }
 output keyVaultSecretArrayOutput array = [
-//@[07:32) Output keyVaultSecretArrayOutput. Type: array. Declaration start char: 0, length: 73
+//@[07:32) Output keyVaultSecretArrayOutput. Type: [string]. Declaration start char: 0, length: 73
   kv.getSecret('mySecret')
 ]
 output keyVaultSecretArrayInterpolatedOutput array = [
-//@[07:44) Output keyVaultSecretArrayInterpolatedOutput. Type: array. Declaration start char: 0, length: 90
+//@[07:44) Output keyVaultSecretArrayInterpolatedOutput. Type: [string]. Declaration start char: 0, length: 90
   '${kv.getSecret('mySecret')}'
 ]
 

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.symbols.bicep
@@ -160,7 +160,7 @@ var attemptToReferenceAnOutput = myOutput
 @sys.maxValue(20)
 @minValue(10)
 output notAttachableDecorators int = 32
-//@[07:30) Output notAttachableDecorators. Type: 32. Declaration start char: 0, length: 73
+//@[07:30) Output notAttachableDecorators. Type: int. Declaration start char: 0, length: 73
 
 // nested loops inside output loops are not supported
 output noNestedLoops array = [for thing in things: {

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -222,7 +222,7 @@ resource sampleResource 'Microsoft.Foo/foos@2020-02-02' = {
   name: 'foo'
 }
 output sampleOutput string = 'hello'
-//@[07:019) Output sampleOutput. Type: string. Declaration start char: 0, length: 36
+//@[07:019) Output sampleOutput. Type: 'hello'. Declaration start char: 0, length: 36
 
 param paramAccessingVar string = concat(sampleVar, 's')
 //@[06:023) Parameter paramAccessingVar. Type: string. Declaration start char: 0, length: 55

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -256,7 +256,7 @@ param resrefpar string = foo.id
 //@[025:028) [BCP072 (Error)] This symbol cannot be referenced here. Only other parameters can be referenced in parameter default values. (CodeDescription: none) |foo|
 
 output resrefout bool = bar.id
-//@[024:030) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "string". (CodeDescription: none) |bar.id|
+//@[024:030) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "string". (CodeDescription: none) |bar.id|
 
 // attempting to set read-only properties
 resource baz 'Microsoft.Foo/foos@2020-02-02-alpha' = {

--- a/src/Bicep.Core.Samples/Files/Lambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Lambdas_LF/main.symbols.bicep
@@ -115,7 +115,7 @@ var filteredLoop = filter(itemForLoop, i => i > 5)
 
 output doggoGreetings array = [for item in mapObject: item.greeting]
 //@[035:039) Local item. Type: object. Declaration start char: 35, length: 4
-//@[007:021) Output doggoGreetings. Type: array. Declaration start char: 0, length: 68
+//@[007:021) Output doggoGreetings. Type: string[]. Declaration start char: 0, length: 68
 
 resource storageAcc 'Microsoft.Storage/storageAccounts@2021-09-01' existing = {
 //@[009:019) Resource storageAcc. Type: Microsoft.Storage/storageAccounts@2021-09-01. Declaration start char: 0, length: 100

--- a/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/LoopsIndexed_LF/main.symbols.bicep
@@ -96,13 +96,13 @@ output indexedCollectionName string = storageAccounts[index].name
 output indexedCollectionId string = storageAccounts[index].id
 //@[007:026) Output indexedCollectionId. Type: string. Declaration start char: 0, length: 61
 output indexedCollectionType string = storageAccounts[index].type
-//@[007:028) Output indexedCollectionType. Type: string. Declaration start char: 0, length: 65
+//@[007:028) Output indexedCollectionType. Type: 'Microsoft.Storage/storageAccounts'. Declaration start char: 0, length: 65
 output indexedCollectionVersion string = storageAccounts[index].apiVersion
-//@[007:031) Output indexedCollectionVersion. Type: string. Declaration start char: 0, length: 74
+//@[007:031) Output indexedCollectionVersion. Type: '2019-06-01'. Declaration start char: 0, length: 74
 
 // general case property access
 output indexedCollectionIdentity object = storageAccounts[index].identity
-//@[007:032) Output indexedCollectionIdentity. Type: object. Declaration start char: 0, length: 73
+//@[007:032) Output indexedCollectionIdentity. Type: Identity. Declaration start char: 0, length: 73
 
 // indexed access of two properties
 output indexedEndpointPair object = {
@@ -113,7 +113,7 @@ output indexedEndpointPair object = {
 
 // nested indexer?
 output indexViaReference string = storageAccounts[int(storageAccounts[index].properties.creationTime)].properties.accessTier
-//@[007:024) Output indexViaReference. Type: string. Declaration start char: 0, length: 124
+//@[007:024) Output indexViaReference. Type: 'Cool' | 'Hot'. Declaration start char: 0, length: 124
 
 // dependency on a resource collection
 resource storageAccounts2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, idx) in accounts: {
@@ -318,13 +318,13 @@ output existingIndexedResourceName string = existingStorageAccounts[index * 0].n
 output existingIndexedResourceId string = existingStorageAccounts[index * 1].id
 //@[007:032) Output existingIndexedResourceId. Type: string. Declaration start char: 0, length: 79
 output existingIndexedResourceType string = existingStorageAccounts[index+2].type
-//@[007:034) Output existingIndexedResourceType. Type: string. Declaration start char: 0, length: 81
+//@[007:034) Output existingIndexedResourceType. Type: 'Microsoft.Storage/storageAccounts'. Declaration start char: 0, length: 81
 output existingIndexedResourceApiVersion string = existingStorageAccounts[index-7].apiVersion
-//@[007:040) Output existingIndexedResourceApiVersion. Type: string. Declaration start char: 0, length: 93
+//@[007:040) Output existingIndexedResourceApiVersion. Type: '2019-06-01'. Declaration start char: 0, length: 93
 output existingIndexedResourceLocation string = existingStorageAccounts[index/2].location
 //@[007:038) Output existingIndexedResourceLocation. Type: string. Declaration start char: 0, length: 89
 output existingIndexedResourceAccessTier string = existingStorageAccounts[index%3].properties.accessTier
-//@[007:040) Output existingIndexedResourceAccessTier. Type: string. Declaration start char: 0, length: 104
+//@[007:040) Output existingIndexedResourceAccessTier. Type: 'Cool' | 'Hot'. Declaration start char: 0, length: 104
 
 resource duplicatedNames 'Microsoft.Network/dnsZones@2018-05-01' = [for (zone,i) in []: {
 //@[073:077) Local zone. Type: never. Declaration start char: 73, length: 4

--- a/src/Bicep.Core.Samples/Files/Loops_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Loops_LF/main.symbols.bicep
@@ -93,13 +93,13 @@ output indexedCollectionName string = storageAccounts[index].name
 output indexedCollectionId string = storageAccounts[index].id
 //@[07:026) Output indexedCollectionId. Type: string. Declaration start char: 0, length: 61
 output indexedCollectionType string = storageAccounts[index].type
-//@[07:028) Output indexedCollectionType. Type: string. Declaration start char: 0, length: 65
+//@[07:028) Output indexedCollectionType. Type: 'Microsoft.Storage/storageAccounts'. Declaration start char: 0, length: 65
 output indexedCollectionVersion string = storageAccounts[index].apiVersion
-//@[07:031) Output indexedCollectionVersion. Type: string. Declaration start char: 0, length: 74
+//@[07:031) Output indexedCollectionVersion. Type: '2019-06-01'. Declaration start char: 0, length: 74
 
 // general case property access
 output indexedCollectionIdentity object = storageAccounts[index].identity
-//@[07:032) Output indexedCollectionIdentity. Type: object. Declaration start char: 0, length: 73
+//@[07:032) Output indexedCollectionIdentity. Type: Identity. Declaration start char: 0, length: 73
 
 // indexed access of two properties
 output indexedEndpointPair object = {
@@ -110,7 +110,7 @@ output indexedEndpointPair object = {
 
 // nested indexer?
 output indexViaReference string = storageAccounts[int(storageAccounts[index].properties.creationTime)].properties.accessTier
-//@[07:024) Output indexViaReference. Type: string. Declaration start char: 0, length: 124
+//@[07:024) Output indexViaReference. Type: 'Cool' | 'Hot'. Declaration start char: 0, length: 124
 
 // dependency on a resource collection
 resource storageAccounts2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in accounts: {
@@ -291,7 +291,7 @@ module moduleCollectionWithIndexedDependencies 'passthrough.bicep' = [for module
 }]
 
 output indexedModulesName string = moduleCollectionWithSingleDependency[index].name
-//@[07:025) Output indexedModulesName. Type: string. Declaration start char: 0, length: 83
+//@[07:025) Output indexedModulesName. Type: 'one' | 'three' | 'two'. Declaration start char: 0, length: 83
 output indexedModuleOutput string = moduleCollectionWithSingleDependency[index * 1].outputs.myOutput
 //@[07:026) Output indexedModuleOutput. Type: string. Declaration start char: 0, length: 100
 
@@ -307,13 +307,13 @@ output existingIndexedResourceName string = existingStorageAccounts[index * 0].n
 output existingIndexedResourceId string = existingStorageAccounts[index * 1].id
 //@[07:032) Output existingIndexedResourceId. Type: string. Declaration start char: 0, length: 79
 output existingIndexedResourceType string = existingStorageAccounts[index+2].type
-//@[07:034) Output existingIndexedResourceType. Type: string. Declaration start char: 0, length: 81
+//@[07:034) Output existingIndexedResourceType. Type: 'Microsoft.Storage/storageAccounts'. Declaration start char: 0, length: 81
 output existingIndexedResourceApiVersion string = existingStorageAccounts[index-7].apiVersion
-//@[07:040) Output existingIndexedResourceApiVersion. Type: string. Declaration start char: 0, length: 93
+//@[07:040) Output existingIndexedResourceApiVersion. Type: '2019-06-01'. Declaration start char: 0, length: 93
 output existingIndexedResourceLocation string = existingStorageAccounts[index/2].location
 //@[07:038) Output existingIndexedResourceLocation. Type: string. Declaration start char: 0, length: 89
 output existingIndexedResourceAccessTier string = existingStorageAccounts[index%3].properties.accessTier
-//@[07:040) Output existingIndexedResourceAccessTier. Type: string. Declaration start char: 0, length: 104
+//@[07:040) Output existingIndexedResourceAccessTier. Type: 'Cool' | 'Hot'. Declaration start char: 0, length: 104
 
 resource duplicatedNames 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in []: {
 //@[72:076) Local zone. Type: never. Declaration start char: 72, length: 4
@@ -483,7 +483,7 @@ resource filteredIndexedZones 'Microsoft.Network/dnsZones@2018-05-01' = [for (ac
 }]
 
 output lastNameServers array = filteredIndexedZones[length(accounts) - 1].properties.nameServers
-//@[07:022) Output lastNameServers. Type: array. Declaration start char: 0, length: 96
+//@[07:022) Output lastNameServers. Type: string[]. Declaration start char: 0, length: 96
 
 module filteredIndexedModules 'passthrough.bicep' = [for (account, i) in accounts: if(account.enabled) {
 //@[58:065) Local account. Type: any. Declaration start char: 58, length: 7

--- a/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/ModulesWithScopes_LF/main.symbols.bicep
@@ -30,7 +30,7 @@ module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscriptio
 
 
 output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
-//@[7:30) Output myManagementGroupOutput. Type: string. Declaration start char: 0, length: 77
+//@[7:30) Output myManagementGroupOutput. Type: 'hello!'. Declaration start char: 0, length: 77
 output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
-//@[7:27) Output mySubscriptionOutput. Type: string. Declaration start char: 0, length: 71
+//@[7:27) Output mySubscriptionOutput. Type: 'hello!'. Declaration start char: 0, length: 71
 

--- a/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Modules_CRLF/main.symbols.bicep
@@ -141,7 +141,7 @@ output stringOutputB string = modATest.outputs.stringOutputB
 output objOutput object = modATest.outputs.objOutput
 //@[07:16) Output objOutput. Type: object. Declaration start char: 0, length: 52
 output arrayOutput array = modATest.outputs.arrayOutput
-//@[07:18) Output arrayOutput. Type: array. Declaration start char: 0, length: 55
+//@[07:18) Output arrayOutput. Type: string[]. Declaration start char: 0, length: 55
 output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
 //@[07:30) Output modCalculatedNameOutput. Type: object. Declaration start char: 0, length: 82
 

--- a/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/NestedResources_LF/main.symbols.bicep
@@ -100,4 +100,4 @@ resource loopParent 'My.Rp/parentType@2020-12-01' = {
 }
 
 output loopChildOutput string = loopParent::loopChild[0].name
-//@[07:22) Output loopChildOutput. Type: string. Declaration start char: 0, length: 61
+//@[07:22) Output loopChildOutput. Type: 'loopChild'. Declaration start char: 0, length: 61

--- a/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Outputs_CRLF/main.symbols.bicep
@@ -1,23 +1,23 @@
 
 @sys.description('string output description')
 output myStr string = 'hello'
-//@[07:12) Output myStr. Type: string. Declaration start char: 0, length: 76
+//@[07:12) Output myStr. Type: 'hello'. Declaration start char: 0, length: 76
 
 @sys.description('int output description')
 output myInt int = 7
-//@[07:12) Output myInt. Type: int. Declaration start char: 0, length: 64
+//@[07:12) Output myInt. Type: 7. Declaration start char: 0, length: 64
 output myOtherInt int = 20 / 13 + 80 % -4
-//@[07:17) Output myOtherInt. Type: int. Declaration start char: 0, length: 41
+//@[07:17) Output myOtherInt. Type: 260. Declaration start char: 0, length: 41
 
 @sys.description('bool output description')
 output myBool bool = !false
-//@[07:13) Output myBool. Type: bool. Declaration start char: 0, length: 72
+//@[07:13) Output myBool. Type: true. Declaration start char: 0, length: 72
 output myOtherBool bool = true
-//@[07:18) Output myOtherBool. Type: bool. Declaration start char: 0, length: 30
+//@[07:18) Output myOtherBool. Type: true. Declaration start char: 0, length: 30
 
 @sys.description('object array description')
 output suchEmpty array = [
-//@[07:16) Output suchEmpty. Type: array. Declaration start char: 0, length: 75
+//@[07:16) Output suchEmpty. Type: <empty array>. Declaration start char: 0, length: 75
 ]
 
 output suchEmpty2 object = {
@@ -47,7 +47,7 @@ output obj object = {
 }
 
 output myArr array = [
-//@[07:12) Output myArr. Type: array. Declaration start char: 0, length: 74
+//@[07:12) Output myArr. Type: ['pirates', 'say', 'arr' | 'arr2']. Declaration start char: 0, length: 74
   'pirates'
   'say'
    false ? 'arr2' : 'arr'
@@ -57,7 +57,7 @@ output rgLocation string = resourceGroup().location
 //@[07:17) Output rgLocation. Type: string. Declaration start char: 0, length: 51
 
 output isWestUs bool = resourceGroup().location != 'westus' ? false : true
-//@[07:15) Output isWestUs. Type: bool. Declaration start char: 0, length: 74
+//@[07:15) Output isWestUs. Type: false | true. Declaration start char: 0, length: 74
 
 output expressionBasedIndexer string = {
 //@[07:29) Output expressionBasedIndexer. Type: string. Declaration start char: 0, length: 140
@@ -83,12 +83,12 @@ param paramWithOverlappingOutput string
 //@[06:32) Parameter paramWithOverlappingOutput. Type: string. Declaration start char: 0, length: 39
 
 output varWithOverlappingOutput string = varWithOverlappingOutput
-//@[07:31) Output varWithOverlappingOutput. Type: string. Declaration start char: 0, length: 65
+//@[07:31) Output varWithOverlappingOutput. Type: 'hello'. Declaration start char: 0, length: 65
 output paramWithOverlappingOutput string = paramWithOverlappingOutput
 //@[07:33) Output paramWithOverlappingOutput. Type: string. Declaration start char: 0, length: 69
 
 // top-level output loops are supported
 output generatedArray array = [for i in range(0,10): i]
 //@[35:36) Local i. Type: int. Declaration start char: 35, length: 1
-//@[07:21) Output generatedArray. Type: array. Declaration start char: 0, length: 55
+//@[07:21) Output generatedArray. Type: int[]. Declaration start char: 0, length: 55
 

--- a/src/Bicep.Core.Samples/Files/Registry_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Registry_LF/main.symbols.bicep
@@ -106,7 +106,7 @@ module vnetDeploy 'ts:11111111-1111-1111-1111-111111111111/prod-rg/vnet-spec:v2'
 output siteUrls array = [for (site, i) in websites: siteDeploy[i].outputs.siteUrl]
 //@[30:34) Local site. Type: object | object. Declaration start char: 30, length: 4
 //@[36:37) Local i. Type: int. Declaration start char: 36, length: 1
-//@[07:15) Output siteUrls. Type: array. Declaration start char: 0, length: 82
+//@[07:15) Output siteUrls. Type: string[]. Declaration start char: 0, length: 82
 
 module passthroughPort 'br:localhost:5000/passthrough/port:v1' = {
 //@[07:22) Module passthroughPort. Type: module. Declaration start char: 0, length: 128

--- a/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/ResourcesTenant_CRLF/main.symbols.bicep
@@ -56,7 +56,7 @@ resource yetAnotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for
 
 output managementGroupIds array = [for i in range(0, length(managementGroups)): {
 //@[39:40) Local i. Type: int. Declaration start char: 39, length: 1
-//@[07:25) Output managementGroupIds. Type: array. Declaration start char: 0, length: 172
+//@[07:25) Output managementGroupIds. Type: object[]. Declaration start char: 0, length: 172
   name: yetAnotherSet[i].name
   displayName: yetAnotherSet[i].properties.displayName
 }]

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
@@ -146,9 +146,9 @@ var _siteType = site.type
 //@[04:013) Variable _siteType. Type: 'Microsoft.Web/sites'. Declaration start char: 0, length: 25
 
 output siteApiVersion string = site.apiVersion
-//@[07:021) Output siteApiVersion. Type: string. Declaration start char: 0, length: 46
+//@[07:021) Output siteApiVersion. Type: '2019-08-01'. Declaration start char: 0, length: 46
 output siteType string = site.type
-//@[07:015) Output siteType. Type: string. Declaration start char: 0, length: 34
+//@[07:015) Output siteType. Type: 'Microsoft.Web/sites'. Declaration start char: 0, length: 34
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 //@[09:015) Resource nested. Type: Microsoft.Resources/deployments@2019-10-01. Declaration start char: 0, length: 354
@@ -491,9 +491,9 @@ resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
 output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
 //@[07:023) Output p1_subnet1prefix. Type: string. Declaration start char: 0, length: 68
 output p1_subnet1name string = p1_subnet1.name
-//@[07:021) Output p1_subnet1name. Type: string. Declaration start char: 0, length: 46
+//@[07:021) Output p1_subnet1name. Type: 'subnet1'. Declaration start char: 0, length: 46
 output p1_subnet1type string = p1_subnet1.type
-//@[07:021) Output p1_subnet1type. Type: string. Declaration start char: 0, length: 46
+//@[07:021) Output p1_subnet1type. Type: 'Microsoft.Network/virtualNetworks/subnets'. Declaration start char: 0, length: 46
 output p1_subnet1id string = p1_subnet1.id
 //@[07:019) Output p1_subnet1id. Type: string. Declaration start char: 0, length: 42
 
@@ -524,9 +524,9 @@ resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
 output p2_res2childprop string = p2_res2child.properties.someProp
 //@[07:023) Output p2_res2childprop. Type: string. Declaration start char: 0, length: 65
 output p2_res2childname string = p2_res2child.name
-//@[07:023) Output p2_res2childname. Type: string. Declaration start char: 0, length: 50
+//@[07:023) Output p2_res2childname. Type: 'child2'. Declaration start char: 0, length: 50
 output p2_res2childtype string = p2_res2child.type
-//@[07:023) Output p2_res2childtype. Type: string. Declaration start char: 0, length: 50
+//@[07:023) Output p2_res2childtype. Type: 'Microsoft.Rp2/resource2/child2'. Declaration start char: 0, length: 50
 output p2_res2childid string = p2_res2child.id
 //@[07:021) Output p2_res2childid. Type: string. Declaration start char: 0, length: 46
 
@@ -545,9 +545,9 @@ resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
 output p3_res1childprop string = p3_child1.properties.someProp
 //@[07:023) Output p3_res1childprop. Type: string. Declaration start char: 0, length: 62
 output p3_res1childname string = p3_child1.name
-//@[07:023) Output p3_res1childname. Type: string. Declaration start char: 0, length: 47
+//@[07:023) Output p3_res1childname. Type: 'child1'. Declaration start char: 0, length: 47
 output p3_res1childtype string = p3_child1.type
-//@[07:023) Output p3_res1childtype. Type: string. Declaration start char: 0, length: 47
+//@[07:023) Output p3_res1childtype. Type: 'Microsoft.Rp1/resource1/child1'. Declaration start char: 0, length: 47
 output p3_res1childid string = p3_child1.id
 //@[07:021) Output p3_res1childid. Type: string. Declaration start char: 0, length: 43
 
@@ -567,9 +567,9 @@ resource p4_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' existing = {
 output p4_res1childprop string = p4_child1.properties.someProp
 //@[07:023) Output p4_res1childprop. Type: string. Declaration start char: 0, length: 62
 output p4_res1childname string = p4_child1.name
-//@[07:023) Output p4_res1childname. Type: string. Declaration start char: 0, length: 47
+//@[07:023) Output p4_res1childname. Type: 'child1'. Declaration start char: 0, length: 47
 output p4_res1childtype string = p4_child1.type
-//@[07:023) Output p4_res1childtype. Type: string. Declaration start char: 0, length: 47
+//@[07:023) Output p4_res1childtype. Type: 'Microsoft.Rp1/resource1/child1'. Declaration start char: 0, length: 47
 output p4_res1childid string = p4_child1.id
 //@[07:021) Output p4_res1childid. Type: string. Declaration start char: 0, length: 43
 

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.symbols.bicep
@@ -94,13 +94,13 @@ var nonNull = mightIncludeNull[0]!.key
 //@[4:11) Variable nonNull. Type: 'value'. Declaration start char: 0, length: 38
 
 output nonNull string = nonNull
-//@[7:14) Output nonNull. Type: string. Declaration start char: 0, length: 31
+//@[7:14) Output nonNull. Type: 'value'. Declaration start char: 0, length: 31
 
 var maybeNull = mightIncludeNull[0].?key
 //@[4:13) Variable maybeNull. Type: 'value' | null. Declaration start char: 0, length: 40
 
 output maybeNull string? = maybeNull
-//@[7:16) Output maybeNull. Type: null | string. Declaration start char: 0, length: 36
+//@[7:16) Output maybeNull. Type: 'value' | null. Declaration start char: 0, length: 36
 
 type nullable = string?
 //@[5:13) TypeAlias nullable. Type: Type<null | string>. Declaration start char: 0, length: 23

--- a/src/Bicep.Core.Samples/Files/Unicode_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Unicode_LF/main.symbols.bicep
@@ -26,7 +26,7 @@ var variousAlphabets = {
 output concatUnicodeStrings string = concat('Θμ', '二头肌', 'α')
 //@[7:27) Output concatUnicodeStrings. Type: string. Declaration start char: 0, length: 61
 output interpolateUnicodeStrings string = 'Θμ二${emojis}头肌${ninjaCat}α'
-//@[7:32) Output interpolateUnicodeStrings. Type: string. Declaration start char: 0, length: 70
+//@[7:32) Output interpolateUnicodeStrings. Type: 'Θμ二💪😊😈🍕☕头肌🐱‍👤α'. Declaration start char: 0, length: 70
 
 // all of these should produce the same string
 var surrogate_char      = '𐐷'

--- a/src/Bicep.Core/Diagnostics/ErrorTrackingDiagnosticWriterDecorator.cs
+++ b/src/Bicep.Core/Diagnostics/ErrorTrackingDiagnosticWriterDecorator.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Diagnostics;
+
+// ErrorTrackingDiagnosticWriterDecorator wraps another diagnostic writer and will track whether any error-level diagnostics have been written.
+public class ErrorTrackingDiagnosticWriterDecorator : IDiagnosticWriter
+{
+    private readonly IDiagnosticWriter decorated;
+    private bool hasErrors = false;
+
+    public ErrorTrackingDiagnosticWriterDecorator(IDiagnosticWriter decorated)
+    {
+        this.decorated = decorated;
+    }
+
+    public void Write(IDiagnostic diagnostic)
+    {
+        if (diagnostic.Level == DiagnosticLevel.Error)
+        {
+            hasErrors = true;
+        }
+
+        decorated.Write(diagnostic);
+    }
+
+    public bool HasErrors => hasErrors;
+}

--- a/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DocumentSymbolTests.cs
@@ -87,7 +87,7 @@ output myOutput string = 'myOutput'
                     x.DocumentSymbol!.Name.Should().Be("myOutput");
                     x.DocumentSymbol.Kind.Should().Be(SymbolKind.Interface);
                     x.DocumentSymbol.Children.Should().BeEmpty();
-                    x.DocumentSymbol.Detail.Should().Be("string");
+                    x.DocumentSymbol.Detail.Should().Be("'myOutput'");
                 }
             );
 

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -69,6 +69,11 @@ namespace Bicep.LangServer.IntegrationTests
         [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
         public async Task HoveringOverSymbolReferencesAndDeclarationsShouldProduceHovers(DataSet dataSet)
         {
+            if (dataSet.HasExternalModules)
+            {
+                Assert.Inconclusive("Opening this data set in the language server will result in all modules having a type of 'error'. This makes hovers unreliable.");
+            }
+
             var (compilation, _, fileUri) = await dataSet.SetupPrerequisitesAndCreateCompilation(TestContext);
             var uri = DocumentUri.From(fileUri);
 


### PR DESCRIPTION
Addresses an ask from #10354

As a companion to #10418, this PR updates output type inference to take the supplied output value into account. 

One potential drawback of inferring more detailed type information from the value is that while Bicep can easily figure out an extremely narrow type for a statement written in Bicep, the compiler isn't as smart when looking at JSON templates. E.g., the type of `foo` would be `'foo'` in `output foo string = 'foo'` and would just be `string` in:

```json
{
  ...
  "outputs": {
    "foo": {
      "type": "string",
      "value": "foo"
    }
  }
}
```

The above limitation would mean that type inference would work for a local bicep module but not one that had been published to the registry.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10421)