### PR TITLE
Derive operation return type from operands

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Expressions/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Expressions/parameters.symbols.bicepparam
@@ -61,7 +61,7 @@ param myInt = sys.int(myBool ? 123 : 456)
 //@[6:11) ParameterAssignment myInt. Type: int. Declaration start char: 0, length: 41
 
 param myArray = [
-//@[6:13) ParameterAssignment myArray. Type: ['a' | 'b', false, 579, 333, 6, 20, true, false, false, true]. Declaration start char: 0, length: 123
+//@[6:13) ParameterAssignment myArray. Type: ['a' | 'b', false, 579, 333, 6, 5, true, false, false, true]. Declaration start char: 0, length: 123
   (true ? 'a' : 'b')
   !true
   123 + 456

--- a/src/Bicep.Core.UnitTests/TypeSystem/OperatorTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/OperatorTests.cs
@@ -3,9 +3,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -56,6 +59,229 @@ namespace Bicep.Core.UnitTests.TypeSystem
         private static IEnumerable<TEnum> GetValues<TEnum>() where TEnum : struct
         {
             return Enum.GetValues(typeof(TEnum)).OfType<TEnum>();
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetUnaryTestCases), DynamicDataSourceType.Method)]
+        public void Unary_operator_resolves_correct_type(UnaryOperationSyntax expression, TypeSymbol operandType, TypeSymbol expected)
+        {
+            var actual = OperationReturnTypeEvaluator.TryFoldUnaryExpression(expression, operandType);
+            actual.Should().Be(expected);
+        }
+
+        private static IEnumerable<object[]> GetUnaryTestCases()
+        {
+            static object[] Case(UnaryOperationSyntax expression, TypeSymbol operandType, TypeSymbol expected)
+                => new object[] { expression, operandType, expected };
+
+
+            var symbolRef = TestSyntaxFactory.CreateVariableAccess("foo");
+            UnaryOperationSyntax minus = new(TestSyntaxFactory.CreateToken(TokenType.Minus), symbolRef);
+            UnaryOperationSyntax not = new(TestSyntaxFactory.CreateToken(TokenType.Exclamation), symbolRef);
+
+            return new[]
+            {
+                Case(minus, LanguageConstants.Int, LanguageConstants.Int),
+                Case(minus, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(-1)),
+                Case(minus, TypeFactory.CreateIntegerType(-20, -10), TypeFactory.CreateIntegerType(10, 20)),
+                Case(minus, TypeHelper.CreateTypeUnion(TypeFactory.CreateIntegerLiteralType(-100), TypeFactory.CreateIntegerType(10, 20)), TypeHelper.CreateTypeUnion(TypeFactory.CreateIntegerLiteralType(100), TypeFactory.CreateIntegerType(-20, -10))),
+                Case(minus, TypeFactory.CreateIntegerLiteralType(long.MinValue), LanguageConstants.Int),
+                Case(not, LanguageConstants.Bool, LanguageConstants.Bool),
+                Case(not, TypeFactory.CreateBooleanLiteralType(true), TypeFactory.CreateBooleanLiteralType(false)),
+                Case(not, TypeHelper.CreateTypeUnion(TypeFactory.CreateBooleanLiteralType(true), TypeFactory.CreateBooleanLiteralType(false)), TypeHelper.CreateTypeUnion(TypeFactory.CreateBooleanLiteralType(true), TypeFactory.CreateBooleanLiteralType(false))),
+            };
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetBinaryTestCases), DynamicDataSourceType.Method)]
+        public void Binary_operator_resolves_correct_type(BinaryOperator @operator, TypeSymbol leftOperandType, TypeSymbol rightOperandType, TypeSymbol expected)
+        {
+            var actual = OperationReturnTypeEvaluator.TryFoldBinaryExpression(OperationSyntaxFor(@operator), leftOperandType, rightOperandType, out _);
+            actual.Should().Be(expected);
+        }
+
+        private static BinaryOperationSyntax OperationSyntaxFor(BinaryOperator @operator) => new(leftExpression: TestSyntaxFactory.CreateVariableAccess("foo"), rightExpression: TestSyntaxFactory.CreateVariableAccess("bar"), operatorToken: @operator switch
+        {
+            BinaryOperator.LogicalOr => TestSyntaxFactory.CreateToken(TokenType.LogicalOr),
+            BinaryOperator.LogicalAnd => TestSyntaxFactory.CreateToken(TokenType.LogicalAnd),
+            BinaryOperator.Equals => TestSyntaxFactory.CreateToken(TokenType.Equals),
+            BinaryOperator.NotEquals => TestSyntaxFactory.CreateToken(TokenType.NotEquals),
+            BinaryOperator.EqualsInsensitive => TestSyntaxFactory.CreateToken(TokenType.EqualsInsensitive),
+            BinaryOperator.NotEqualsInsensitive => TestSyntaxFactory.CreateToken(TokenType.NotEqualsInsensitive),
+            BinaryOperator.LessThan => TestSyntaxFactory.CreateToken(TokenType.LessThan),
+            BinaryOperator.LessThanOrEqual => TestSyntaxFactory.CreateToken(TokenType.LessThanOrEqual),
+            BinaryOperator.GreaterThan => TestSyntaxFactory.CreateToken(TokenType.GreaterThan),
+            BinaryOperator.GreaterThanOrEqual => TestSyntaxFactory.CreateToken(TokenType.GreaterThanOrEqual),
+            BinaryOperator.Add => TestSyntaxFactory.CreateToken(TokenType.Plus),
+            BinaryOperator.Subtract => TestSyntaxFactory.CreateToken(TokenType.Minus),
+            BinaryOperator.Multiply => TestSyntaxFactory.CreateToken(TokenType.Asterisk),
+            BinaryOperator.Divide => TestSyntaxFactory.CreateToken(TokenType.Slash),
+            BinaryOperator.Modulo => TestSyntaxFactory.CreateToken(TokenType.Modulo),
+            BinaryOperator.Coalesce => TestSyntaxFactory.CreateToken(TokenType.DoubleQuestion),
+            _ => throw new InvalidOperationException("Unrecognized operator")
+        });
+
+        private static IEnumerable<object[]> GetBinaryTestCases()
+        {
+            static object[] Case(BinaryOperator @operator, TypeSymbol leftOperandType, TypeSymbol rightOperandType, TypeSymbol expected)
+                => new object[] { @operator, leftOperandType, rightOperandType, expected };
+
+            return new[]
+            {
+                // ||
+                Case(BinaryOperator.LogicalOr, LanguageConstants.Bool, LanguageConstants.Bool, LanguageConstants.Bool),
+                Case(BinaryOperator.LogicalOr, LanguageConstants.True, LanguageConstants.Any, LanguageConstants.True),
+                Case(BinaryOperator.LogicalOr, LanguageConstants.Any, LanguageConstants.True, LanguageConstants.True),
+                Case(BinaryOperator.LogicalOr, LanguageConstants.False, LanguageConstants.False, LanguageConstants.False),
+
+                // &&
+                Case(BinaryOperator.LogicalAnd, LanguageConstants.Bool, LanguageConstants.Bool, LanguageConstants.Bool),
+                Case(BinaryOperator.LogicalAnd, LanguageConstants.False, LanguageConstants.Any, LanguageConstants.False),
+                Case(BinaryOperator.LogicalAnd, LanguageConstants.Any, LanguageConstants.False, LanguageConstants.False),
+                Case(BinaryOperator.LogicalAnd, LanguageConstants.True, LanguageConstants.True, LanguageConstants.True),
+
+                // ==
+                Case(BinaryOperator.Equals, LanguageConstants.Any, LanguageConstants.Any, LanguageConstants.Bool),
+                Case(BinaryOperator.Equals, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("literal"), LanguageConstants.True),
+                Case(BinaryOperator.Equals, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("LiTeRaL"), LanguageConstants.False),
+
+                // !=
+                Case(BinaryOperator.NotEquals, LanguageConstants.Any, LanguageConstants.Any, LanguageConstants.Bool),
+                Case(BinaryOperator.NotEquals, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("literal"), LanguageConstants.False),
+                Case(BinaryOperator.NotEquals, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("LiTeRaL"), LanguageConstants.True),
+
+                // =~
+                Case(BinaryOperator.EqualsInsensitive, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Bool),
+                Case(BinaryOperator.EqualsInsensitive, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("literal"), LanguageConstants.True),
+                Case(BinaryOperator.EqualsInsensitive, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("LiTeRaL"), LanguageConstants.True),
+                Case(BinaryOperator.EqualsInsensitive, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("L1T3R4L"), LanguageConstants.False),
+
+                // !~
+                Case(BinaryOperator.NotEqualsInsensitive, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Bool),
+                Case(BinaryOperator.NotEqualsInsensitive, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("literal"), LanguageConstants.False),
+                Case(BinaryOperator.NotEqualsInsensitive, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("LiTeRaL"), LanguageConstants.False),
+                Case(BinaryOperator.NotEqualsInsensitive, TypeFactory.CreateStringLiteralType("literal"), TypeFactory.CreateStringLiteralType("L1T3R4L"), LanguageConstants.True),
+
+                // int < int
+                Case(BinaryOperator.LessThan, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Bool),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(2), LanguageConstants.True),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(2), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.False),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.False),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.True),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.Bool),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.False),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.False),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.True),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.Bool),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.False),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.False),
+
+                // int <= int
+                Case(BinaryOperator.LessThanOrEqual, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Bool),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(2), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(2), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.False),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 0), LanguageConstants.Bool),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.False),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.Bool),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 0), LanguageConstants.Bool),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.False),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.Bool),
+
+                // int > int
+                Case(BinaryOperator.GreaterThan, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(2), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(2), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 0), LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 0), LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.Bool),
+
+                // int >= int
+                Case(BinaryOperator.GreaterThanOrEqual, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(2), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(2), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerLiteralType(1), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerLiteralType(1), TypeFactory.CreateIntegerType(maxValue: 2), LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 2), LanguageConstants.False),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerType(maxValue: 1), TypeFactory.CreateIntegerType(minValue: 1), LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 0), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 1), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateIntegerType(minValue: 1), TypeFactory.CreateIntegerType(maxValue: 2), LanguageConstants.Bool),
+
+                // string < string
+                Case(BinaryOperator.LessThan, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Bool),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateStringLiteralType("a"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.True),
+                Case(BinaryOperator.LessThan, TypeFactory.CreateStringLiteralType("b"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.False),
+
+                // string <= string
+                Case(BinaryOperator.LessThanOrEqual, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Bool),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateStringLiteralType("a"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateStringLiteralType("b"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.True),
+                Case(BinaryOperator.LessThanOrEqual, TypeFactory.CreateStringLiteralType("c"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.False),
+
+                // string > string
+                Case(BinaryOperator.GreaterThan, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateStringLiteralType("b"), TypeFactory.CreateStringLiteralType("a"), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThan, TypeFactory.CreateStringLiteralType("a"), TypeFactory.CreateStringLiteralType("a"), LanguageConstants.False),
+
+                // string >= string
+                Case(BinaryOperator.GreaterThanOrEqual, LanguageConstants.String, LanguageConstants.String, LanguageConstants.Bool),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateStringLiteralType("c"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateStringLiteralType("b"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.True),
+                Case(BinaryOperator.GreaterThanOrEqual, TypeFactory.CreateStringLiteralType("a"), TypeFactory.CreateStringLiteralType("b"), LanguageConstants.False),
+
+                // +
+                Case(BinaryOperator.Add, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Int),
+                Case(BinaryOperator.Add, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(20)),
+                Case(BinaryOperator.Add, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateIntegerType(20, 30)),
+                Case(BinaryOperator.Add, TypeFactory.CreateIntegerType(0, 10), TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateIntegerType(10, 30)),
+
+                // -
+                Case(BinaryOperator.Subtract, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Int),
+                Case(BinaryOperator.Subtract, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(0)),
+                Case(BinaryOperator.Subtract, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateIntegerType(-10, 0)),
+                Case(BinaryOperator.Subtract, TypeFactory.CreateIntegerType(0, 10), TypeFactory.CreateIntegerType(10, 20), TypeFactory.CreateIntegerType(-20, 0)),
+
+                // *
+                Case(BinaryOperator.Multiply, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Int),
+                Case(BinaryOperator.Multiply, TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(100)),
+
+                // /
+                Case(BinaryOperator.Divide, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Int),
+                Case(BinaryOperator.Divide, TypeFactory.CreateIntegerLiteralType(50), TypeFactory.CreateIntegerLiteralType(10), TypeFactory.CreateIntegerLiteralType(5)),
+
+                // %
+                Case(BinaryOperator.Modulo, LanguageConstants.Int, LanguageConstants.Int, LanguageConstants.Int),
+                Case(BinaryOperator.Modulo, TypeFactory.CreateIntegerLiteralType(4), TypeFactory.CreateIntegerLiteralType(3), TypeFactory.CreateIntegerLiteralType(1)),
+                Case(BinaryOperator.Modulo, LanguageConstants.Int, TypeFactory.CreateIntegerLiteralType(3), TypeFactory.CreateIntegerType(-2, 2)),
+                Case(BinaryOperator.Modulo, TypeFactory.CreateIntegerType(0, 27), TypeFactory.CreateIntegerLiteralType(3), TypeFactory.CreateIntegerType(0, 2)),
+                Case(BinaryOperator.Modulo, LanguageConstants.Int, TypeFactory.CreateIntegerType(-28, 33), TypeFactory.CreateIntegerType(-32, 32)),
+
+                // ??
+                Case(BinaryOperator.Coalesce, LanguageConstants.Any, LanguageConstants.Any, LanguageConstants.Any),
+                Case(BinaryOperator.Coalesce, LanguageConstants.String, LanguageConstants.Bool, LanguageConstants.String),
+                Case(BinaryOperator.Coalesce, LanguageConstants.Null, LanguageConstants.Bool, LanguageConstants.Bool),
+                Case(BinaryOperator.Coalesce,
+                    TypeHelper.CreateTypeUnion(LanguageConstants.Null, TypeFactory.CreateStringLiteralType("Fizz"), TypeFactory.CreateStringLiteralType("Buzz")),
+                    TypeFactory.CreateStringLiteralType("Pop"),
+                    TypeHelper.CreateTypeUnion(TypeFactory.CreateStringLiteralType("Fizz"), TypeFactory.CreateStringLiteralType("Buzz"), TypeFactory.CreateStringLiteralType("Pop"))),
+            };
         }
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -678,7 +678,12 @@ namespace Bicep.Core.TypeSystem
                 return baseExpressionType;
             }
 
-            var evaluated = OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, baseExpressionType);
+            var diagnosticWriter = ToListDiagnosticWriter.Create();
+            var evaluated = OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, baseExpressionType, diagnosticWriter);
+            if (diagnosticWriter.GetDiagnostics().OfType<ErrorDiagnostic>().Any())
+            {
+                return ErrorType.Create(diagnosticWriter.GetDiagnostics().OfType<ErrorDiagnostic>());
+            }
 
             if (evaluated is {} result && TypeHelper.IsLiteralType(result))
             {

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -678,16 +678,14 @@ namespace Bicep.Core.TypeSystem
                 return baseExpressionType;
             }
 
-            var evaluated = OperationReturnTypeEvaluator.FoldUnaryExpression(syntax, baseExpressionType, out var foldDiags);
-            foldDiags ??= ImmutableArray<IDiagnostic>.Empty;
+            var evaluated = OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, baseExpressionType);
 
-            if (evaluated is {} result && TypeHelper.IsLiteralType(result) && !foldDiags.OfType<ErrorDiagnostic>().Any())
+            if (evaluated is {} result && TypeHelper.IsLiteralType(result))
             {
                 return result;
             }
 
-            return ErrorType.Create(foldDiags.OfType<ErrorDiagnostic>()
-                .Append(DiagnosticBuilder.ForPosition(syntax).TypeExpressionLiteralConversionFailed()));
+            return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).TypeExpressionLiteralConversionFailed());
         }
 
         private bool RequiresDeferral(SyntaxBase syntax) => syntax switch

--- a/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
+++ b/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
@@ -1,180 +1,267 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Azure.Deployments.Expression.Expressions;
+using System.Numerics;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.TypeSystem;
 
-internal static class OperationReturnTypeEvaluator
+public static class OperationReturnTypeEvaluator
 {
-    private static readonly ImmutableArray<UnaryEvaluator> unaryEvaluators = new List<UnaryEvaluator>()
-    {
-        new(UnaryOperator.Not, LanguageConstants.Bool, "not", LanguageConstants.Bool),
-        new(UnaryOperator.Minus, LanguageConstants.Int, "sub", LanguageConstants.Int, new FunctionArgument(0)),
-    }.ToImmutableArray();
+    private static readonly ImmutableArray<IUnaryEvaluator> unaryEvaluators = ImmutableArray.Create<IUnaryEvaluator>(
+        new NotEvaluator(),
+        new MinusEvaluator());
 
-    private static readonly ImmutableArray<BinaryEvaluator> binaryEvaluators = new List<BinaryEvaluator>()
-    {
+    private static readonly IBinaryEvaluator equalsEvaluator
+        = new BinaryEvaluator(BinaryOperator.Equals, (LanguageConstants.Any, LanguageConstants.Any), "equals", LanguageConstants.Bool);
+
+    private static readonly ImmutableArray<IBinaryEvaluator> binaries = ImmutableArray.Create<IBinaryEvaluator>(
         // logical
-        new(BinaryOperator.LogicalOr, LanguageConstants.Bool, LanguageConstants.Bool, "or", LanguageConstants.Bool),
-        new(BinaryOperator.LogicalAnd, LanguageConstants.Bool, LanguageConstants.Bool, "and", LanguageConstants.Bool),
+        new LogicalOrEvaluator(),
+        new LogicalAndEvaluator(),
 
         // equality
-        new(BinaryOperator.Equals, LanguageConstants.Any, LanguageConstants.Any, "equals", LanguageConstants.Bool),
+        equalsEvaluator,
         new NotEqualsEvaluator(),
         new InsensitiveEqualityEvaluator(BinaryOperator.EqualsInsensitive),
         new InsensitiveEqualityEvaluator(BinaryOperator.NotEqualsInsensitive, negated: true),
 
         // relational (int)
-        new(BinaryOperator.LessThan, LanguageConstants.Int, LanguageConstants.Int, "less", LanguageConstants.Bool),
-        new(BinaryOperator.LessThanOrEqual, LanguageConstants.Int, LanguageConstants.Int, "lessOrEquals", LanguageConstants.Bool),
-        new(BinaryOperator.GreaterThan, LanguageConstants.Int, LanguageConstants.Int, "greater", LanguageConstants.Bool),
-        new(BinaryOperator.GreaterThanOrEqual, LanguageConstants.Int, LanguageConstants.Int, "greaterOrEquals", LanguageConstants.Bool),
+        new LessThanEvaluator(),
+        new LessThanOrEqualToEvaluator(),
+        new GreaterThanEvaluator(),
+        new GreaterThanOrEqualToEvaluator(),
 
         // relational (string)
-        new(BinaryOperator.LessThan, LanguageConstants.String, LanguageConstants.String, "less", LanguageConstants.Bool),
-        new(BinaryOperator.LessThanOrEqual, LanguageConstants.String, LanguageConstants.String, "lessOrEquals", LanguageConstants.Bool),
-        new(BinaryOperator.GreaterThan, LanguageConstants.String, LanguageConstants.String, "greater", LanguageConstants.Bool),
-        new(BinaryOperator.GreaterThanOrEqual, LanguageConstants.String, LanguageConstants.String, "greaterOrEquals", LanguageConstants.Bool),
+        new BinaryEvaluator(BinaryOperator.LessThan, (LanguageConstants.String, LanguageConstants.String), "less", LanguageConstants.Bool),
+        new BinaryEvaluator(BinaryOperator.LessThanOrEqual, (LanguageConstants.String, LanguageConstants.String), "lessOrEquals", LanguageConstants.Bool),
+        new BinaryEvaluator(BinaryOperator.GreaterThan, (LanguageConstants.String, LanguageConstants.String), "greater", LanguageConstants.Bool),
+        new BinaryEvaluator(BinaryOperator.GreaterThanOrEqual, (LanguageConstants.String, LanguageConstants.String), "greaterOrEquals", LanguageConstants.Bool),
 
         // arithmetic
-        new(BinaryOperator.Add, LanguageConstants.Int, LanguageConstants.Int, "add", LanguageConstants.Int),
-        new(BinaryOperator.Subtract, LanguageConstants.Int, LanguageConstants.Int, "sub", LanguageConstants.Int),
-        new(BinaryOperator.Multiply, LanguageConstants.Int, LanguageConstants.Int, "mul", LanguageConstants.Int),
-        new(BinaryOperator.Divide, LanguageConstants.Int, LanguageConstants.Int, "mul", LanguageConstants.Int),
-        new(BinaryOperator.Modulo, LanguageConstants.Int, LanguageConstants.Int, "mod", LanguageConstants.Int),
+        new AdditionEvaluator(),
+        new SubtractionEvaluator(),
+        new BinaryEvaluator(BinaryOperator.Multiply, (LanguageConstants.Int, LanguageConstants.Int), "mul", LanguageConstants.Int),
+        new BinaryEvaluator(BinaryOperator.Divide, (LanguageConstants.Int, LanguageConstants.Int), "div", LanguageConstants.Int),
+        new ModuloEvaluator(),
 
         // coalesce
-        new(BinaryOperator.Coalesce, LanguageConstants.Any, LanguageConstants.Any, "coalesce", LanguageConstants.Any),
-    }.ToImmutableArray();
+        new CoalesceEvaluator());
 
-    internal static TypeSymbol? FoldUnaryExpression(UnaryOperationSyntax expressionSyntax, TypeSymbol operandType, out IEnumerable<IDiagnostic> foldDiagnostics)
+    public static TypeSymbol? TryFoldUnaryExpression(UnaryOperationSyntax expressionSyntax, TypeSymbol operandType)
+        => unaryEvaluators.Where(e => e.IsMatch(expressionSyntax.Operator, operandType)).FirstOrDefault()?.Evaluate(expressionSyntax, operandType);
+
+    public static TypeSymbol? TryFoldBinaryExpression(BinaryOperationSyntax expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, out IEnumerable<IDiagnostic> foldDiagnostics)
     {
-        if (unaryEvaluators.Where(e => e.IsMatch(expressionSyntax.Operator, operandType)).FirstOrDefault() is {} evaluator)
+        if (binaries.Where(e => e.IsMatch(expressionSyntax.Operator, leftOperandType, rightOperandType)).FirstOrDefault() is {} evaluator)
         {
-            return evaluator.Evaluate(expressionSyntax, out foldDiagnostics, operandType);
+            return evaluator.Evaluate(expressionSyntax, leftOperandType, rightOperandType, out foldDiagnostics);
         }
 
         foldDiagnostics = Enumerable.Empty<IDiagnostic>();
         return null;
     }
 
-    internal static TypeSymbol? FoldBinaryExpression(BinaryOperationSyntax expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, out IEnumerable<IDiagnostic> foldDiagnostics)
+    private interface IUnaryEvaluator
     {
-        if (binaryEvaluators.Where(e => e.IsMatch(expressionSyntax.Operator, leftOperandType, rightOperandType)).FirstOrDefault() is {} evaluator)
-        {
-            return evaluator.Evaluate(expressionSyntax, out foldDiagnostics, leftOperandType, rightOperandType);
-        }
+        UnaryOperator Operator { get; }
 
-        foldDiagnostics = Enumerable.Empty<IDiagnostic>();
-        return null;
+        TypeSymbol OperandType { get; }
+
+        TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol operandType);
+
+        bool IsMatch(UnaryOperator @operator, TypeSymbol operandType)
+            => Operator == @operator && TypeValidator.AreTypesAssignable(operandType, OperandType);
     }
 
-    private abstract class Evaluator
+    private class NotEvaluator : IUnaryEvaluator
     {
+        public UnaryOperator Operator => UnaryOperator.Not;
+
+        public TypeSymbol OperandType => LanguageConstants.Bool;
+
+        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol operandType) => operandType switch
+        {
+            UnionType union => TypeHelper.CreateTypeUnion(union.Members.Select(t => Evaluate(expressionSyntax, t.Type))), 
+            BooleanLiteralType booleanLiteral => TypeFactory.CreateBooleanLiteralType(!booleanLiteral.Value, booleanLiteral.ValidationFlags),
+            BooleanType @bool => @bool,
+            _ => TypeFactory.CreateBooleanType(operandType.ValidationFlags),
+        };
+    }
+
+    private static TypeSymbol Negate(TypeSymbol toNegate)
+    {
+        switch (toNegate)
+        {
+            case UnionType union:
+                List<TypeSymbol> transformed = new();
+                List<ErrorType> errors = new();
+
+                foreach (var member in union.Members)
+                {
+                    var evaluatedMember = Negate(member.Type);
+
+                    if (evaluatedMember is ErrorType error)
+                    {
+                        errors.Add(error);
+                    }
+                    else
+                    {
+                        transformed.Add(evaluatedMember);
+                    }
+                }
+
+                if (errors.Any())
+                {
+                    return ErrorType.Create(errors.SelectMany(e => e.GetDiagnostics()));
+                }
+
+                var unionOfTransformed = TypeHelper.CreateTypeUnion(transformed);
+                return TypeCollapser.TryCollapse(unionOfTransformed) ?? unionOfTransformed;
+            case IntegerLiteralType integerLiteral when Negate(integerLiteral.Value) is long negated:
+                return TypeFactory.CreateIntegerLiteralType(negated, integerLiteral.ValidationFlags);
+            case IntegerType @int:
+                return TypeFactory.CreateIntegerType(minValue: Negate(@int.MaxValue), maxValue: Negate(@int.MinValue), @int.ValidationFlags);
+            default:
+                return LanguageConstants.Int;
+        }
+    }
+
+    private static long? Negate(long? toNegate) => toNegate switch
+    {
+        long nonNull => Negate(nonNull),
+        _ => null,
+    };
+
+    private static long? Negate(long toNegate) => toNegate switch
+    {
+        // -long.MinValue would overflow by 1
+        long.MinValue => null,
+        _ => -toNegate,
+    };
+
+    private class MinusEvaluator : IUnaryEvaluator
+    {
+        public UnaryOperator Operator => UnaryOperator.Minus;
+
+        public TypeSymbol OperandType => LanguageConstants.Int;
+
+        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol operandType) => Negate(operandType);
+    }
+
+    private interface IBinaryEvaluator
+    {
+        BinaryOperator Operator { get; }
+
+        (TypeSymbol Left, TypeSymbol Right) OperandTypes { get; }
+
+        TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, out IEnumerable<IDiagnostic> evaluationDiagnostics);
+
+        bool IsMatch(BinaryOperator @operator, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+            => Operator == @operator &&
+                TypeValidator.AreTypesAssignable(leftOperandType, OperandTypes.Left) &&
+                TypeValidator.AreTypesAssignable(rightOperandType, OperandTypes.Right);
+    }
+
+    private class BinaryEvaluator : IBinaryEvaluator
+    {
+        private readonly BinaryOperator @operator;
+        private readonly (TypeSymbol, TypeSymbol) operandTypes;
         private readonly string armFunctionName;
-        private readonly TypeSymbol nonLiteralReturnType;
-        private readonly ImmutableArray<FunctionArgument>? prefixArgs;
+        private readonly TypeSymbol genericReturnType;
 
-        protected Evaluator(string armFunctionName, TypeSymbol nonLiteralReturnType, params FunctionArgument[] prefixArgs)
+        public BinaryEvaluator(BinaryOperator @operator, (TypeSymbol, TypeSymbol) operandTypes, string armFunctionName, TypeSymbol genericReturnType)
         {
+            this.@operator = @operator;
+            this.operandTypes = operandTypes;
             this.armFunctionName = armFunctionName;
-            this.nonLiteralReturnType = nonLiteralReturnType;
-            this.prefixArgs = prefixArgs.Any() ? prefixArgs.ToImmutableArray() : null;
+            this.genericReturnType = genericReturnType;
         }
 
-        internal virtual TypeSymbol Evaluate(SyntaxBase expressionSyntax, out IEnumerable<IDiagnostic> evaluationDiagnostics, params TypeSymbol[] operandTypes)
+        public BinaryOperator Operator => @operator;
+
+        public (TypeSymbol, TypeSymbol) OperandTypes => operandTypes;
+
+        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, out IEnumerable<IDiagnostic> evaluationDiagnostics)
         {
-            var type = ArmFunctionReturnTypeEvaluator.TryEvaluate(armFunctionName, out var builders, operandTypes, prefixArgs) ?? nonLiteralReturnType;
+            var literal = ArmFunctionReturnTypeEvaluator.TryEvaluate(armFunctionName, out var builders, new[] { leftOperandType, rightOperandType });
             evaluationDiagnostics = builders.Select(b => b(DiagnosticBuilder.ForPosition(expressionSyntax)));
 
-            return type;
-        }
-    }
-
-    private class UnaryEvaluator : Evaluator
-    {
-        private readonly UnaryOperator unaryOperator;
-        private readonly TypeSymbol expectedOperandType;
-
-        internal UnaryEvaluator(UnaryOperator unaryOperator,
-            TypeSymbol expectedOperandType,
-            string armFunctionName,
-            TypeSymbol nonLiteralReturnType,
-            params FunctionArgument[] prefixArgs) : base(armFunctionName, nonLiteralReturnType, prefixArgs)
-        {
-            this.unaryOperator = unaryOperator;
-            this.expectedOperandType = expectedOperandType;
+            return literal ?? TryDeriveNonLiteralType(expressionSyntax, leftOperandType, rightOperandType) ?? genericReturnType;
         }
 
-        internal bool IsMatch(UnaryOperator @operator, TypeSymbol operandType)
-            => unaryOperator == @operator && TypeValidator.AreTypesAssignable(operandType, expectedOperandType);
+        protected virtual TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+            => null;
     }
 
-    private class BinaryEvaluator : Evaluator
+    private class LogicalOrEvaluator : BinaryEvaluator
     {
-        private readonly BinaryOperator binaryOperator;
-        private readonly TypeSymbol expectedLeftOperandType;
-        private readonly TypeSymbol expectedRightOperandType;
+        public LogicalOrEvaluator() : base(BinaryOperator.LogicalOr, (LanguageConstants.Bool, LanguageConstants.Bool), "or", LanguageConstants.Bool) { }
 
-        internal BinaryEvaluator(BinaryOperator binaryOperator,
-            TypeSymbol expectedLeftOperandType,
-            TypeSymbol expectedRightOperandType,
-            string armFunctionName,
-            TypeSymbol nonLiteralReturnType,
-            params FunctionArgument[] prefixArgs) : base(armFunctionName, nonLiteralReturnType, prefixArgs)
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType) => (leftOperandType, rightOperandType) switch
         {
-            this.binaryOperator = binaryOperator;
-            this.expectedLeftOperandType = expectedLeftOperandType;
-            this.expectedRightOperandType = expectedRightOperandType;
-        }
-
-        internal bool IsMatch(BinaryOperator @operator, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
-            => binaryOperator == @operator &&
-                TypeValidator.AreTypesAssignable(leftOperandType, expectedLeftOperandType) &&
-                TypeValidator.AreTypesAssignable(rightOperandType, expectedRightOperandType);
+            (BooleanLiteralType leftLiteral, _) when leftLiteral.Value => LanguageConstants.True,
+            (_, BooleanLiteralType rightLiteral) when rightLiteral.Value => LanguageConstants.True,
+            (BooleanLiteralType, BooleanLiteralType) => LanguageConstants.False,
+            _ => null,
+        };
     }
 
-    private class NotEqualsEvaluator : BinaryEvaluator
+    private class LogicalAndEvaluator : BinaryEvaluator
     {
-        internal NotEqualsEvaluator() : base(BinaryOperator.NotEquals, LanguageConstants.Any, LanguageConstants.Any, "", LanguageConstants.Bool) {}
+        public LogicalAndEvaluator() : base(BinaryOperator.LogicalAnd, (LanguageConstants.Bool, LanguageConstants.Bool), "and", LanguageConstants.Bool) { }
 
-        internal override TypeSymbol Evaluate(SyntaxBase expressionSyntax, out IEnumerable<IDiagnostic> evaluationDiagnostics, params TypeSymbol[] operandTypes)
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType) => (leftOperandType, rightOperandType) switch
         {
-            var returnType = ArmFunctionReturnTypeEvaluator.TryEvaluate("equals", out var builders, operandTypes);
-            evaluationDiagnostics = builders.Select(builder => builder(DiagnosticBuilder.ForPosition(expressionSyntax)));
+            (BooleanLiteralType leftLiteral, _) when !leftLiteral.Value => LanguageConstants.False,
+            (_, BooleanLiteralType rightLiteral) when !rightLiteral.Value => LanguageConstants.False,
+            (BooleanLiteralType, BooleanLiteralType) => LanguageConstants.True,
+            _ => null,
+        };
+    }
 
-            if (returnType is BooleanLiteralType booleanLiteral)
+    private class NotEqualsEvaluator : IBinaryEvaluator
+    {
+        public BinaryOperator Operator => BinaryOperator.NotEquals;
+
+        public (TypeSymbol, TypeSymbol) OperandTypes => equalsEvaluator.OperandTypes;
+
+        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, out IEnumerable<IDiagnostic> evaluationDiagnostics)
+            => equalsEvaluator.Evaluate(expressionSyntax, leftOperandType, rightOperandType, out evaluationDiagnostics) switch
             {
-                return TypeFactory.CreateBooleanLiteralType(!booleanLiteral.Value);
-            }
-
-            return LanguageConstants.Bool;
-        }
+                BooleanLiteralType literalReturn => TypeFactory.CreateBooleanLiteralType(!literalReturn.Value),
+                _ => LanguageConstants.Bool,
+            };
     }
 
-    private class InsensitiveEqualityEvaluator : BinaryEvaluator
+    private class InsensitiveEqualityEvaluator : IBinaryEvaluator
     {
+        private readonly BinaryOperator @operator;
         private readonly bool negated;
 
-        internal InsensitiveEqualityEvaluator(BinaryOperator op, bool negated = false) : base(op, LanguageConstants.String, LanguageConstants.String, "", LanguageConstants.Bool)
+        internal InsensitiveEqualityEvaluator(BinaryOperator @operator, bool negated = false)
         {
+            this.@operator = @operator;
             this.negated = negated;
         }
 
-        internal override TypeSymbol Evaluate(SyntaxBase expressionSyntax, out IEnumerable<IDiagnostic> evaluationDiagnostics, params TypeSymbol[] operandTypes)
+        public BinaryOperator Operator => @operator;
+
+        public (TypeSymbol, TypeSymbol) OperandTypes => (LanguageConstants.String, LanguageConstants.String);
+
+        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, out IEnumerable<IDiagnostic> evaluationDiagnostics)
         {
             List<IDiagnostic> diags = new();
             evaluationDiagnostics = diags;
-            var transformedArgTypes = new TypeSymbol[operandTypes.Length];
-            for (int i = 0; i < operandTypes.Length; i++)
+            var transformedArgTypes = new TypeSymbol[2];
+            for (int i = 0; i < 2; i++)
             {
-                transformedArgTypes[i] = ArmFunctionReturnTypeEvaluator.TryEvaluate("toLower", out var builderDelegates, new [] { operandTypes[i] }) ?? LanguageConstants.String;
+                transformedArgTypes[i] = ArmFunctionReturnTypeEvaluator.TryEvaluate("toLower", out var builderDelegates, new [] { i % 2 == 0 ? leftOperandType : rightOperandType }) ?? LanguageConstants.String;
                 diags.AddRange(builderDelegates.Select(b => b(DiagnosticBuilder.ForPosition(expressionSyntax))));
             }
 
@@ -188,5 +275,214 @@ internal static class OperationReturnTypeEvaluator
 
             return LanguageConstants.Bool;
         }
+    }
+
+    private abstract class NumericComparisonEvaluator : BinaryEvaluator
+    {
+        protected NumericComparisonEvaluator(BinaryOperator @operator, string armFunctionName)
+            : base(@operator, (LanguageConstants.Int, LanguageConstants.Int), armFunctionName, LanguageConstants.Bool) { }
+    }
+
+    private static long? MinValue(TypeSymbol operandType) => operandType switch
+    {
+        IntegerLiteralType literal => literal.Value,
+        IntegerType @int => @int.MinValue,
+        UnionType union => union.Members.Select(m => MinValue(m.Type)) switch
+        {
+            IEnumerable<long?> minOfEachMember when minOfEachMember.All(m => m.HasValue) => minOfEachMember.Min(),
+            _ => null,
+        },
+        _ => null,
+    };
+
+    private static long? MaxValue(TypeSymbol operandType) => operandType switch
+    {
+        IntegerLiteralType literal => literal.Value,
+        IntegerType @int => @int.MaxValue,
+        UnionType union => union.Members.Select(m => MaxValue(m.Type)) switch
+        {
+            IEnumerable<long?> maxOfEachMember when maxOfEachMember.All(m => m.HasValue) => maxOfEachMember.Max(),
+            _ => null,
+        },
+        _ => null,
+    };
+
+    private class LessThanEvaluator : NumericComparisonEvaluator
+    {
+        internal LessThanEvaluator() : base(BinaryOperator.LessThan, "less") { }
+
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+        {
+            if (MaxValue(leftOperandType) is long leftMax && MinValue(rightOperandType) is long rightMin && leftMax < rightMin)
+            {
+                return LanguageConstants.True;
+            }
+
+            if (MinValue(leftOperandType) is long leftMin && MaxValue(rightOperandType) is long rightMax && leftMin >= rightMax)
+            {
+                return LanguageConstants.False;
+            }
+
+            return null;
+        }
+    }
+
+    private class LessThanOrEqualToEvaluator : NumericComparisonEvaluator
+    {
+        internal LessThanOrEqualToEvaluator() : base(BinaryOperator.LessThanOrEqual, "lessOrEquals") { }
+
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+        {
+            if (MaxValue(leftOperandType) is long leftMax && MinValue(rightOperandType) is long rightMin && leftMax <= rightMin)
+            {
+                return LanguageConstants.True;
+            }
+
+            if (MinValue(leftOperandType) is long leftMin && MaxValue(rightOperandType) is long rightMax && leftMin > rightMax)
+            {
+                return LanguageConstants.False;
+            }
+
+            return null;
+        }
+    }
+
+    private class GreaterThanEvaluator : NumericComparisonEvaluator
+    {
+        internal GreaterThanEvaluator() : base(BinaryOperator.GreaterThan, "greater") { }
+
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+        {
+            if (MinValue(leftOperandType) is long leftMin && MaxValue(rightOperandType) is long rightMax && leftMin > rightMax)
+            {
+                return LanguageConstants.True;
+            }
+
+            if (MaxValue(leftOperandType) is long leftMax && MinValue(rightOperandType) is long rightMin && leftMax <= rightMin)
+            {
+                return LanguageConstants.False;
+            }
+
+            return null;
+        }
+    }
+
+    private class GreaterThanOrEqualToEvaluator : NumericComparisonEvaluator
+    {
+        internal GreaterThanOrEqualToEvaluator() : base(BinaryOperator.GreaterThanOrEqual, "greaterOrEquals") { }
+
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+        {
+            if (MinValue(leftOperandType) is long leftMin && MaxValue(rightOperandType) is long rightMax && leftMin >= rightMax)
+            {
+                return LanguageConstants.True;
+            }
+
+            if (MaxValue(leftOperandType) is long leftMax && MinValue(rightOperandType) is long rightMin && leftMax < rightMin)
+            {
+                return LanguageConstants.False;
+            }
+
+            return null;
+        }
+    }
+
+    private abstract class ArithmeticEvaluator : BinaryEvaluator
+    {
+        protected ArithmeticEvaluator(BinaryOperator @operator, string armFunctionName)
+            : base(@operator, (LanguageConstants.Int, LanguageConstants.Int), armFunctionName, LanguageConstants.Int) { }
+
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+            => DeriveNonLiteralType(leftOperandType, rightOperandType);
+
+        private TypeSymbol DeriveNonLiteralType(TypeSymbol leftOperandType, TypeSymbol rightOperandType) => (leftOperandType, rightOperandType) switch
+        {
+            (UnionType leftUnion, _) => CollapseIfPossible(TypeHelper.CreateTypeUnion(leftUnion.Members.Select(m => DeriveNonLiteralType(m.Type, rightOperandType)))),
+            (_, UnionType rightUnion) => CollapseIfPossible(TypeHelper.CreateTypeUnion(rightUnion.Members.Select(m => DeriveNonLiteralType(leftOperandType, m.Type)))),
+            _ => PerformTypeArithmetic(leftOperandType, rightOperandType),
+        };
+
+        private static TypeSymbol CollapseIfPossible(TypeSymbol derived) => TypeCollapser.TryCollapse(derived) ?? derived;
+
+        protected abstract TypeSymbol PerformTypeArithmetic(TypeSymbol leftOperandType, TypeSymbol rightOperandType);
+    }
+
+    private static TypeSymbol PerformAdditiveTypeArithmetic(TypeSymbol leftOperand, TypeSymbol rightOperand) => (leftOperand, rightOperand) switch
+    {
+        (IntegerLiteralType leftLiteral, IntegerLiteralType rightLiteral) when TryAdd(leftLiteral.Value, rightLiteral.Value) is long sum
+            => TypeFactory.CreateIntegerLiteralType(sum),
+        (IntegerLiteralType leftLiteral, IntegerType rightInt) => PerformAdditiveTypeArithmetic(leftLiteral, rightInt),
+        (IntegerType leftInt, IntegerLiteralType rightLiteral) => PerformAdditiveTypeArithmetic(rightLiteral, leftInt),
+        (IntegerType leftInt, IntegerType rightInt) => TypeFactory.CreateIntegerType(TryAdd(leftInt.MinValue, rightInt.MinValue), TryAdd(leftInt.MaxValue, rightInt.MaxValue)),
+        _ => LanguageConstants.Int,
+
+    };
+
+    private static TypeSymbol PerformAdditiveTypeArithmetic(IntegerLiteralType integerLiteral, IntegerType @int)
+        => TypeFactory.CreateIntegerType(TryAdd(integerLiteral.Value, @int.MinValue), TryAdd(integerLiteral.Value, @int.MaxValue));
+
+    private static long? TryAdd(long? a, long? b) => (a, b) switch
+    {
+        (long nonNullA, long nonNullB) => BigInteger.Add(nonNullA, nonNullB) switch
+        {
+            var sum when sum >= long.MinValue || sum <= long.MaxValue => (long)sum,
+            _ => null,
+        },
+        _ => null,
+    };
+
+    private class AdditionEvaluator : ArithmeticEvaluator
+    {
+        internal AdditionEvaluator() : base(BinaryOperator.Add, "add") { }
+
+        protected override TypeSymbol PerformTypeArithmetic(TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+            => PerformAdditiveTypeArithmetic(leftOperandType, rightOperandType);
+    }
+
+    private class SubtractionEvaluator : ArithmeticEvaluator
+    {
+        internal SubtractionEvaluator() : base(BinaryOperator.Subtract, "sub") { }
+
+        protected override TypeSymbol PerformTypeArithmetic(TypeSymbol leftOperandType, TypeSymbol rightOperandType)
+            => PerformAdditiveTypeArithmetic(leftOperandType, Negate(rightOperandType));
+    }
+
+    private class ModuloEvaluator : ArithmeticEvaluator
+    {
+        internal ModuloEvaluator() : base(BinaryOperator.Modulo, "mod") { }
+
+        protected override TypeSymbol PerformTypeArithmetic(TypeSymbol leftOperandType, TypeSymbol rightOperandType) => (leftOperandType, rightOperandType) switch
+        {
+            (IntegerLiteralType literalDividend, IntegerLiteralType literalDivisor) => TypeFactory.CreateIntegerLiteralType(literalDividend.Value % literalDivisor.Value),
+            (IntegerType rangedDividend, IntegerLiteralType literalDivisor) => TypeFactory.CreateIntegerType(
+                minValue: rangedDividend.MinValue.HasValue && rangedDividend.MinValue.Value >= 0
+                    ? 0
+                    : 1 - Math.Abs(literalDivisor.Value),
+                maxValue: rangedDividend.MaxValue.HasValue && rangedDividend.MaxValue.Value <= 0
+                    ? 0
+                    : Math.Abs(literalDivisor.Value) - 1),
+            (_, IntegerLiteralType literalDivisor) => TypeFactory.CreateIntegerType(1 - Math.Abs(literalDivisor.Value), Math.Abs(literalDivisor.Value) - 1),
+            (_, IntegerType rangedDivisor) when rangedDivisor.MinValue.HasValue && rangedDivisor.MaxValue.HasValue && rangedDivisor.MinValue.Value > long.MinValue
+                => Math.Max(Math.Abs(rangedDivisor.MinValue.Value), Math.Abs(rangedDivisor.MaxValue.Value)) switch
+                {
+                    long maxDivisor => TypeFactory.CreateIntegerType(1 - maxDivisor, maxDivisor - 1),
+                },
+            _ => LanguageConstants.Int,
+        };
+    }
+
+    private class CoalesceEvaluator : BinaryEvaluator
+    {
+        public CoalesceEvaluator() : base(BinaryOperator.Coalesce, (LanguageConstants.Any, LanguageConstants.Any), "coalesce", LanguageConstants.Any) { }
+
+        protected override TypeSymbol? TryDeriveNonLiteralType(SyntaxBase expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType) => leftOperandType switch
+        {
+            // if the left operand is definitely null, use the right operand's type
+            NullType => rightOperandType,
+            // if the left operand may be null, use a union of the type the left operand will be if not null plus the right operand's type
+            _ when TypeHelper.TryRemoveNullability(leftOperandType) is TypeSymbol nonNullType => TypeHelper.CreateTypeUnion(nonNullType, rightOperandType),
+            // if we got here, the left operand is not nullable, so use its type
+            _ => leftOperandType,
+        };
     }
 }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1059,7 +1059,7 @@ namespace Bicep.Core.TypeSystem
 
                 // operands don't appear to have errors
                 // let's fold the expression so that an operation with two literal typed operands will have a literal return type
-                if (OperationReturnTypeEvaluator.FoldBinaryExpression(syntax, operandType1, operandType2, out var foldDiags) is {} result)
+                if (OperationReturnTypeEvaluator.TryFoldBinaryExpression(syntax, operandType1, operandType2, out var foldDiags) is {} result)
                 {
                     diagnostics.WriteMultiple(foldDiags);
 
@@ -1094,10 +1094,8 @@ namespace Bicep.Core.TypeSystem
 
                 // operand doesn't appear to have errors
                 // let's fold the expression so that an operation with a literal typed operand will have a literal return type
-                if (OperationReturnTypeEvaluator.FoldUnaryExpression(syntax, operandType, out var foldDiags) is {} result)
+                if (OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, operandType) is {} result)
                 {
-                    diagnostics.WriteMultiple(foldDiags);
-
                     return result;
                 }
 

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1059,10 +1059,8 @@ namespace Bicep.Core.TypeSystem
 
                 // operands don't appear to have errors
                 // let's fold the expression so that an operation with two literal typed operands will have a literal return type
-                if (OperationReturnTypeEvaluator.TryFoldBinaryExpression(syntax, operandType1, operandType2, out var foldDiags) is {} result)
+                if (OperationReturnTypeEvaluator.TryFoldBinaryExpression(syntax, operandType1, operandType2, diagnostics) is {} result)
                 {
-                    diagnostics.WriteMultiple(foldDiags);
-
                     return result;
                 }
 
@@ -1094,7 +1092,7 @@ namespace Bicep.Core.TypeSystem
 
                 // operand doesn't appear to have errors
                 // let's fold the expression so that an operation with a literal typed operand will have a literal return type
-                if (OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, operandType) is {} result)
+                if (OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, operandType, diagnostics) is {} result)
                 {
                     return result;
                 }


### PR DESCRIPTION
Partly addresses #10098 and resolves #10429

This PR updates operator expression analysis to perform type arithmetic on operators to determine if a more precise type can be derived. The TypeAssignmentVisitor is currently executing the underlying ARM function when all operands are literal, and this PR augments that behavior by falling back to type metadata analysis if one or more operands are non-literal (e.g., we can infer that `int % 3` will be `> -3 && < 3`)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10545)