### PR TITLE
Treat the presence of a type refinement as a opt-in signal for refinement checking

### DIFF
--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -280,7 +280,6 @@ param expressionInModifier string = 2 + 3
 //@[11:021) [BCP032 (Error)] The value must be a compile-time constant. (CodeDescription: none) |length([])|
 @allowed([
   resourceGroup().id
-//@[02:020) [BCP335 (Warning)] The provided value has no configured maximum length and may be too long to assign to a target with a configured maximum length of 5. (CodeDescription: none) |resourceGroup().id|
 //@[02:020) [BCP032 (Error)] The value must be a compile-time constant. (CodeDescription: none) |resourceGroup().id|
 ])
 param nonCompileTimeConstant string

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
@@ -264,20 +264,18 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 Row(TypeFactory.CreateStringType(1, 10),
                     TypeFactory.CreateStringType(2, 11),
                     TypeFactory.CreateStringType(2, 10),
-                    ("BCP334", DiagnosticLevel.Warning, "The provided value may have a length as small as 1 and may be too short to assign to a target with a configured minimum length of 2.")),
+                    ("BCP334", DiagnosticLevel.Warning, "The provided value can have a length as small as 1 and may be too short to assign to a target with a configured minimum length of 2.")),
 
                 // A source type whose domain overlaps but extends above the domain of the target type should narrow and warn
                 Row(TypeFactory.CreateStringType(3, 11),
                     TypeFactory.CreateStringType(2, 10),
                     TypeFactory.CreateStringType(3, 10),
-                    ("BCP335", DiagnosticLevel.Warning, "The provided value may have a length as large as 11 and may be too long to assign to a target with a configured maximum length of 10.")),
+                    ("BCP335", DiagnosticLevel.Warning, "The provided value can have a length as large as 11 and may be too long to assign to a target with a configured maximum length of 10.")),
 
-                // A source type whose domain contains but extends both below and above the domain of the target type should narrow and warn
+                // A source type whose domain contains but extends both below and above the domain of the target type should narrow and not warn
                 Row(TypeFactory.CreateStringType(),
                     TypeFactory.CreateStringType(5, 10),
-                    TypeFactory.CreateStringType(5, 10),
-                    ("BCP334", DiagnosticLevel.Warning, "The provided value has no configured minimum length and may be too short to assign to a target with a configured minimum length of 5."),
-                    ("BCP335", DiagnosticLevel.Warning, "The provided value has no configured maximum length and may be too long to assign to a target with a configured maximum length of 10.")),
+                    TypeFactory.CreateStringType(5, 10)),
 
                 // A source type whose domain is disjoint from the domain of the target should error and not narrow
                 Row(TypeFactory.CreateStringType(minLength: 10),
@@ -356,20 +354,18 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 Row(TypeFactory.CreateIntegerType(-1, 10),
                     TypeFactory.CreateIntegerType(0, 11),
                     TypeFactory.CreateIntegerType(0, 10),
-                    ("BCP329", DiagnosticLevel.Warning, "The provided value may be as small as -1 and may be too small to assign to a target with a configured minimum of 0.")),
+                    ("BCP329", DiagnosticLevel.Warning, "The provided value can be as small as -1 and may be too small to assign to a target with a configured minimum of 0.")),
 
                 // A source type whose domain overlaps but extends above the domain of the target type should narrow and warn
                 Row(TypeFactory.CreateIntegerType(0, 11),
                     TypeFactory.CreateIntegerType(-5, 10),
                     TypeFactory.CreateIntegerType(0, 10),
-                    ("BCP330", DiagnosticLevel.Warning, "The provided value may be as large as 11 and may be too large to assign to a target with a configured maximum of 10.")),
+                    ("BCP330", DiagnosticLevel.Warning, "The provided value can be as large as 11 and may be too large to assign to a target with a configured maximum of 10.")),
 
-                // A source type whose domain contains but extends both below and above the domain of the target type should narrow and warn
+                // A source type whose domain contains but extends both below and above the domain of the target type should narrow and not warn
                 Row(TypeFactory.CreateIntegerType(),
                     TypeFactory.CreateIntegerType(-5, 10),
-                    TypeFactory.CreateIntegerType(-5, 10),
-                    ("BCP329", DiagnosticLevel.Warning, "The provided value has no configured minimum and may be too small to assign to a target with a configured minimum of -5."),
-                    ("BCP330", DiagnosticLevel.Warning, "The provided value has no configured maximum and may be too large to assign to a target with a configured maximum of 10.")),
+                    TypeFactory.CreateIntegerType(-5, 10)),
 
                 // A source type whose domain is disjoint from the domain of the target should error and not narrow
                 Row(TypeFactory.CreateIntegerType(minValue: 10),
@@ -560,20 +556,18 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 Row(TypeFactory.CreateArrayType(1, 10),
                     TypeFactory.CreateArrayType(2, 11),
                     TypeFactory.CreateArrayType(2, 10),
-                    ("BCP334", DiagnosticLevel.Warning, "The provided value may have a length as small as 1 and may be too short to assign to a target with a configured minimum length of 2.")),
+                    ("BCP334", DiagnosticLevel.Warning, "The provided value can have a length as small as 1 and may be too short to assign to a target with a configured minimum length of 2.")),
 
                 // A source type whose domain overlaps but extends above the domain of the target type should narrow and warn
                 Row(TypeFactory.CreateArrayType(3, 11),
                     TypeFactory.CreateArrayType(2, 10),
                     TypeFactory.CreateArrayType(3, 10),
-                    ("BCP335", DiagnosticLevel.Warning, "The provided value may have a length as large as 11 and may be too long to assign to a target with a configured maximum length of 10.")),
+                    ("BCP335", DiagnosticLevel.Warning, "The provided value can have a length as large as 11 and may be too long to assign to a target with a configured maximum length of 10.")),
 
-                // A source type whose domain contains but extends both below and above the domain of the target type should narrow and warn
+                // A source type whose domain contains but extends both below and above the domain of the target type should narrow and not warn
                 Row(TypeFactory.CreateArrayType(),
                     TypeFactory.CreateArrayType(5, 10),
-                    TypeFactory.CreateArrayType(5, 10),
-                    ("BCP334", DiagnosticLevel.Warning, "The provided value has no configured minimum length and may be too short to assign to a target with a configured minimum length of 5."),
-                    ("BCP335", DiagnosticLevel.Warning, "The provided value has no configured maximum length and may be too long to assign to a target with a configured maximum length of 10.")),
+                    TypeFactory.CreateArrayType(5, 10)),
 
                 // A source type whose domain is disjoint from the domain of the target should error and not narrow
                 Row(TypeFactory.CreateArrayType(minLength: 10),

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1854,17 +1854,17 @@ namespace Bicep.Core.Diagnostics
                 "BCP328",
                 $"The provided value (which will always be less than or equal to {sourceMax}) is too small to assign to a target for which the minimum allowable value is {targetMin}.");
 
-            public Diagnostic SourceIntDomainExtendsBelowTargetIntDomain(long? sourceMin, long targetMin) => new(
+            public Diagnostic SourceIntDomainExtendsBelowTargetIntDomain(long sourceMin, long targetMin) => new(
                 TextSpan,
                 DiagnosticLevel.Warning,
                 "BCP329",
-                $"The provided value {(sourceMin.HasValue ? $"may be as small as {sourceMin.Value}" : "has no configured minimum")} and may be too small to assign to a target with a configured minimum of {targetMin}.");
+                $"The provided value can be as small as {sourceMin} and may be too small to assign to a target with a configured minimum of {targetMin}.");
 
-            public Diagnostic SourceIntDomainExtendsAboveTargetIntDomain(long? sourceMax, long targetMax) => new(
+            public Diagnostic SourceIntDomainExtendsAboveTargetIntDomain(long sourceMax, long targetMax) => new(
                 TextSpan,
                 DiagnosticLevel.Warning,
                 "BCP330",
-                $"The provided value {(sourceMax.HasValue ? $"may be as large as {sourceMax.Value}" : "has no configured maximum")} and may be too large to assign to a target with a configured maximum of {targetMax}.");
+                $"The provided value can be as large as {sourceMax} and may be too large to assign to a target with a configured maximum of {targetMax}.");
 
             public ErrorDiagnostic MinMayNotExceedMax(string minDecoratorName, long minValue, string maxDecoratorName, long maxValue) => new(
                 TextSpan,
@@ -1883,17 +1883,17 @@ namespace Bicep.Core.Diagnostics
                 "BCP333",
                 $"The provided value (whose length will always be less than or equal to {sourceMaxLength}) is too short to assign to a target for which the minimum allowable length is {targetMinLength}.");
 
-            public Diagnostic SourceValueLengthDomainExtendsBelowTargetValueLengthDomain(long? sourceMinLength, long targetMinLength) => new(
+            public Diagnostic SourceValueLengthDomainExtendsBelowTargetValueLengthDomain(long sourceMinLength, long targetMinLength) => new(
                 TextSpan,
                 DiagnosticLevel.Warning,
                 "BCP334",
-                $"The provided value {(sourceMinLength.HasValue ? $"may have a length as small as {sourceMinLength.Value}" : "has no configured minimum length")} and may be too short to assign to a target with a configured minimum length of {targetMinLength}.");
+                $"The provided value can have a length as small as {sourceMinLength} and may be too short to assign to a target with a configured minimum length of {targetMinLength}.");
 
-            public Diagnostic SourceValueLengthDomainExtendsAboveTargetValueLengthDomain(long? sourceMaxLength, long targetMaxLength) => new(
+            public Diagnostic SourceValueLengthDomainExtendsAboveTargetValueLengthDomain(long sourceMaxLength, long targetMaxLength) => new(
                 TextSpan,
                 DiagnosticLevel.Warning,
                 "BCP335",
-                $"The provided value {(sourceMaxLength.HasValue ? $"may have a length as large as {sourceMaxLength.Value}" : "has no configured maximum length")} and may be too long to assign to a target with a configured maximum length of {targetMaxLength}.");
+                $"The provided value can have a length as large as {sourceMaxLength} and may be too long to assign to a target with a configured maximum length of {targetMaxLength}.");
 
             public ErrorDiagnostic ParametersFileUnsupported() => new(
                 TextSpan,

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -390,62 +390,57 @@ namespace Bicep.Core.TypeSystem
 
         private TypeSymbol NarrowIntegerAssignmentType(SyntaxBase expression, TypeSymbol expressionType, IntegerType targetType)
         {
-            var targetMin = targetType.MinValue ?? long.MinValue;
-            var targetMax = targetType.MaxValue ?? long.MaxValue;
             switch (expressionType)
             {
                 case IntegerType expressionInteger:
-                    var expressionMin = expressionInteger.MinValue ?? long.MinValue;
-                    var expressionMax = expressionInteger.MaxValue ?? long.MaxValue;
-
-                    if (expressionMin > targetMax)
+                    if (expressionInteger.MinValue.HasValue && targetType.MaxValue.HasValue && expressionInteger.MinValue.Value > targetType.MaxValue.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression)
-                            .SourceIntDomainDisjointFromTargetIntDomain_SourceHigh(ShouldWarn(targetType), expressionMin, targetMax));
+                            .SourceIntDomainDisjointFromTargetIntDomain_SourceHigh(ShouldWarn(targetType), expressionInteger.MinValue.Value, targetType.MaxValue.Value));
                         break;
                     }
 
-                    if (expressionMax < targetMin)
+                    if (expressionInteger.MaxValue.HasValue && targetType.MinValue.HasValue && expressionInteger.MaxValue.Value < targetType.MinValue.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression)
-                            .SourceIntDomainDisjointFromTargetIntDomain_SourceLow(ShouldWarn(targetType), expressionMax, targetMin));
+                            .SourceIntDomainDisjointFromTargetIntDomain_SourceLow(ShouldWarn(targetType), expressionInteger.MaxValue.Value, targetType.MinValue.Value));
                         break;
                     }
 
-                    if (expressionMin < targetMin)
+                    if (expressionInteger.MinValue.HasValue && targetType.MinValue.HasValue && expressionInteger.MinValue.Value < targetType.MinValue.Value)
                     {
-                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceIntDomainExtendsBelowTargetIntDomain(expressionInteger.MinValue, targetMin));
+                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceIntDomainExtendsBelowTargetIntDomain(expressionInteger.MinValue.Value, targetType.MinValue.Value));
                     }
 
-                    if (expressionMax > targetMax)
+                    if (expressionInteger.MaxValue.HasValue && targetType.MaxValue.HasValue && expressionInteger.MaxValue.Value > targetType.MaxValue.Value)
                     {
-                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceIntDomainExtendsAboveTargetIntDomain(expressionInteger.MaxValue, targetMax));
+                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceIntDomainExtendsAboveTargetIntDomain(expressionInteger.MaxValue.Value, targetType.MaxValue.Value));
                     }
 
                     return TypeFactory.CreateIntegerType(
-                        minValue: Math.Max(expressionMin, targetMin) switch
+                        minValue: Math.Max(expressionInteger.MinValue ?? long.MinValue, targetType.MinValue ?? long.MinValue) switch
                         {
                             long.MinValue => null,
                             long otherwise => otherwise,
                         },
-                        maxValue: Math.Min(expressionMax, targetMax) switch
+                        maxValue: Math.Min(expressionInteger.MaxValue ?? long.MaxValue, targetType.MaxValue ?? long.MaxValue) switch
                         {
                             long.MaxValue => null,
                             long otherwise => otherwise,
                         },
                         targetType.ValidationFlags);
                 case IntegerLiteralType expressionIntegerLiteral:
-                    if (expressionIntegerLiteral.Value > targetMax)
+                    if (targetType.MaxValue.HasValue && expressionIntegerLiteral.Value > targetType.MaxValue.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression)
-                            .SourceIntDomainDisjointFromTargetIntDomain_SourceHigh(ShouldWarn(targetType), expressionIntegerLiteral.Value, targetMax));
+                            .SourceIntDomainDisjointFromTargetIntDomain_SourceHigh(ShouldWarn(targetType), expressionIntegerLiteral.Value, targetType.MaxValue.Value));
                         break;
                     }
 
-                    if (expressionIntegerLiteral.Value < targetMin)
+                    if (targetType.MinValue.HasValue && expressionIntegerLiteral.Value < targetType.MinValue.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression)
-                            .SourceIntDomainDisjointFromTargetIntDomain_SourceLow(ShouldWarn(targetType), expressionIntegerLiteral.Value, targetMin));
+                            .SourceIntDomainDisjointFromTargetIntDomain_SourceLow(ShouldWarn(targetType), expressionIntegerLiteral.Value, targetType.MinValue.Value));
                         break;
                     }
 
@@ -487,59 +482,56 @@ namespace Bicep.Core.TypeSystem
             switch (expressionType)
             {
                 case StringType expressionString:
-                    var expressionMinLength = expressionString.MinLength ?? 0;
-                    var expressionMaxLength = expressionString.MaxLength ?? long.MaxValue;
-
-                    if (expressionMinLength > targetMaxLength)
+                    if (expressionString.MinLength.HasValue && targetType.MaxLength.HasValue && expressionString.MinLength.Value > targetType.MaxLength.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression)
-                            .SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceHigh(ShouldWarn(targetType), expressionMinLength, targetMaxLength));
+                            .SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceHigh(ShouldWarn(targetType), expressionString.MinLength.Value, targetType.MaxLength.Value));
                         break;
                     }
 
-                    if (expressionMaxLength < targetMinLength)
+                    if (expressionString.MaxLength.HasValue && targetType.MinLength.HasValue && expressionString.MaxLength.Value < targetType.MinLength.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression)
-                            .SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceLow(ShouldWarn(targetType), expressionMaxLength, targetMinLength));
+                            .SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceLow(ShouldWarn(targetType), expressionString.MaxLength.Value, targetType.MinLength.Value));
                         break;
                     }
 
-                    if (expressionMinLength < targetMinLength)
+                    if (expressionString.MinLength.HasValue && targetType.MinLength.HasValue && expressionString.MinLength.Value < targetType.MinLength.Value)
                     {
-                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsBelowTargetValueLengthDomain(expressionString.MinLength, targetMinLength));
+                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsBelowTargetValueLengthDomain(expressionString.MinLength.Value, targetType.MinLength.Value));
                     }
 
-                    if (expressionMaxLength > targetMaxLength)
+                    if (expressionString.MaxLength.HasValue && targetType.MaxLength.HasValue && expressionString.MaxLength.Value > targetType.MaxLength.Value)
                     {
-                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsAboveTargetValueLengthDomain(expressionString.MaxLength, targetMaxLength));
+                        diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsAboveTargetValueLengthDomain(expressionString.MaxLength.Value, targetType.MaxLength.Value));
                     }
 
                     return TypeFactory.CreateStringType(
-                        minLength: Math.Max(expressionMinLength, targetMinLength) switch
+                        minLength: Math.Max(expressionString.MinLength ?? 0, targetType.MinLength ?? 0) switch
                         {
-                            0 => null,
+                            <= 0 => null,
                             long otherwise => otherwise,
                         },
-                        maxLength: Math.Min(expressionMaxLength, targetMaxLength) switch
+                        maxLength: Math.Min(expressionString.MaxLength ?? long.MaxValue, targetType.MaxLength ?? long.MaxValue) switch
                         {
                             long.MaxValue => null,
                             long otherwise => otherwise,
                         },
                         validationFlags: targetType.ValidationFlags);
                 case StringLiteralType expressionStringLiteral:
-                    if (expressionStringLiteral.RawStringValue.Length > targetMaxLength)
+                    if (targetType.MaxLength.HasValue && expressionStringLiteral.RawStringValue.Length > targetType.MaxLength.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceHigh(
                             ShouldWarn(targetType),
                             expressionStringLiteral.RawStringValue.Length,
-                            targetMaxLength));
+                            targetType.MaxLength.Value));
                     }
-                    else if (expressionStringLiteral.RawStringValue.Length < targetMinLength)
+                    else if (targetType.MinLength.HasValue && expressionStringLiteral.RawStringValue.Length < targetType.MinLength.Value)
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceLow(
                             ShouldWarn(targetType),
                             expressionStringLiteral.RawStringValue.Length,
-                            targetMinLength));
+                            targetType.MinLength.Value));
                     }
 
                     // if a literal was assignable to a string-typed target, the literal will always be the most narrow type
@@ -612,47 +604,42 @@ namespace Bicep.Core.TypeSystem
 
             if (expressionType is ArrayType expressionArrayType)
             {
-                var expressionMinLength = expressionArrayType.MinLength ?? 0;
-                var targetMinLength = targetType.MinLength ?? 0;
-                var expressionMaxLength = expressionArrayType.MaxLength ?? long.MaxValue;
-                var targetMaxLength = targetType.MaxLength ?? long.MaxValue;
-
-                if (expressionMinLength > targetMaxLength)
+                if (expressionArrayType.MinLength.HasValue && targetType.MaxLength.HasValue && expressionArrayType.MinLength.Value > targetType.MaxLength.Value)
                 {
                     diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceHigh(
                         ShouldWarn(targetType),
-                        expressionMinLength,
-                        targetMaxLength));
+                        expressionArrayType.MinLength.Value,
+                        targetType.MaxLength.Value));
                     return expressionType;
                 }
 
-                if (expressionMaxLength < targetMinLength)
+                if (expressionArrayType.MaxLength.HasValue && targetType.MinLength.HasValue && expressionArrayType.MaxLength.Value < targetType.MinLength.Value)
                 {
                     diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainDisjointFromTargetValueLengthDomain_SourceLow(
                         ShouldWarn(targetType),
-                        expressionMaxLength,
-                        targetMinLength));
+                        expressionArrayType.MaxLength.Value,
+                        targetType.MinLength.Value));
                     return expressionType;
                 }
 
-                if (expressionMinLength < targetMinLength)
+                if (expressionArrayType.MinLength.HasValue && targetType.MinLength.HasValue && expressionArrayType.MinLength.Value < targetType.MinLength.Value)
                 {
-                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsBelowTargetValueLengthDomain(expressionArrayType.MinLength, targetMinLength));
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsBelowTargetValueLengthDomain(expressionArrayType.MinLength.Value, targetType.MinLength.Value));
                 }
 
-                if (expressionMaxLength > targetMaxLength)
+                if (expressionArrayType.MaxLength.HasValue && targetType.MaxLength.HasValue && expressionArrayType.MaxLength.Value > targetType.MaxLength.Value)
                 {
-                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsAboveTargetValueLengthDomain(expressionArrayType.MaxLength, targetMaxLength));
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(expression).SourceValueLengthDomainExtendsAboveTargetValueLengthDomain(expressionArrayType.MaxLength.Value, targetType.MaxLength.Value));
                 }
 
                 return new TypedArrayType(NarrowType(config, expression, expressionArrayType.Item.Type, targetType.Item.Type),
                     targetType.ValidationFlags,
-                    minLength: Math.Max(expressionMinLength, targetMinLength) switch
+                    minLength: Math.Max(expressionArrayType.MinLength ?? 0, targetType.MinLength ?? 0) switch
                     {
-                        0 => null,
+                        <= 0 => null,
                         long otherwise => otherwise,
                     },
-                    maxLength: Math.Min(expressionMaxLength, targetMaxLength) switch
+                    maxLength: Math.Min(expressionArrayType.MaxLength ?? long.MaxValue, targetType.MaxLength ?? long.MaxValue) switch
                     {
                         long.MaxValue => null,
                         long otherwise => otherwise,


### PR DESCRIPTION
Resolves #10489 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10544)