### PR TITLE
Add intellisense support for param and output values

### DIFF
--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -125,7 +125,7 @@ output incorrectTypeOutput2 int = myRes.properties.nestedObj.readOnlyProp
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"writeOnlyProp\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"properties\" does not contain property \"missingOutput\". Available properties include \"additionalProps\", \"nestedObj\", \"readOnlyProp\", \"requiredProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"missingOutput\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\"."),
-                x => x.Should().HaveCodeAndSeverity("BCP026", DiagnosticLevel.Error).And.HaveMessage("The output expects a value of type \"int\" but the provided value is of type \"string\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP033", DiagnosticLevel.Error).And.HaveMessage("Expected a value of type \"int\" but the provided value is of type \"string\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"readOnlyProp\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\".")
             );
         }

--- a/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -90,32 +90,32 @@ output foo string =
 // wrong string output values
 output str string = true
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:24) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[20:24) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "true". (CodeDescription: none) |true|
 output str string = false
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:25) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[20:25) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "false". (CodeDescription: none) |false|
 output str string = [
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:24) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[20:24) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output str string = {
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:24) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
+//@[20:24) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
 }
 output str string = 52
 //@[07:10) [BCP145 (Error)] Output "str" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |str|
-//@[20:22) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "52". (CodeDescription: none) |52|
+//@[20:22) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "52". (CodeDescription: none) |52|
 
 // wrong int output values
 output i int = true
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:19) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[15:19) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "true". (CodeDescription: none) |true|
 output i int = false
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:20) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[15:20) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "false". (CodeDescription: none) |false|
 output i int = [
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:19) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[15:19) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output i int = }
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
@@ -124,65 +124,65 @@ output i int = }
 //@[00:01) [BCP007 (Error)] This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration. (CodeDescription: none) |}|
 output i int = 'test'
 //@[07:08) [BCP145 (Error)] Output "i" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |i|
-//@[15:21) [BCP026 (Error)] The output expects a value of type "int" but the provided value is of type "'test'". (CodeDescription: none) |'test'|
+//@[15:21) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "'test'". (CodeDescription: none) |'test'|
 
 // wrong bool output values
 output b bool = [
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:20) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[16:20) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output b bool = {
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:20) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
+//@[16:20) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
 }
 output b bool = 32
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:18) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "32". (CodeDescription: none) |32|
+//@[16:18) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "32". (CodeDescription: none) |32|
 output b bool = 'str'
 //@[07:08) [BCP145 (Error)] Output "b" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |b|
-//@[16:21) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
+//@[16:21) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
 
 // wrong array output values
 output arr array = 32
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:21) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "32". (CodeDescription: none) |32|
+//@[19:21) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "32". (CodeDescription: none) |32|
 output arr array = true
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:23) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[19:23) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "true". (CodeDescription: none) |true|
 output arr array = false
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:24) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[19:24) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "false". (CodeDescription: none) |false|
 output arr array = {
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:23) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
+//@[19:23) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "object". (CodeDescription: none) |{\r\n}|
 }
 output arr array = 'str'
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |arr|
-//@[19:24) [BCP026 (Error)] The output expects a value of type "array" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
+//@[19:24) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
 
 // wrong object output values
 output o object = 32
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:20) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "32". (CodeDescription: none) |32|
+//@[18:20) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "32". (CodeDescription: none) |32|
 output o object = true
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:22) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "true". (CodeDescription: none) |true|
+//@[18:22) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "true". (CodeDescription: none) |true|
 output o object = false
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:23) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "false". (CodeDescription: none) |false|
+//@[18:23) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "false". (CodeDescription: none) |false|
 output o object = [
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:22) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
+//@[18:22) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "<empty array>". (CodeDescription: none) |[\r\n]|
 ]
 output o object = 'str'
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |o|
-//@[18:23) [BCP026 (Error)] The output expects a value of type "object" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
+//@[18:23) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'str'". (CodeDescription: none) |'str'|
 
 // a few expression cases
 output exp string = 2 + 3
-//@[20:25) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "5". (CodeDescription: none) |2 + 3|
+//@[20:25) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "5". (CodeDescription: none) |2 + 3|
 output union string = true ? 's' : 1
-//@[22:36) [BCP026 (Error)] The output expects a value of type "string" but the provided value is of type "'s' | 1". (CodeDescription: none) |true ? 's' : 1|
+//@[22:36) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "'s' | 1". (CodeDescription: none) |true ? 's' : 1|
 output bad int = true && !4
 //@[25:27) [BCP044 (Error)] Cannot apply operator "!" to operand of type "4". (CodeDescription: none) |!4|
 output deeper bool = true ? -true : (14 && 's') + 10
@@ -197,6 +197,7 @@ var attemptToReferenceAnOutput = myOutput
 @sys.maxValue(20)
 @minValue(10)
 output notAttachableDecorators int = 32
+//@[37:39) [BCP327 (Error)] The provided value (which will always be greater than or equal to 32) is too large to assign to a target for which the maximum allowable value is 20. (CodeDescription: none) |32|
 
 // nested loops inside output loops are not supported
 output noNestedLoops array = [for thing in things: {

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -256,7 +256,7 @@ param resrefpar string = foo.id
 //@[025:028) [BCP072 (Error)] This symbol cannot be referenced here. Only other parameters can be referenced in parameter default values. (CodeDescription: none) |foo|
 
 output resrefout bool = bar.id
-//@[024:030) [BCP026 (Error)] The output expects a value of type "bool" but the provided value is of type "string". (CodeDescription: none) |bar.id|
+//@[024:030) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "string". (CodeDescription: none) |bar.id|
 
 // attempting to set read-only properties
 resource baz 'Microsoft.Foo/foos@2020-02-02-alpha' = {

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -1376,12 +1376,28 @@ namespace Bicep.Core.TypeSystem
                     // use the item's type and propagate flags
                     return TryCreateAssignment(ResolveDiscriminatedObjects(namespaceType.ConfigurationType.Type, syntax), syntax, importAssignment.Flags);
                 case FunctionArgumentSyntax:
+                case OutputDeclarationSyntax parentOutput when syntax == parentOutput.Value:
                     if (GetNonNullableTypeAssignment(parent) is not { } parentAssignment)
                     {
                         return null;
                     }
 
                     return TryCreateAssignment(ResolveDiscriminatedObjects(parentAssignment.Reference.Type, syntax), syntax, parentAssignment.Flags);
+                case ParameterDefaultValueSyntax:
+                    // if we're in a parameter default value, get the declared type of the parameter itself
+                    parent = this.binder.GetParent(parent);
+
+                    if (parent is null)
+                    {
+                        throw new InvalidOperationException("Expected ParameterDefaultValueSyntax to have a parent.");
+                    }
+
+                    if (GetDeclaredTypeAssignment(parent) is not { } parameterAssignment)
+                    {
+                        return null;
+                    }
+
+                    return TryCreateAssignment(ResolveDiscriminatedObjects(parameterAssignment.Reference.Type, syntax), syntax, parameterAssignment.Flags);
             }
 
             return null;

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -212,7 +212,7 @@ namespace Bicep.Core.TypeSystem
             });
 
         public override void VisitTypedLocalVariableSyntax(TypedLocalVariableSyntax syntax)
-            => AssignType(syntax, () => 
+            => AssignType(syntax, () =>
             {
                 if (typeManager.GetDeclaredType(syntax) is not {} declaredType)
                 {
@@ -1889,24 +1889,22 @@ namespace Bicep.Core.TypeSystem
             var valueType = typeManager.GetTypeInfo(syntax.Value);
 
             // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
-            var diagnostics = new List<IDiagnostic>();
-            diagnostics.AddRange(valueType.GetDiagnostics());
-
-            // Avoid reporting an additional error if we failed to bind the output type.
-            if (TypeValidator.AreTypesAssignable(valueType, assignedType) == false && valueType is not ErrorType && assignedType is not ErrorType)
+            if (valueType is ErrorType)
             {
-                var builder = DiagnosticBuilder.ForPosition(syntax.Value);
-                if (TypeHelper.WouldBeAssignableIfNonNullable(valueType, assignedType, out var nonNullableValueType))
-                {
-                    diagnostics.Add(builder.PossibleNullReferenceAssignment(assignedType, valueType, syntax.Value));
-                }
-                else
-                {
-                    return builder.OutputTypeMismatch(assignedType, valueType).AsEnumerable();
-                }
+                return valueType.GetDiagnostics();
             }
 
-            return diagnostics;
+            if (assignedType is ErrorType)
+            {
+                // no point in checking that the value is assignable to the declared output type if no valid declared type could be discerned
+                return Enumerable.Empty<IDiagnostic>();
+            }
+
+            var diagnosticWriter = ToListDiagnosticWriter.Create();
+
+            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, parsingErrorLookup, diagnosticWriter, syntax.Value, assignedType);
+
+            return diagnosticWriter.GetDiagnostics();
         }
 
         private IEnumerable<IDiagnostic> ValidateDefaultValue(ParameterDefaultValueSyntax defaultValueSyntax, TypeSymbol assignedType)

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1135,54 +1135,54 @@ output test string |
         [TestMethod]
         public async Task TypeDrivenCompletionsAreOfferedInParameterAndOutputValues()
         {
-            var fileWithCursors = @"
-type bigObject = {
-  foo: {
-    bar: {
-      baz: bool
-    }
-  }
-  fizz: {
-    buzz: {
-      pop: 'snap' | 'crackle'
-    }
-  }
-}
+            var fileWithCursors = """
+                type bigObject = {
+                  foo: {
+                    bar: {
+                      baz: bool
+                    }
+                  }
+                  fizz: {
+                    buzz: {
+                      pop: 'snap' | 'crackle'
+                    }
+                  }
+                }
 
-param p bigObject = {
-  ǂ
-}
+                param p bigObject = {
+                  ǂ
+                }
 
-param p2 bigObject = {
-  foo: {
-    ǂ
-  }
-}
+                param p2 bigObject = {
+                  foo: {
+                    ǂ
+                  }
+                }
 
-param p3 bigObject = {
-  foo: {
-    bar: {
-      ǂ
-    }
-  }
-}
+                param p3 bigObject = {
+                  foo: {
+                    bar: {
+                      ǂ
+                    }
+                  }
+                }
 
-param p4 bigObject = {
-  foo: {
-    bar: {
-      baz: ǂ
-    }
-  }
-}
+                param p4 bigObject = {
+                  foo: {
+                    bar: {
+                      baz: ǂ
+                    }
+                  }
+                }
 
-output o bigObject = {
-  fizz: {
-    buzz: {
-      pop: ǂ
-    }
-  }
-}
-";
+                output o bigObject = {
+                  fizz: {
+                    buzz: {
+                      pop: ǂ
+                    }
+                  }
+                }
+                """;
 
             await RunCompletionScenarioTest(
                 this.TestContext,


### PR DESCRIPTION
Resolves #10654 

Bicep currently offers no completion support within parameter default values or within output values, and a major benefit of using structured types is that the compiler will catch typos and complete property names for you. While testing this change, I noticed that output statements only perform a shallow assignability check on the value. Now that user-defined types are supported on outputs, it makes sense to perform deep validation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10680)