### PR TITLE
Adding support for taking diagnostics format as input for bicep build

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -307,8 +307,8 @@ output myOutput string = 'hello!'
         }
 
         [DataRow(new string[] {})]
-        [DataRow(new[] { "--diagnosticsformat", "defAULt"})]
-        [DataRow(new[] { "--diagnosticsformat", "jsOn"})]
+        [DataRow(new[] { "--diagnostics-format", "defAULt"})]
+        [DataRow(new[] { "--diagnostics-format", "sArif"})]
         [DataTestMethod]
         public async Task Build_WithOutDir_ShouldSucceed(string[] args)
         {
@@ -325,7 +325,29 @@ output myOutput string = 'hello!'
 
             File.Exists(expectedOutputFile).Should().BeTrue();
             output.Should().BeEmpty();
-            error.Should().BeEmpty();
+            if (Array.Exists(args, x => x.Equals("sarif", StringComparison.OrdinalIgnoreCase)))
+            {
+                error.Should().Contain(@"{
+  ""$schema"": ""https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json"",
+  ""version"": ""2.1.0"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""driver"": {
+          ""name"": ""bicep""
+        }
+      },
+      ""results"": [],
+      ""columnKind"": ""utf16CodeUnits""
+    }
+  ]
+}");
+            }
+            else
+            {
+                error.Should().BeEmpty();
+            }
+
             result.Should().Be(0);
         }
 
@@ -400,7 +422,7 @@ output myOutput string = 'hello!'
         }
 
         [DataRow(new string[] {})]
-        [DataRow(new[] { "--diagnosticsformat", "defAULt"})]
+        [DataRow(new[] { "--diagnostics-format", "defAULt"})]
         [DataTestMethod]
         public async Task Build_WithValidBicepConfig_ShouldProduceOutputFileAndExpectedError(string[] args)
         {
@@ -432,7 +454,7 @@ output myOutput string = 'hello!'
         }
 
         [TestMethod]
-        public async Task Build_WithValidBicepConfig_ShouldProduceOutputFileAndExpectedErrorInJSONFormat()
+        public async Task Build_WithValidBicepConfig_ShouldProduceOutputFileAndExpectedErrorInSarifFormat()
         {
             string testOutputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
             var inputFile = FileHelper.SaveResultFile(this.TestContext, "main.bicep", @"param storageAccountName string = 'test'", testOutputPath);
@@ -454,7 +476,7 @@ output myOutput string = 'hello!'
 
             File.Exists(expectedOutputFile).Should().BeFalse();
 
-            var (output, error, result) = await Bicep("build", "--outdir", testOutputPath, inputFile, "--diagnosticsformat", "jsOn");
+            var (output, error, result) = await Bicep("build", "--outdir", testOutputPath, inputFile, "--diagnostics-format", "saRif");
 
             File.Exists(expectedOutputFile).Should().BeTrue();
             result.Should().Be(0);

--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -327,7 +327,8 @@ output myOutput string = 'hello!'
             output.Should().BeEmpty();
             if (Array.Exists(args, x => x.Equals("sarif", StringComparison.OrdinalIgnoreCase)))
             {
-                error.Should().Contain(@"{
+                var errorJToken = JToken.Parse(error);
+                var expectedErrorJToken = JToken.Parse(@"{
   ""$schema"": ""https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json"",
   ""version"": ""2.1.0"",
   ""runs"": [
@@ -342,6 +343,12 @@ output myOutput string = 'hello!'
     }
   ]
 }");
+                errorJToken.Should().EqualWithJsonDiffOutput(
+                TestContext,
+                expectedErrorJToken,
+                "",
+                "",
+                validateLocation: false);
             }
             else
             {

--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -307,6 +307,7 @@ output myOutput string = 'hello!'
         }
 
         [DataRow(new string[] {})]
+        [DataRow(new[] { "--diagnosticsformat", "defAULt"})]
         [DataRow(new[] { "--diagnosticsformat", "jsOn"})]
         [DataTestMethod]
         public async Task Build_WithOutDir_ShouldSucceed(string[] args)
@@ -398,8 +399,10 @@ output myOutput string = 'hello!'
             error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: \"Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed. LineNumber: 8 | BytePositionInLine: 0.\".");
         }
 
-        [TestMethod]
-        public async Task Build_WithValidBicepConfig_ShouldProduceOutputFileAndExpectedError()
+        [DataRow(new string[] {})]
+        [DataRow(new[] { "--diagnosticsformat", "defAULt"})]
+        [DataTestMethod]
+        public async Task Build_WithValidBicepConfig_ShouldProduceOutputFileAndExpectedError(string[] args)
         {
             string testOutputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
             var inputFile = FileHelper.SaveResultFile(this.TestContext, "main.bicep", @"param storageAccountName string = 'test'", testOutputPath);
@@ -420,8 +423,7 @@ output myOutput string = 'hello!'
             var expectedOutputFile = Path.Combine(testOutputPath, "main.json");
 
             File.Exists(expectedOutputFile).Should().BeFalse();
-
-            var (output, error, result) = await Bicep("build", "--outdir", testOutputPath, inputFile);
+            var (output, error, result) = await Bicep(new[] { "build", "--outdir", testOutputPath, inputFile}.Concat(args).ToArray());
 
             File.Exists(expectedOutputFile).Should().BeTrue();
             result.Should().Be(0);

--- a/src/Bicep.Cli.IntegrationTests/RootCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RootCommandTests.cs
@@ -67,6 +67,7 @@ namespace Bicep.Cli.IntegrationTests
                     "--outdir",
                     "--outfile",
                     "--stdout",
+                    "--diagnostics-format",
                     "--version",
                     "--help",
                     "information",

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -867,6 +867,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -2018,7 +2027,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       },
       "bicep.cli.unittests": {

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -720,6 +720,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -1839,7 +1848,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       }
     },

--- a/src/Bicep.Cli/Arguments/BuildArguments.cs
+++ b/src/Bicep.Cli/Arguments/BuildArguments.cs
@@ -48,6 +48,19 @@ namespace Bicep.Cli.Arguments
                         i++;
                         break;
 
+                    case "--diagnosticsformat":
+                        if (args.Length == i + 1)
+                        {
+                            throw new CommandLineException($"The --diagnosticsformat parameter expects an argument");
+                        }
+                        if (DiagnosticsFormat is not null)
+                        {
+                            throw new CommandLineException($"The --diagnosticsformat parameter cannot be specified twice");
+                        }
+                        DiagnosticsFormat = args[i + 1];
+                        i++;
+                        break;
+
                     default:
                         if (args[i].StartsWith("--"))
                         {
@@ -100,6 +113,8 @@ namespace Bicep.Cli.Arguments
         public string? OutputDir { get; }
 
         public string? OutputFile { get; }
+
+        public string? DiagnosticsFormat { get; }
 
         public bool NoRestore { get; }
     }

--- a/src/Bicep.Cli/Arguments/BuildArguments.cs
+++ b/src/Bicep.Cli/Arguments/BuildArguments.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.FileSystem;
+using System;
 using System.IO;
 
 namespace Bicep.Cli.Arguments
@@ -48,16 +49,16 @@ namespace Bicep.Cli.Arguments
                         i++;
                         break;
 
-                    case "--diagnosticsformat":
+                    case "--diagnostics-format":
                         if (args.Length == i + 1)
                         {
-                            throw new CommandLineException($"The --diagnosticsformat parameter expects an argument");
+                            throw new CommandLineException($"The --diagnostics-format parameter expects an argument");
                         }
                         if (DiagnosticsFormat is not null)
                         {
-                            throw new CommandLineException($"The --diagnosticsformat parameter cannot be specified twice");
+                            throw new CommandLineException($"The --diagnostics-format parameter cannot be specified twice");
                         }
-                        DiagnosticsFormat = args[i + 1];
+                        DiagnosticsFormat = ToDiagnosticsFormat(args[i + 1]);
                         i++;
                         break;
 
@@ -104,6 +105,25 @@ namespace Bicep.Cli.Arguments
                     throw new CommandLineException(string.Format(CliResources.DirectoryDoesNotExistFormat, outputDir));
                 }
             }
+
+            if(DiagnosticsFormat is null)
+            {
+                DiagnosticsFormat = Arguments.DiagnosticsFormat.Default;
+            }
+        }
+
+        private static DiagnosticsFormat ToDiagnosticsFormat(string? format)
+        {
+            if(format is null || (format is not null && format.Equals("default", StringComparison.OrdinalIgnoreCase)))
+            {
+                return Arguments.DiagnosticsFormat.Default;
+            }
+            else if(format is not null && format.Equals("sarif", StringComparison.OrdinalIgnoreCase))
+            {
+                return Arguments.DiagnosticsFormat.Sarif;
+            }
+
+            throw new ArgumentException($"Unrecognized diagnostics format {format}");
         }
 
         public bool OutputToStdOut { get; }
@@ -114,7 +134,7 @@ namespace Bicep.Cli.Arguments
 
         public string? OutputFile { get; }
 
-        public string? DiagnosticsFormat { get; }
+        public DiagnosticsFormat? DiagnosticsFormat { get; }
 
         public bool NoRestore { get; }
     }

--- a/src/Bicep.Cli/Arguments/DiagnosticsFormat.cs
+++ b/src/Bicep.Cli/Arguments/DiagnosticsFormat.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public enum DiagnosticsFormat
+    {
+        Default,
+        Sarif
+    }
+}

--- a/src/Bicep.Cli/Bicep.Cli.csproj
+++ b/src/Bicep.Cli/Bicep.Cli.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Sarif.Sdk" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Cli/Commands/BuildCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildCommand.cs
@@ -57,6 +57,7 @@ namespace Bicep.Cli.Commands
 
             if (IsBicepFile(inputPath))
             {
+                diagnosticLogger.SetupFormat(args.DiagnosticsFormat);
                 var compilation = await compilationService.CompileAsync(inputPath, args.NoRestore);
 
                 if (diagnosticLogger.ErrorCount < 1)
@@ -73,6 +74,8 @@ namespace Bicep.Cli.Commands
                         writer.ToFile(compilation, outputPath);
                     }
                 }
+
+                diagnosticLogger.FlushLog();
 
                 // return non-zero exit code on errors
                 return diagnosticLogger.ErrorCount > 0 ? 1 : 0;

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -67,7 +67,7 @@ Usage:
       --outfile <file>              Saves the output as the specified file path.
       --stdout                      Prints the output to stdout.
       --no-restore                  Builds the bicep file without restoring external modules.
-      --diagnosticsformat <format>  Sets the format with which diagnostics are displayed. Valid values are ( Default | Json ).
+      --diagnostics-format <format>  Sets the format with which diagnostics are displayed. Valid values are ( {string.Join(" | ", Enum.GetNames(typeof(DiagnosticsFormat)))} ).
 
     Examples:
       bicep build file.bicep
@@ -75,7 +75,7 @@ Usage:
       bicep build file.bicep --outdir dir1
       bicep build file.bicep --outfile file.json
       bicep build file.bicep --no-restore
-      bicep build file.bicep --diagnosticsformat json
+      bicep build file.bicep --diagnostics-format sarif
 
     {exeName} format [options] <file>
     Formats a .bicep file.

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -63,10 +63,11 @@ Usage:
       <file>        The input file
 
     Options:
-      --outdir <dir>    Saves the output at the specified directory.
-      --outfile <file>  Saves the output as the specified file path.
-      --stdout          Prints the output to stdout.
-      --no-restore      Builds the bicep file without restoring external modules.
+      --outdir <dir>                Saves the output at the specified directory.
+      --outfile <file>              Saves the output as the specified file path.
+      --stdout                      Prints the output to stdout.
+      --no-restore                  Builds the bicep file without restoring external modules.
+      --diagnosticsformat <format>  Sets the format with which diagnostics are displayed. Valid values are ( Default | Json ).
 
     Examples:
       bicep build file.bicep
@@ -74,6 +75,7 @@ Usage:
       bicep build file.bicep --outdir dir1
       bicep build file.bicep --outfile file.json
       bicep build file.bicep --no-restore
+      bicep build file.bicep --diagnosticsformat json
 
     {exeName} format [options] <file>
     Formats a .bicep file.

--- a/src/Bicep.Cli/Logging/BicepDiagnosticLogger.cs
+++ b/src/Bicep.Cli/Logging/BicepDiagnosticLogger.cs
@@ -3,9 +3,14 @@
 
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Text;
+using Microsoft.CodeAnalysis.Sarif;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
+using System.Text.Json;
 
 namespace Bicep.Cli.Logging
 {
@@ -15,12 +20,16 @@ namespace Bicep.Cli.Logging
     public class BicepDiagnosticLogger : IDiagnosticLogger
     {
         private readonly ILogger logger;
+        private readonly IOContext io;
 
-        public BicepDiagnosticLogger(ILogger logger)
+        public BicepDiagnosticLogger(ILogger logger, IOContext io)
         {
             this.logger = logger;
+            this.io = io;
             this.ErrorCount = 0;
             this.WarningCount = 0;
+            sarifResults = new List<Result>();
+            sarifLog = new SarifLog();
         }
 
         public void LogDiagnostic(Uri fileUri, IDiagnostic diagnostic, ImmutableArray<int> lineStarts)
@@ -29,19 +38,122 @@ namespace Bicep.Cli.Logging
 
             // build a a code description link if the Uri is assigned
             var codeDescription = diagnostic.Uri == null ? string.Empty : $" [{diagnostic.Uri.AbsoluteUri}]";
-
-            var message = $"{fileUri.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}";
-
-            this.logger.Log(ToLogLevel(diagnostic.Level), message);
+            if (Format == DiagnosticsFormat.Default) 
+            {
+                var message = $"{fileUri.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}";
+                this.logger.Log(ToLogLevel(diagnostic.Level), message);
+            }
+            else if (Format == DiagnosticsFormat.Json)
+            {
+                sarifResults.Add(new Result()
+                {
+                    RuleId = diagnostic.Code,
+                    Level = ToFailureLevel(diagnostic.Level),
+                    Message = new Message
+                    {
+                        Text = $"{diagnostic.Message}{codeDescription}",
+                    },
+                    Locations = new[]
+                    {
+                        new Location
+                        {
+                            PhysicalLocation = new PhysicalLocation
+                            {
+                                ArtifactLocation = new ArtifactLocation
+                                {
+                                    Uri = fileUri
+                                },
+                                Region = new Region
+                                {
+                                    StartLine = line + 1,
+                                    CharOffset = character + 1,
+                                }
+                            }
+                        }
+                    }
+                });
+            }
 
             // Increment counters
             if (diagnostic.Level == DiagnosticLevel.Warning) { this.WarningCount++; }
             if (diagnostic.Level == DiagnosticLevel.Error) { this.ErrorCount++; }
         }
 
+
+        private enum DiagnosticsFormat
+        {
+            Default,
+            Json
+        }
+
         public int ErrorCount { get; private set; }
 
         private int WarningCount { get; set; }
+
+        private DiagnosticsFormat Format { get; set; }
+
+        private SarifLog sarifLog { get; set; }
+
+        private List<Result> sarifResults { get; set; }
+
+
+        public void SetupFormat(string? format)
+        {
+            Format = ToDiagnosticsFormat(format);
+            if(Format == DiagnosticsFormat.Json)
+            {
+                // setup an empty run on the sarif log to add results to.
+                sarifLog.Runs = new List<Run>();
+                sarifLog.Runs.Add(new Run()
+                {
+                    Tool = new Tool(new ToolComponent()
+                    {
+                        Name = "bicep",
+                    }, null, null)
+                });
+            }
+        }
+
+        public void FlushLog()
+        {
+            if(Format == DiagnosticsFormat.Json && sarifResults.Count > 0)
+            {
+                // if there are errors/warnings, add the results from the run to the sarif log, serialize and write to stderr.
+                // if none are present, omit flushing the in memory log to maintain parity with how the default diagnostics are handled.
+                sarifLog.Runs[0].Results = sarifResults;
+                var settings = new JsonSerializerSettings()
+                {
+                    Formatting = Formatting.Indented
+                };
+
+                var sarifText = JsonConvert.SerializeObject(sarifLog, settings);
+                io.Error.Write(sarifText);
+                io.Error.Flush();
+            }
+        }
+
+        private static DiagnosticsFormat ToDiagnosticsFormat(string? format)
+        {
+            if(format is null)
+            {
+                return DiagnosticsFormat.Default;
+            }
+            else if(format is not null && format.Equals("json", StringComparison.OrdinalIgnoreCase))
+            {
+                return DiagnosticsFormat.Json;
+            }
+
+            throw new ArgumentException($"Unrecognized diagnostics format {format}");
+        }
+
+        private static FailureLevel ToFailureLevel(DiagnosticLevel level)
+            => level switch
+            {
+                DiagnosticLevel.Info => FailureLevel.Note,
+                DiagnosticLevel.Warning => FailureLevel.Warning,
+                DiagnosticLevel.Error => FailureLevel.Error,
+                _ => throw new ArgumentException($"Unrecognized level {level}"),
+            };
 
         private static LogLevel ToLogLevel(DiagnosticLevel level)
             => level switch

--- a/src/Bicep.Cli/Logging/BicepDiagnosticLogger.cs
+++ b/src/Bicep.Cli/Logging/BicepDiagnosticLogger.cs
@@ -134,7 +134,7 @@ namespace Bicep.Cli.Logging
 
         private static DiagnosticsFormat ToDiagnosticsFormat(string? format)
         {
-            if(format is null)
+            if(format is null || (format is not null && format.Equals("default", StringComparison.OrdinalIgnoreCase)))
             {
                 return DiagnosticsFormat.Default;
             }

--- a/src/Bicep.Cli/Logging/IDiagnosticLogger.cs
+++ b/src/Bicep.Cli/Logging/IDiagnosticLogger.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Cli.Arguments;
 using Bicep.Core.Diagnostics;
 using System;
 using System.Collections.Immutable;
@@ -11,7 +12,7 @@ namespace Bicep.Cli.Logging
     {
         void LogDiagnostic(Uri fileUri, IDiagnostic diagnostic, ImmutableArray<int> lineStarts);
 
-        void SetupFormat (string? format);
+        void SetupFormat (DiagnosticsFormat? format);
 
         void FlushLog();
 

--- a/src/Bicep.Cli/Logging/IDiagnosticLogger.cs
+++ b/src/Bicep.Cli/Logging/IDiagnosticLogger.cs
@@ -11,6 +11,10 @@ namespace Bicep.Cli.Logging
     {
         void LogDiagnostic(Uri fileUri, IDiagnostic diagnostic, ImmutableArray<int> lineStarts);
 
+        void SetupFormat (string? format);
+
+        void FlushLog();
+
         int ErrorCount { get; }
     }
 }

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -42,6 +42,16 @@
         "resolved": "3.5.119",
         "contentHash": "x8k4zV6YKZA5Rr810439lG9NngdbyPtFv0QpIYz32m1Im59kvSbEHO8gKGZoNvsfZSquayjEDUCa8acbut372g=="
       },
+      "Sarif.Sdk": {
+        "type": "Direct",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "Azure.Bicep.Types": {
         "type": "Transitive",
         "resolved": "0.3.99",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -867,6 +867,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -2018,7 +2027,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       },
       "bicep.core.samples": {

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -867,6 +867,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -2018,7 +2027,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       },
       "bicep.core.unittests": {

--- a/src/Bicep.Core.UnitTests/Assertions/JTokenAssertionsExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/JTokenAssertionsExtensions.cs
@@ -37,25 +37,35 @@ namespace Bicep.Core.UnitTests.Assertions
             return string.Join('\n', lineLogs);
         }
 
-        public static AndConstraint<JTokenAssertions> EqualWithJsonDiffOutput(this JTokenAssertions instance, TestContext testContext, JToken expected, string expectedLocation, string actualLocation, string because = "", params object[] becauseArgs)
+        public static AndConstraint<JTokenAssertions> EqualWithJsonDiffOutput(this JTokenAssertions instance, TestContext testContext, JToken expected, string expectedLocation, string actualLocation, string because = "", bool validateLocation = true, params object[] becauseArgs)
         {
             var jsonDiff = GetJsonDiff(instance.Subject, expected);
 
             var testPassed = jsonDiff is null;
-            var isBaselineUpdate = !testPassed && BaselineHelper.ShouldSetBaseline(testContext);
-            if (isBaselineUpdate)
+            if (validateLocation)
             {
-                BaselineHelper.SetBaseline(actualLocation, expectedLocation);
-            }
+                var isBaselineUpdate = !testPassed && BaselineHelper.ShouldSetBaseline(testContext);
+                if (isBaselineUpdate)
+                {
+                    BaselineHelper.SetBaseline(actualLocation, expectedLocation);
+                }
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(testPassed)
-                .FailWith(
-                    BaselineHelper.GetAssertionFormatString(isBaselineUpdate),
-                    jsonDiff,
-                    BaselineHelper.GetAbsolutePathRelativeToRepoRoot(actualLocation),
-                    BaselineHelper.GetAbsolutePathRelativeToRepoRoot(expectedLocation));
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(testPassed)
+                    .FailWith(
+                        BaselineHelper.GetAssertionFormatString(isBaselineUpdate),
+                        jsonDiff,
+                        BaselineHelper.GetAbsolutePathRelativeToRepoRoot(actualLocation),
+                        BaselineHelper.GetAbsolutePathRelativeToRepoRoot(expectedLocation));
+            }
+            else
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(testPassed)
+                    .FailWith(jsonDiff);
+            }
 
             return new AndConstraint<JTokenAssertions>(instance);
         }

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -881,6 +881,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -2032,7 +2041,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       },
       "bicep.core.samples": {

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -889,6 +889,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -2040,7 +2049,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       },
       "bicep.core.samples": {

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -968,6 +968,15 @@
         "resolved": "4.4.0",
         "contentHash": "YhEdSQUsTx+C8m8Bw7ar5/VesXvCFMItyZF7G1AUY+OM0VPZUOeAVpJ4Wl6fydBGUYZxojTDR3I6Bj/+BPkJNA=="
       },
+      "Sarif.Sdk": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "+wws/czP6/gGhFeLyHTtBIQ3V6rg7K8c5aGeGMnLvbUTQybAV0j25sQ9DF5t+qgRA4XxBRJGGKN4lRB1Q+tUdA==",
+        "dependencies": {
+          "Newtonsoft.Json": "9.0.1",
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -2119,7 +2128,8 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Decompiler": "[1.0.0, )",
-          "Microsoft.Extensions.Logging": "[7.0.0, )"
+          "Microsoft.Extensions.Logging": "[7.0.0, )",
+          "Sarif.Sdk": "[4.1.0, )"
         }
       },
       "bicep.core.samples": {


### PR DESCRIPTION
Fixes #2973

Adds support to set a diagnostics format when running bicep build. Accepted values are default (maps to the current Visual Studio format) and JSON (utilizes the SARIF format).

When no errors/warnings are present, no diagnostics are emitted (as opposed to a shell object).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10672)