### PR TITLE
Use stderr for tracing

### DIFF
--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -49,7 +49,7 @@ namespace Bicep.Cli
 
             if (FeatureProvider.TracingEnabled)
             {
-                Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
+                Trace.Listeners.Add(new TextWriterTraceListener(Console.Error));
             }
 
             // this event listener picks up SDK events and writes them to Trace.WriteLine()


### PR DESCRIPTION
Closes https://github.com/Azure/bicep/issues/10477. Tested locally to confirm that it fixes the issue where trace messages break `az deployment`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10727)