### PR TITLE
Add support for Custom Kubernetes Resources

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -339,6 +339,26 @@ resource secret 'core/Secret@v1' = {
             result.Should().NotHaveAnyDiagnostics();
         }
 
+        [TestMethod]
+        public void Kubernetes_CustomResourceType_EmitWarning()
+        {
+            var result = CompilationHelper.Compile(Services, """
+                import 'kubernetes@1.0.0' with {
+                  namespace: 'default'
+                  kubeConfig: ''
+                }
+                resource crd 'custom/Foo@v1' = {
+                  metadata: {
+                    name: 'existing-service'
+                  }
+                }
+                """);
+
+            result.Should().GenerateATemplate();
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP081", DiagnosticLevel.Warning, @"Resource type ""custom/Foo@v1"" does not have types available."),
+            });
+        }
 
         [TestMethod]
         public void Storage_import_basic_test_with_qualified_type()

--- a/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeProvider.cs
@@ -172,7 +172,28 @@ namespace Bicep.Core.TypeSystem.K8s
         }
 
         public ResourceType? TryGenerateFallbackType(NamespaceType declaringNamespace, ResourceTypeReference typeReference, ResourceTypeGenerationFlags flags)
-            => null;
+        {
+            var resourceType = generatedTypeCache.GetOrAdd(flags, typeReference, () =>
+            {
+                var resourceType = new ResourceTypeComponents(
+                    typeReference,
+                    ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Resource,
+                    ResourceScope.None,
+                    ResourceFlags.None,
+                    new ObjectType(typeReference.FormatName(), TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.Any));
+
+                return SetBicepResourceProperties(resourceType, flags);
+            });
+
+            return new(
+                declaringNamespace,
+                resourceType.TypeReference,
+                resourceType.ValidParentScopes,
+                resourceType.ReadOnlyScopes,
+                resourceType.Flags,
+                resourceType.Body,
+                UniqueIdentifierProperties);
+        }
 
         public bool HasDefinedType(ResourceTypeReference typeReference)
             => availableResourceTypes.Contains(typeReference);


### PR DESCRIPTION
Updated `KubernetesResourceTypeProvider.TryGenerateFallbackType` to always return a generic fallback type.

Closes https://github.com/Azure/bicep-extensibility/issues/128.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10598)