### PR TITLE
Support bicepparam files for VS Code deploy bicep file action

### DIFF
--- a/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
@@ -103,6 +103,9 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection WithAzResourceProvider(this IServiceCollection services, IAzResourceProvider azResourceProvider)
         => Register(services, azResourceProvider);
 
+    public static IServiceCollection WithArmClientProvider(this IServiceCollection services, IArmClientProvider armClientProvider)
+        => Register(services, armClientProvider);
+
     public static IServiceCollection WithEmptyAzResources(this IServiceCollection services)
         => services.WithAzResources(Enumerable.Empty<ResourceTypeComponents>());
 

--- a/src/Bicep.LangServer.IntegrationTests/DeployBicepFileActionTest.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DeployBicepFileActionTest.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.ResourceManager;
+using Bicep.Core;
+using Bicep.Core.FileSystem;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.FileSystem;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.LangServer.IntegrationTests.Helpers;
+using Bicep.LanguageServer.Handlers;
+using Bicep.LanguageServer.Providers;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+using TextRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Bicep.LangServer.IntegrationTests
+{
+    public class MockArmClientProvider : IArmClientProvider
+    {
+        public ArmClient createArmClient(TokenCredential credential, string? defaultSubscriptionId, ArmClientOptions options)
+        {
+            var clientMock = StrictMock.Of<ArmClient>();
+
+            return clientMock.Object;
+        }
+    }
+
+    [TestClass]
+    public class DeployBicepFileActionTest
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        [TestMethod]
+        public async Task IncorrectUpdateOption_WithBicepparamFile_ReturnsError()
+        {   
+            var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
+            var bicepparamFileUri = InMemoryFileResolver.GetFileUri("/path/to/param.bicepparam");
+
+            var fileTextsByUri = new Dictionary<Uri, string>() 
+            {
+                [bicepFileUri] = "",
+                [bicepparamFileUri] = ""
+            };
+
+            using var helper = await LanguageServerHelper.StartServerWithText(
+                TestContext, 
+                fileTextsByUri,
+                bicepFileUri, 
+                services => services
+                .WithFeatureOverrides(new(TestContext, ParamsFilesEnabled: true))
+                .WithArmClientProvider(new MockArmClientProvider()));
+
+            var client = helper.Client;
+            var bicepDeploymentStartParams = new BicepDeploymentStartParams(
+                bicepFileUri.AbsolutePath, 
+                bicepparamFileUri.AbsolutePath, 
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                "fake-token-123",
+                "123456",
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                true,
+                string.Empty,
+                LanguageServer.Deploy.ParametersFileUpdateOption.Create,
+                new List<BicepUpdatedDeploymentParameter>(),
+                "https://management.azure.com/",
+                "https://management.core.windows.net/");
+
+            var deploymentStartResponse = await client.Workspace.ExecuteCommandWithResponse<BicepDeploymentStartResponse>(
+                new Command {
+                    Name = "deploy/start",
+                    Arguments = new JArray(
+                        bicepDeploymentStartParams.ToJToken()
+                    )
+                }
+            );
+
+            deploymentStartResponse.isSuccess.Should().BeFalse();
+            deploymentStartResponse.outputMessage.Should().Be("Cannot create/overwrite/update parameter files when using a bicep parameters file");
+        }
+
+        [TestMethod]
+        public async Task ProvidingUpdateParameterValues_WithBicepparamFile_ReturnsError()
+        {   
+            var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
+            var bicepparamFileUri = InMemoryFileResolver.GetFileUri("/path/to/param.bicepparam");
+
+            var fileTextsByUri = new Dictionary<Uri, string>() 
+            {
+                [bicepFileUri] = "",
+                [bicepparamFileUri] = ""
+            };
+
+            using var helper = await LanguageServerHelper.StartServerWithText(
+                TestContext, 
+                fileTextsByUri,
+                bicepFileUri, 
+                services => services
+                .WithFeatureOverrides(new(TestContext, ParamsFilesEnabled: true))
+                .WithArmClientProvider(new MockArmClientProvider()));
+
+            var client = helper.Client;
+            var bicepDeploymentStartParams = new BicepDeploymentStartParams(
+                bicepFileUri.AbsolutePath, 
+                bicepparamFileUri.AbsolutePath, 
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                "fake-token-123",
+                "123456",
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                true,
+                string.Empty,
+                LanguageServer.Deploy.ParametersFileUpdateOption.None,
+                new List<BicepUpdatedDeploymentParameter>{
+                    new BicepUpdatedDeploymentParameter("foo", "bar", false, null)
+                },
+                "https://management.azure.com/",
+                "https://management.core.windows.net/");
+
+            var deploymentStartResponse = await client.Workspace.ExecuteCommandWithResponse<BicepDeploymentStartResponse>(
+                new Command {
+                    Name = "deploy/start",
+                    Arguments = new JArray(
+                        bicepDeploymentStartParams.ToJToken()
+                    )
+                }
+            );
+
+            deploymentStartResponse.isSuccess.Should().BeFalse();
+            deploymentStartResponse.outputMessage.Should().Be("Cannot update parameters for bicep parameter file");
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
@@ -12,6 +12,7 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using Bicep.Core;
+using Bicep.Core.Json;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.LanguageServer;
@@ -49,18 +50,15 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 armClient,
                 documentPath,
                 string.Empty,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 scope,
                 string.Empty,
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache()
+                );
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
                 string.Format(LangServerResources.UnsupportedTargetScopeMessage, scope));
@@ -84,18 +82,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 armClient,
                 documentPath,
                 string.Empty,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 LanguageConstants.TargetScopeTypeSubscription,
                 location,
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
 
@@ -118,18 +112,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 armClient,
                 documentPath,
                 string.Empty,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 LanguageConstants.TargetScopeTypeManagementGroup,
                 location,
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
 
@@ -153,18 +143,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 armClient,
                 documentPath,
                 string.Empty,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41",
                 LanguageConstants.TargetScopeTypeTenant,
                 string.Empty,
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
                 string.Format(LangServerResources.UnsupportedTargetScopeMessage, LanguageConstants.TargetScopeTypeTenant));
@@ -205,18 +191,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 CreateMockArmClient(),
                 documentPath,
                 template,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 scope,
                 location,
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 deployId,
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentStartedMessage, documentPath);
             var expectedDeploymentLink = @"https://portal.azure.com/#blade/HubsExtension/DeploymentDetailsBlade/overview/id/%2Fsubscriptions%2F07268dd7-4c50-434b-b1ff-67b8164edb41%2FresourceGroups%2Fbhavyatest%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2Fbicep_deployment";
@@ -225,102 +207,6 @@ namespace Bicep.LangServer.UnitTests.Deploy
             bicepDeployStartResponse.isSuccess.Should().BeTrue();
             bicepDeployStartResponse.outputMessage.Should().Be(expectedDeploymentOutputMessage);
             bicepDeployStartResponse.viewDeploymentInPortalMessage.Should().Be(expectedViewDeploymentInPortalMessage);
-        }
-
-        [TestMethod]
-        public async Task StartDeploymentAsync_WithInvalidParameterFilePath_ReturnsDeploymentFailedMessage()
-        {
-            var template = @"{
-  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
-  ""resources"": [
-    {
-      ""type"": ""Microsoft.Storage/storageAccounts"",
-      ""apiVersion"": ""2021-06-01"",
-      ""name"": ""storageaccount"",
-      ""location"": ""[resourceGroup().location]"",
-      ""properties"": {}
-    }
-  ]
-}";
-            var deploymentCollection = CreateDeploymentCollection(LanguageConstants.TargetScopeTypeSubscription);
-            var deploymentCollectionProvider = StrictMock.Of<IDeploymentCollectionProvider>();
-            deploymentCollectionProvider
-                .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeSubscription))
-                .Returns(deploymentCollection);
-            var documentPath = "some_path";
-            var parametersFilePath = @"c:\parameter.json";
-
-            var bicepDeployStartResponse = await DeploymentHelper.StartDeploymentAsync(
-                deploymentCollectionProvider.Object,
-                CreateMockArmClient(),
-                documentPath,
-                template,
-                parametersFilePath,
-                "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
-                LanguageConstants.TargetScopeTypeSubscription,
-                "eastus",
-                string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
-                "https://portal.azure.com",
-                "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
-
-            var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, @"Could not find file");
-
-            bicepDeployStartResponse.isSuccess.Should().BeFalse();
-            bicepDeployStartResponse.outputMessage.Should().Contain(expectedDeploymentOutputMessage);
-            bicepDeployStartResponse.viewDeploymentInPortalMessage.Should().BeNull();
-        }
-
-        [TestMethod]
-        public async Task StartDeploymentAsync_WithInvalidParameterFileContents_ReturnsDeploymentFailedMessage()
-        {
-            var template = @"{
-  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
-  ""resources"": [
-    {
-      ""type"": ""Microsoft.Storage/storageAccounts"",
-      ""apiVersion"": ""2021-06-01"",
-      ""name"": ""storageaccount"",
-      ""location"": ""[resourceGroup().location]"",
-      ""properties"": {}
-    }
-  ]
-}";
-            var deploymentCollection = CreateDeploymentCollection(LanguageConstants.TargetScopeTypeSubscription);
-            var deploymentCollectionProvider = StrictMock.Of<IDeploymentCollectionProvider>();
-            deploymentCollectionProvider
-                .Setup(m => m.GetDeploymentCollection(It.IsAny<ArmClient>(), It.IsAny<ResourceIdentifier>(), LanguageConstants.TargetScopeTypeSubscription))
-                .Returns(deploymentCollection);
-            string parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", "invalid_parameters_file");
-            var documentPath = "some_path";
-
-            var bicepDeployStartResponse = await DeploymentHelper.StartDeploymentAsync(
-                deploymentCollectionProvider.Object,
-                CreateMockArmClient(),
-                documentPath,
-                template,
-                parametersFilePath,
-                "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
-                LanguageConstants.TargetScopeTypeSubscription,
-                "eastus",
-                string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
-                "https://portal.azure.com",
-                "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
-
-            var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, @"Unexpected character encountered while parsing value: i. Path '', line 0, position 0.");
-
-            bicepDeployStartResponse.isSuccess.Should().BeFalse();
-            bicepDeployStartResponse.outputMessage.Should().Be(expectedDeploymentOutputMessage);
-            bicepDeployStartResponse.viewDeploymentInPortalMessage.Should().BeNull();
         }
 
         [TestMethod]
@@ -349,18 +235,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 CreateMockArmClient(),
                 documentPath,
                 template,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "",
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedMessage, documentPath);
 
@@ -396,18 +278,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 CreateMockArmClient(),
                 documentPath,
                 template,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "",
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage);
 
@@ -451,18 +329,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 CreateMockArmClient(),
                 documentPath,
                 template,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeResourceGroup,
                 "",
                 string.Empty,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache(),
-                null);
+                JsonElementFactory.CreateElement(""),
+                new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage);
 
@@ -510,18 +384,14 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 CreateMockArmClient(),
                 "some_path",
                 template,
-                string.Empty,
                 "/subscriptions/07268dd7-4c50-434b-b1ff-67b8164edb41/resourceGroups/bhavyatest",
                 LanguageConstants.TargetScopeTypeSubscription,
                 "eastus",
                 deployId,
-                string.Empty,
-                ParametersFileUpdateOption.None,
-                new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "deployment_name",
-                deploymentOperationsCache,
-                null);
+                JsonElementFactory.CreateElement(""),
+                deploymentOperationsCache);
 
             deploymentOperationsCache.FindAndRemoveDeploymentOperation(deployId).Should().NotBeNull();
         }

--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -56,7 +57,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache()
                 );
 
@@ -88,7 +89,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
@@ -118,7 +119,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
@@ -149,7 +150,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
@@ -197,7 +198,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 deployId,
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentStartedMessage, documentPath);
@@ -241,7 +242,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedMessage, documentPath);
@@ -284,7 +285,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage);
@@ -335,7 +336,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 string.Empty,
                 "https://portal.azure.com",
                 "bicep_deployment",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 new DeploymentOperationsCache());
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage);
@@ -390,7 +391,7 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 deployId,
                 "https://portal.azure.com",
                 "deployment_name",
-                JsonElementFactory.CreateElement(""),
+                JsonElementFactory.CreateElement("{}"),
                 deploymentOperationsCache);
 
             deploymentOperationsCache.FindAndRemoveDeploymentOperation(deployId).Should().NotBeNull();

--- a/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Deploy/DeploymentHelperTests.cs
@@ -59,7 +59,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
                 string.Format(LangServerResources.UnsupportedTargetScopeMessage, scope));
@@ -93,7 +94,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
 
@@ -126,7 +128,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.MissingLocationDeploymentFailedMessage, documentPath);
 
@@ -160,7 +163,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath,
                 string.Format(LangServerResources.UnsupportedTargetScopeMessage, LanguageConstants.TargetScopeTypeTenant));
@@ -211,7 +215,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 deployId,
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentStartedMessage, documentPath);
             var expectedDeploymentLink = @"https://portal.azure.com/#blade/HubsExtension/DeploymentDetailsBlade/overview/id/%2Fsubscriptions%2F07268dd7-4c50-434b-b1ff-67b8164edb41%2FresourceGroups%2Fbhavyatest%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2Fbicep_deployment";
@@ -260,7 +265,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, @"Could not find file");
 
@@ -307,7 +313,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.InvalidParameterFileDeploymentFailedMessage, documentPath, parametersFilePath, @"Unexpected character encountered while parsing value: i. Path '', line 0, position 0.");
 
@@ -352,7 +359,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedMessage, documentPath);
 
@@ -398,7 +406,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage);
 
@@ -452,7 +461,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "bicep_deployment",
-                new DeploymentOperationsCache());
+                new DeploymentOperationsCache(),
+                null);
 
             var expectedDeploymentOutputMessage = string.Format(LangServerResources.DeploymentFailedWithExceptionMessage, documentPath, errorMessage);
 
@@ -510,7 +520,8 @@ namespace Bicep.LangServer.UnitTests.Deploy
                 new List<BicepUpdatedDeploymentParameter>(),
                 "https://portal.azure.com",
                 "deployment_name",
-                deploymentOperationsCache);
+                deploymentOperationsCache,
+                null);
 
             deploymentOperationsCache.FindAndRemoveDeploymentOperation(deployId).Should().NotBeNull();
         }

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
@@ -69,9 +69,9 @@ param bar = 1
             var dir = Path.GetDirectoryName(bicepFilePath);
             string bicepparamFilePath = FileHelper.SaveResultFile(TestContext, "param.bicepparam", bicepparamFileContents, testOutputPath: dir);
 
-            DocumentUri bicepparamUri = DocumentUri.FromFileSystemPath(bicepparamFilePath);
+            var bicepparamUri = DocumentUri.FromFileSystemPath(bicepparamFilePath);
 
-            BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(bicepparamUri, bicepFileContents, upsertCompilation: false);
+            var bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(bicepparamUri, bicepFileContents, upsertCompilation: false);
 
             var bicepDeploymentStartCommandHandler = CreateHandler(bicepCompilationManager);
 

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
@@ -126,5 +126,37 @@ param bar = '1'
             result.isSuccess.Should().BeFalse();
             result.compilationResult.Should().Contain(expectedError);
         }
+
+
+        [TestMethod]
+        public void ExtractParametersObject_WithValidJsonReturns_ParametersPropertyValue()
+        {
+            var paramJson = 
+@"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""foo"": {
+      ""value"": ""something""
+    },
+    ""bar"": {
+      ""value"": 1
+    }
+  }
+}";
+            var bicepDeploymentStartCommandHandler = CreateHandler(StrictMock.Of<ICompilationManager>().Object);
+
+            var result = bicepDeploymentStartCommandHandler.ExtractParametersObjectValue(paramJson);
+
+            result.Should().BeEquivalentToIgnoringNewlines(
+@"{
+  ""foo"": {
+    ""value"": ""something""
+  },
+  ""bar"": {
+    ""value"": 1
+  }
+}");
+        }
     }
 }

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.Core;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.LangServer.IntegrationTests;
+using Bicep.LanguageServer;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Deploy;
+using Bicep.LanguageServer.Handlers;
+using Bicep.LanguageServer.Providers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+
+namespace Bicep.LangServer.UnitTests.Handlers
+{
+    [TestClass]
+    public class BicepDeploymentStartCommandHandlerTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private BicepDeploymentStartCommandHandler CreateHandler(ICompilationManager compilationManager)
+        {
+            var helper = ServiceBuilder.Create(services => services
+                .AddSingleton(StrictMock.Of<ISerializer>().Object)
+                .AddSingleton(StrictMock.Of<IDeploymentCollectionProvider>().Object)
+                .AddSingleton(StrictMock.Of<IDeploymentOperationsCache>().Object)
+                .AddSingleton(compilationManager)
+                .AddSingleton(BicepTestConstants.CreateMockTelemetryProvider().Object)
+                .AddSingleton(StrictMock.Of<IArmClientProvider>().Object)
+                .WithFeatureOverrides(new(TestContext, ParamsFilesEnabled: true))
+                .AddSingleton<BicepDeploymentStartCommandHandler>());
+
+            return helper.Construct<BicepDeploymentStartCommandHandler>();
+        }
+
+        [TestMethod]
+        public async Task DeploymentFileActionBuildOf_ValidBicepparametersfile_SucceedsWithResult()
+        {
+            var bicepFileContents = @"
+param foo string
+param bar int            
+            ";
+
+            var bicepparamFileContents = @"
+using './main.bicep'
+
+param foo = 'something'
+param bar = 1
+            ";
+
+            var expectedParamJson = "{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#\",\r\n  \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"foo\": {\r\n      \"value\": \"something\"\r\n    },\r\n    \"bar\": {\r\n      \"value\": 1\r\n    }\r\n  }\r\n}";
+
+            string bicepFilePath = FileHelper.SaveResultFile(TestContext, "main.bicep", bicepFileContents);
+            var dir = Path.GetDirectoryName(bicepFilePath);
+            string bicepparamFilePath = FileHelper.SaveResultFile(TestContext, "param.bicepparam", bicepparamFileContents, testOutputPath: dir);
+
+            DocumentUri bicepparamUri = DocumentUri.FromFileSystemPath(bicepparamFilePath);
+
+            BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(bicepparamUri, bicepFileContents, upsertCompilation: false);
+
+            var bicepDeploymentStartCommandHandler = CreateHandler(bicepCompilationManager);
+
+            var result = await bicepDeploymentStartCommandHandler.TryCompileBicepparamFile(bicepparamFilePath);
+
+            result.isSuccess.Should().BeTrue();
+            result.compilationResult.Should().Be(expectedParamJson);
+        }
+
+
+        [TestMethod]
+        public async Task DeploymentFileActionBuildOf_InvalidBicepparametersfile_FailsWithError()
+        {
+            var bicepFileContents = @"
+param foo string
+param bar int            
+            ";
+
+            var bicepparamFileContents = @"
+using './main.bicep'
+
+param foo = 'something'
+param bar = '1'
+            ";
+
+            var expectedError = @"Error BCP260: The parameter ""bar"" expects a value of type ""int"" but the provided value is of type ""'1'""";
+
+            string bicepFilePath = FileHelper.SaveResultFile(TestContext, "main.bicep", bicepFileContents);
+            var dir = Path.GetDirectoryName(bicepFilePath);
+            string bicepparamFilePath = FileHelper.SaveResultFile(TestContext, "param.bicepparam", bicepparamFileContents, testOutputPath: dir);
+
+            DocumentUri bicepparamUri = DocumentUri.FromFileSystemPath(bicepparamFilePath);
+
+            BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(bicepparamUri, bicepFileContents, upsertCompilation: false);
+
+            var bicepDeploymentStartCommandHandler = CreateHandler(bicepCompilationManager);
+
+            var result = await bicepDeploymentStartCommandHandler.TryCompileBicepparamFile(bicepparamFilePath);
+
+            result.isSuccess.Should().BeFalse();
+            result.compilationResult.Should().Contain(expectedError);
+        }
+    }
+}

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
@@ -63,7 +63,19 @@ param foo = 'something'
 param bar = 1
             ";
 
-            var expectedParamJson = "{\r\n  \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#\",\r\n  \"contentVersion\": \"1.0.0.0\",\r\n  \"parameters\": {\r\n    \"foo\": {\r\n      \"value\": \"something\"\r\n    },\r\n    \"bar\": {\r\n      \"value\": 1\r\n    }\r\n  }\r\n}";
+            var expectedParamJson = 
+@"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""foo"": {
+      ""value"": ""something""
+    },
+    ""bar"": {
+      ""value"": 1
+    }
+  }
+}";
 
             string bicepFilePath = FileHelper.SaveResultFile(TestContext, "main.bicep", bicepFileContents);
             var dir = Path.GetDirectoryName(bicepFilePath);
@@ -78,7 +90,7 @@ param bar = 1
             var result = await bicepDeploymentStartCommandHandler.TryCompileBicepparamFile(bicepparamFilePath);
 
             result.isSuccess.Should().BeTrue();
-            result.compilationResult.Should().Be(expectedParamJson);
+            result.compilationResult.Should().BeEquivalentToIgnoringNewlines(expectedParamJson);
         }
 
 

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -24,6 +24,7 @@ using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Telemetry;
 using Bicep.LanguageServer.Utils;
 using MediatR;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
@@ -110,7 +111,7 @@ namespace Bicep.LanguageServer.Handlers
                 }
                 else
                 {
-                    parametersFileJson = bicepparamCompilationResult.compilationResult;
+                    parametersFileJson = ExtractParametersObjectValue(bicepparamCompilationResult.compilationResult);
                 }
             }
             else
@@ -196,6 +197,20 @@ namespace Bicep.LanguageServer.Handlers
             await paramsOutputWriter.FlushAsync();
 
             return new BicepparamCompilationResult(true, paramsOutputBuffer.ToString());
+        }
+
+        public string ExtractParametersObjectValue(string JsonParametersContent) 
+        {
+            var jObject = JObject.Parse(JsonParametersContent);
+            var parameters = jObject["parameters"];
+
+            if (parameters is not null)
+            {
+                return parameters.ToString();
+            }    
+            
+            //return original JSON if no "parameters" property found
+            return jObject.ToString();
         }
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -174,7 +174,7 @@ namespace Bicep.LanguageServer.Handlers
             telemetryProvider.PostEvent(telemetryEvent);
         }
 
-        private async Task<BicepparamCompilationResult> TryCompileBicepparamFile(string parametersFilePath)
+        public async Task<BicepparamCompilationResult> TryCompileBicepparamFile(string parametersFilePath)
         {
             var documentUri = DocumentUri.FromFileSystemPath(parametersFilePath);
             var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -12,10 +14,13 @@ using Azure.ResourceManager;
 using Bicep.Core;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Json;
 using Bicep.Core.Semantics;
 using Bicep.Core.Tracing;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Deploy;
+using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Telemetry;
 using Bicep.LanguageServer.Utils;
 using MediatR;
@@ -40,13 +45,15 @@ namespace Bicep.LanguageServer.Handlers
         string deploymentName,
         string portalUrl,
         bool parametersFileExists,
-        string? parametersFileName, 
+        string? parametersFileName,
         ParametersFileUpdateOption parametersFileUpdateOption,
-        List<BicepUpdatedDeploymentParameter> updatedDeploymentParameters, 
+        List<BicepUpdatedDeploymentParameter> updatedDeploymentParameters,
         string resourceManagerEndpointUrl,
         string audience) : IRequest<string>;
 
     public record BicepDeploymentStartResponse(bool isSuccess, string outputMessage, string? viewDeploymentInPortalMessage);
+
+    public record BicepparamCompilationResult(bool isSuccess, string compilationResult);
 
     public class BicepDeploymentStartCommandHandler : ExecuteTypedResponseCommandHandlerBase<BicepDeploymentStartParams, BicepDeploymentStartResponse>
     {
@@ -55,9 +62,9 @@ namespace Bicep.LanguageServer.Handlers
         private readonly ITelemetryProvider telemetryProvider;
         private readonly BicepCompiler bicepCompiler;
         private readonly ICompilationManager compilationManager;
+        private readonly IArmClientProvider armClientProvider;
 
-
-        public BicepDeploymentStartCommandHandler(IDeploymentCollectionProvider deploymentCollectionProvider, IDeploymentOperationsCache deploymentOperationsCache, BicepCompiler bicepCompiler, ICompilationManager compilationManager, ISerializer serializer, ITelemetryProvider telemetryProvider)
+        public BicepDeploymentStartCommandHandler(IDeploymentCollectionProvider deploymentCollectionProvider, IDeploymentOperationsCache deploymentOperationsCache, BicepCompiler bicepCompiler, ICompilationManager compilationManager, ISerializer serializer, ITelemetryProvider telemetryProvider, IArmClientProvider armClientProvider)
             : base(LangServerConstants.DeployStartCommand, serializer)
         {
             this.deploymentCollectionProvider = deploymentCollectionProvider;
@@ -65,6 +72,7 @@ namespace Bicep.LanguageServer.Handlers
             this.telemetryProvider = telemetryProvider;
             this.bicepCompiler = bicepCompiler;
             this.compilationManager = compilationManager;
+            this.armClientProvider = armClientProvider;
         }
 
         public override async Task<BicepDeploymentStartResponse> Handle(BicepDeploymentStartParams request, CancellationToken cancellationToken)
@@ -76,55 +84,73 @@ namespace Bicep.LanguageServer.Handlers
             options.Environment = new ArmEnvironment(new Uri(request.resourceManagerEndpointUrl), request.audience);
 
             var credential = new CredentialFromTokenAndTimeStamp(request.token, request.expiresOnTimestamp);
-            var armClient = new ArmClient(credential, default, options);
+            var armClient = armClientProvider.createArmClient(credential, default, options);
 
-            string? bicepparamJsonOutput = null;
+            string? parametersFileJson = null;
 
-            if(request.parametersFilePath.EndsWith(".bicepparam"))
+            if (PathHelper.HasBicepparamsExension(DocumentUri.FromFileSystemPath(request.parametersFilePath).ToUri()))
             {
                 //params file validation 
-                if(request.parametersFileUpdateOption != ParametersFileUpdateOption.None)
+                if (request.parametersFileUpdateOption != ParametersFileUpdateOption.None)
                 {
-                    return new BicepDeploymentStartResponse(false, "Can not create/overwrite/update parameter files when using a bicep parameters file", null);
+                    return new BicepDeploymentStartResponse(false, "Cannot create/overwrite/update parameter files when using a bicep parameters file", null);
                 }
 
-                if(request.updatedDeploymentParameters.Any())
+                if (request.updatedDeploymentParameters.Any())
                 {
-                    return new BicepDeploymentStartResponse(false, "Can not update parameters for bicep parameter file", null);
+                    return new BicepDeploymentStartResponse(false, "Cannot update parameters for bicep parameter file", null);
                 }
 
                 //params file compilation
-                var documentUri = DocumentUri.FromFileSystemPath(request.parametersFilePath);
-                var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);
-                
-                var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
-                .FirstOrDefault(x => x.Key.FileUri == documentUri.ToUri());
-                
-                if (diagnosticsByFile.Value.Any(x => x.Level == DiagnosticLevel.Error))
+                var bicepparamCompilationResult = await TryCompileBicepparamFile(request.parametersFilePath);
+
+                if (!bicepparamCompilationResult.isSuccess)
                 {
-                   return new BicepDeploymentStartResponse(false, "Bicep build failed. Please fix below errors:\n" + DiagnosticsHelper.GetDiagnosticsMessage(diagnosticsByFile), null);
-                };
-                
-                bicepparamJsonOutput = GetParamsJsonOutput(compilation);
-            } 
-            
+                    return new BicepDeploymentStartResponse(false, bicepparamCompilationResult.compilationResult, null);
+                }
+                else
+                {
+                    parametersFileJson = bicepparamCompilationResult.compilationResult;
+                }
+            }
+            else
+            {
+                if (request.parametersFileName is { })
+                {
+                    try
+                    {
+                        parametersFileJson = DeploymentParametersHelper.GetUpdatedParametersFileContents(
+                            request.documentPath,
+                            request.parametersFileName,
+                            request.parametersFilePath,
+                            request.parametersFileUpdateOption,
+                            request.updatedDeploymentParameters);
+                    }
+                    catch (Exception e)
+                    {
+                        return new BicepDeploymentStartResponse(false, e.Message, null);
+                    }
+                }
+                else
+                {
+                    return new BicepDeploymentStartResponse(false, "ParametersFileName must be provided with JSON parameters file", null);
+                }
+            }
+
+            //stringified json for params passed here 
             var bicepDeploymentStartResponse = await DeploymentHelper.StartDeploymentAsync(
                 deploymentCollectionProvider,
                 armClient,
                 request.documentPath,
                 request.template,
-                request.parametersFilePath,
                 request.id,
                 request.deploymentScope,
                 request.location,
                 request.deployId,
-                request.parametersFileName,
-                request.parametersFileUpdateOption,
-                request.updatedDeploymentParameters,
                 request.portalUrl,
                 request.deploymentName,
-                deploymentOperationsCache,
-                bicepparamJsonOutput);
+                JsonElementFactory.CreateElement(parametersFileJson),
+                deploymentOperationsCache);
 
             PostDeployStartResultTelemetryEvent(request.deployId, bicepDeploymentStartResponse.isSuccess);
 
@@ -148,8 +174,11 @@ namespace Bicep.LanguageServer.Handlers
             telemetryProvider.PostEvent(telemetryEvent);
         }
 
-        private string GetParamsJsonOutput(Compilation compilation)
+        private async Task<BicepparamCompilationResult> TryCompileBicepparamFile(string parametersFilePath)
         {
+            var documentUri = DocumentUri.FromFileSystemPath(parametersFilePath);
+            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);
+
             var paramsModel = compilation.GetEntrypointSemanticModel();
 
             var paramsOutputBuffer = new StringBuilder();
@@ -158,9 +187,15 @@ namespace Bicep.LanguageServer.Handlers
             var paramsEmitter = new ParametersEmitter(paramsModel);
             var paramsResult = paramsEmitter.Emit(paramsOutputWriter);
 
-            paramsOutputWriter.Flush();
-            
-            return paramsOutputBuffer.ToString();
+            if (paramsResult.Status == EmitStatus.Failed)
+            {
+                var fileDiagnosticPair = KeyValuePair.Create(compilation.SourceFileGrouping.EntryPoint, ImmutableArray.Create(paramsResult.Diagnostics.ToArray()));
+                return new BicepparamCompilationResult(false, DiagnosticsHelper.GetDiagnosticsMessage(fileDiagnosticPair));
+            }
+
+            await paramsOutputWriter.FlushAsync();
+
+            return new BicepparamCompilationResult(true, paramsOutputBuffer.ToString());
         }
     }
 }

--- a/src/Bicep.LangServer/Providers/ArmClientProvider.cs
+++ b/src/Bicep.LangServer/Providers/ArmClientProvider.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.ResourceManager;
+
+namespace Bicep.LanguageServer.Providers
+{
+    public class ArmClientProvider : IArmClientProvider
+    {
+        public ArmClient createArmClient(TokenCredential credential, string? defaultSubscriptionId, ArmClientOptions options)
+        {
+            return new ArmClient(credential, defaultSubscriptionId, options);
+        }
+    }
+}

--- a/src/Bicep.LangServer/Providers/IArmClientFactory.cs
+++ b/src/Bicep.LangServer/Providers/IArmClientFactory.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using Azure.ResourceManager;
+
+namespace Bicep.LanguageServer.Providers
+{
+    public interface IArmClientProvider {
+        public ArmClient createArmClient(TokenCredential credential, string? defaultSubscriptionId, ArmClientOptions options);
+    }
+}

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -120,6 +120,7 @@ namespace Bicep.LanguageServer
                 .AddSingleton<IClientCapabilitiesProvider, ClientCapabilitiesProvider>()
                 .AddSingleton<IModuleReferenceCompletionProvider, ModuleReferenceCompletionProvider>()
                 .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
+                .AddSingleton<IArmClientProvider, ArmClientProvider>()
                 .AddSingleton<ISettingsProvider, SettingsProvider>()
                 .AddSingleton<IAzureContainerRegistriesProvider, AzureContainerRegistriesProvider>()
                 .AddSingleton<IPublicRegistryModuleMetadataProvider>(sp => new PublicRegistryModuleMetadataProvider(initializeCache: true));

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -758,11 +758,11 @@ export class DeployCommand implements Command {
     bicepFolder: string
   ): Promise<IAzureQuickPickItem<string>[]> {
     const quickPickItems: IAzureQuickPickItem<string>[] = [];
-    const workspaceJsonFiles = (
-      await vscode.workspace.findFiles("**/*.{json,jsonc}", undefined)
+    const workspaceParametersFiles = (
+      await vscode.workspace.findFiles("**/*.{json,jsonc,bicepparam}", undefined)
     ).filter((f) => !!f.fsPath);
 
-    workspaceJsonFiles.sort((a, b) => {
+    workspaceParametersFiles.sort((a, b) => {
       const aIsInBicepFolder = path.dirname(a.fsPath) === bicepFolder;
       const bIsInBicepFolder = path.dirname(b.fsPath) === bicepFolder;
 
@@ -776,8 +776,10 @@ export class DeployCommand implements Command {
       return compareStringsOrdinal(a.path, b.path);
     });
 
-    for (const uri of workspaceJsonFiles) {
-      if (!(await this.validateIsValidParameterFile(uri.fsPath, false))) {
+    for (const uri of workspaceParametersFiles) {
+
+      if (!uri.fsPath.endsWith("biceppparam") && 
+          !(await this.validateIsValidParameterFile(uri.fsPath, false))) {
         continue;
       }
 
@@ -787,7 +789,7 @@ export class DeployCommand implements Command {
         ? path.relative(workspaceRoot, uri.fsPath)
         : path.basename(uri.fsPath);
       const quickPickItem: IAzureQuickPickItem<string> = {
-        label: `${"$(json) "} ${relativePath}`,
+        label: `${(uri.fsPath.endsWith("biceppparam")? "$(bicepparam)" : "$(json)")} ${relativePath}`,
         data: uri.fsPath,
         id: uri.toString(),
       };

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -366,22 +366,21 @@ export class DeployCommand implements Command {
       const expiresOnTimestamp = String(accessToken.expiresOnTimestamp);
       const portalUrl = subscription.environment.portalUrl;
 
-      let parametersFileName: string | null
-      let updatedDeploymentParameters: BicepUpdatedDeploymentParameter[]
+      let parametersFileName: string | null;
+      let updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
       let parametersFileUpdateOption = ParametersFileUpdateOption.None;
 
-      if(parametersFilePath.endsWith(".bicepparam")) {
-        parametersFileName = null
-        updatedDeploymentParameters = []        
-      }
-      else  {
+      if (parametersFilePath.endsWith(".bicepparam")) {
+        parametersFileName = null;
+        updatedDeploymentParameters = [];
+      } else {
         [parametersFileName, updatedDeploymentParameters] =
-        await this.handleMissingAndDefaultParams(
-          context,
-          documentPath,
-          parametersFilePath,
-          template
-        );
+          await this.handleMissingAndDefaultParams(
+            context,
+            documentPath,
+            parametersFilePath,
+            template
+          );
 
         // If all the parameters are of type secure, we will not show an option to create or update parameters file
         if (
@@ -427,7 +426,10 @@ export class DeployCommand implements Command {
 
       // If user chose to create/update/overwrite a parameters file at the end of deployment flow, we'll
       // open it in vscode.
-      if (parametersFileUpdateOption !== ParametersFileUpdateOption.None && parametersFileName != null) {
+      if (
+        parametersFileUpdateOption !== ParametersFileUpdateOption.None &&
+        parametersFileName !== null
+      ) {
         if (
           parametersFileUpdateOption === ParametersFileUpdateOption.Create ||
           parametersFileUpdateOption === ParametersFileUpdateOption.Overwrite
@@ -505,7 +507,11 @@ export class DeployCommand implements Command {
             canSelectMany: false,
             defaultUri: sourceUri,
             openLabel: "Select Parameter File",
-            filters: { "All Parameter Files": ["json", "jsonc", "bicepparam"], "JSON Files": ["json", "jsonc"], "Bicepparam Files": ["bicepparam"] },
+            filters: {
+              "All Parameter Files": ["json", "jsonc", "bicepparam"],
+              "JSON Files": ["json", "jsonc"],
+              "Bicepparam Files": ["bicepparam"],
+            },
           });
         if (paramsPaths) {
           assert(paramsPaths.length === 1, "Expected paramsPaths.length === 1");
@@ -519,20 +525,7 @@ export class DeployCommand implements Command {
         parameterFilePath = result.data;
       }
 
-      if (parameterFilePath.endsWith(".bicepparam")) {
-        this.outputChannelManager.appendToOutputChannel(
-          `Bicep Parameter file used in deployment -> ${parameterFilePath}`
-        );
-
-        return parameterFilePath;
-      }
-      else {
-        if (await this.validateIsValidParameterFile(parameterFilePath, true)) {
-          this.outputChannelManager.appendToOutputChannel(
-            `JSON Parameter file used in deployment -> ${parameterFilePath}`
-          );
-      }
-
+      if (await this.validateIsValidParameterFile(parameterFilePath, true)) {
         return parameterFilePath;
       }
     }
@@ -542,6 +535,13 @@ export class DeployCommand implements Command {
     path: string,
     showErrorMessage: boolean
   ): Promise<boolean> {
+    if (path.endsWith(".bicepparam")) {
+      this.outputChannelManager.appendToOutputChannel(
+        `Bicep Parameter file used in deployment -> ${path}`
+      );
+      return true;
+    }
+
     const expectedSchema =
       "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#";
 
@@ -573,6 +573,9 @@ export class DeployCommand implements Command {
       return false;
     }
 
+    this.outputChannelManager.appendToOutputChannel(
+      `JSON Parameter file used in deployment -> ${path}`
+    );
     return true;
   }
 

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -68,7 +68,7 @@ export interface BicepDeploymentStartParams {
   deployId: string;
   deploymentName: string;
   portalUrl: string;
-  parametersFileName: string;
+  parametersFileName: string | null;
   parametersFileUpdateOption: ParametersFileUpdateOption;
   updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
   resourceManagerEndpointUrl: string;


### PR DESCRIPTION
Enable VS Code bicep deploy action to take a bicepparam file as an input for parameters. This is mostly a draft PR and needs some reviewing. Since bicep param files provide a complete set of (required) parameter values, we are not allowing users to provide parameter values during deployment and create/overwrite/update any bicepparam files (these features are still permitted in JSON files) 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10593)