### PR TITLE
Remove expected error from output log

### DIFF
--- a/src/vs-bicep/Install.cmd
+++ b/src/vs-bicep/Install.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-taskkill /im devenv.exe /t /f
+taskkill /im devenv.exe /t /f 2>&1 | findstr /v "not found"
 
 set VsWhereExePath=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
 set "ExtensionsRoot=%~dp0"


### PR DESCRIPTION
Seeing "ERROR: Process devenv.exe not found" looks like a fatal error in the logs...  Turns out it's not.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10488)