### PR TITLE
MAINT: Use dotnet-coverage instead of Coverlet for coverage collection  

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -532,7 +532,7 @@ jobs:
         uses: actions/setup-dotnet@v3
 
       - name: Run Tests
-        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release
+        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --settings ./.github/workflows/codecov.runsettings
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -532,7 +532,7 @@ jobs:
         uses: actions/setup-dotnet@v3
 
       - name: Run Tests
-        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --logger trx --blame --collect:"XPlat Code Coverage" --settings ./.github/workflows/codecov.runsettings --results-directory ./TestResults/
+        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/codecov.runsettings
+++ b/.github/workflows/codecov.runsettings
@@ -3,28 +3,35 @@
   <RunConfiguration>
     <!-- Break builds when no tests are discovered. -->
     <TreatNoTestsAsError>false</TreatNoTestsAsError>
+    <ResultsDirectory>../../TestResults</ResultsDirectory>
   </RunConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>
-      <!-- Settings are documented at https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings -->
-      <DataCollector friendlyName="XPlat Code Coverage">
+      <!-- "Code Coverage" settings documented in https://learn.microsoft.com/en-us/visualstudio/test/customizing-code-coverage-analysis?view=vs-2022 -->
+      <DataCollector friendlyName="Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <!--
-            By default coverlet includes all assemblies that are referenced by test assemblies.
-            In our case, this includes other test assemblies, which makes the coverage results
-            inconsistent. If we want to exclude all test assemblies in the future, we should
-            use the Exclude setting instead.
-           -->
-          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <CodeCoverage>
+            <ModulePaths>
+              <Exclude>
+                <ModulePath>.*moq.dll$</ModulePath>
+              </Exclude>
+            </ModulePaths>
+          </CodeCoverage>
         </Configuration>
       </DataCollector>
     </DataCollectors>
   </DataCollectionRunSettings>
-  <!-- <MSTest>
-    <Parallelize>
-      <Workers>4</Workers>
-      <Scope>ClassLevel</Scope>
-    </Parallelize>
-  </MSTest> -->
+  <LoggerRunSettings>
+    <Loggers>
+      <Logger friendlyName="console" enabled="True">
+        <Configuration>
+          <Verbosity>quiet</Verbosity>
+        </Configuration>
+      </Logger>
+      <Logger friendlyName="trx" enabled="True" />
+      <!-- Enables blame -->
+      <Logger friendlyName="blame" enabled="True" />
+    </Loggers>
+  </LoggerRunSettings>
 </RunSettings>


### PR DESCRIPTION
## Description

3 years back, Coverlet was only xplat  solution available for .NET and that is why it's such popular. VS Code Coverage solution was only available for Windows. Things have changed since. Today the VS Code Coverage solution is more reliable and considerably faster, it offers static or dynamic instrumentation and unlike Coverlet it supports native C++.

There is a Code Coverage window in which you can run code coverage and display results is only available in VS Ent SKU, however, you can collect coverage in command line scenarios and it's also used in Azure pipelines. 

Now it's also offered as [.NET global tool](https://learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage) and it allows you to export results into various format such as popular Cobertura.

## PR Changes:
- Changes `.github\workflows\codecov.runsettings` to use the  VS Code Coverage tool to increase speed and enhance coverage collection 
- Folds some settings to  `.github\workflows\codecov.runsettings` that were previously passed to the `dotnet test` command as command line arguments so that we have more readable pipelines


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10809)