### PR TITLE
Fix 9451

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -102,7 +102,7 @@ namespace Bicep.LanguageServer.Handlers
                  && matchingNodes[^3] is ModuleDeclarationSyntax moduleDeclarationSyntax
                  && matchingNodes[^2] is StringSyntax stringToken
                  && context.Compilation.SourceFileGrouping.TryGetSourceFile(moduleDeclarationSyntax) is ISourceFile sourceFile
-                 && this.moduleDispatcher.TryGetModuleReference(moduleDeclarationSyntax, sourceFile.FileUri, out var moduleReference, out _))
+                 && this.moduleDispatcher.TryGetModuleReference(moduleDeclarationSyntax, request.TextDocument.Uri.ToUri(), out var moduleReference, out _))
                 {
                     // goto beginning of the module file.
                     return GetFileDefinitionLocation(


### PR DESCRIPTION
Fixes #9451

Wrong URI being passed in to TryGetModuleReference for the parentModuleUri (i.e. the file with the registry reference), so the wrong bicepconfig.json was being found, resulting in registry aliases not being available.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10476)