### PR TITLE
MAINT: Fix GitHub Warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -582,7 +582,7 @@ jobs:
         env:
           SECRET_TO_CHECK: ${{ secrets.SECRET_TO_CHECK }}
         if: env.SECRET_TO_CHECK != ''
-        run: echo '::set-output name=verified::true'
+        run: echo 'verified=true' >> $GITHUB_OUTPUT
 
   test-cli-live:
     name: Test CLI (live) (${{ matrix.runtime.rid }}) (${{ matrix.environment }})


### PR DESCRIPTION
## Fixes the deprecation warning in the build workflow:
![image](https://github.com/Azure/bicep/assets/9611108/77db3105-2a11-4cde-802a-bfdf28e3b45b)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10715)