### PR TITLE
Fix remainder of 9580 (vscode force restore command doesn't update compilations)

### DIFF
--- a/src/Bicep.Core/Registry/ExternalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/ExternalModuleRegistry.cs
@@ -48,7 +48,7 @@ namespace Bicep.Core.Registry
              * We have already downloaded the module content from the registry.
              * The following sections will attempt to synchronize the module write with other
              * instances of the language server running on the same machine.
-             * 
+             *
              * We are not trying to prevent tampering with the module cache by the user.
              */
 
@@ -102,21 +102,21 @@ namespace Bicep.Core.Registry
         {
             try
             {
-                // recursively delete the directory 
+                // recursively delete the directory
                 Directory.Delete(moduleDirectoryPath, true);
             }
             catch (Exception exception)
             {
                 throw new ExternalModuleException($"Unable to delete the local module directory \"{moduleDirectoryPath}\". {exception.Message}", exception);
             }
-        }        
+        }
 
         private async Task TryDeleteModuleDirectoryAsync(TModuleReference reference)
         {
             /*
              * The following sections will attempt to synchronize the module directory delete with other
              * instances of the language server running on the same machine.
-             * 
+             *
              * We are not trying to prevent tampering with the module cache by the user.
              */
 
@@ -130,7 +130,7 @@ namespace Bicep.Core.Registry
                     // no lock exists, proceed
                     var moduleDirectoryPath = this.GetModuleDirectoryPath(reference);
 
-                    // delete the directory the contents to disk
+                    // delete the directory and its contents on disk
                     DeleteModuleDirectory(moduleDirectoryPath);
 
                     return;
@@ -138,7 +138,7 @@ namespace Bicep.Core.Registry
                     try {
                         // Even if the FileLock is disposed, the file remain there. See comments in FileLock.cs
                         // saying there's a race condition on Linux with the DeleteOnClose flag on the FileStream.
-                        // We will attempt the delete the file. If it throws, the lock is still open and will continue 
+                        // We will attempt to delete the file. If it throws, the lock is still open and will continue
                         // to wait until retry interval expires
                         File.Delete(lockFileUri.LocalPath);
                     }
@@ -155,7 +155,7 @@ namespace Bicep.Core.Registry
         }
 
         // base implementation for cache invalidation that should fit all external registries
-        protected async Task<IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>> InvalidateModulesCacheInternal(RootConfiguration configuration, IEnumerable<TModuleReference> references)
+        protected async Task<IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>> InvalidateModulesCacheInternal(IEnumerable<TModuleReference> references)
         {
             var statuses = new Dictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>();
 

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -166,10 +166,11 @@ namespace Bicep.Core.Registry
             foreach (var registry in referencesByRegistry.Select(byRegistry => byRegistry.Key))
             {
                 // if we're asked to purge modules cache
-                if (forceModulesRestore) {
+                if (forceModulesRestore)
+                {
                     var forceModulesRestoreStatuses = await registry.InvalidateModulesCache(referencesByRegistry[registry]);
 
-                    // update cache invalidation status for each failed modules
+                    // update cache invalidation status for each failed module
                     foreach (var (failedReference, failureBuilder) in forceModulesRestoreStatuses)
                     {
                         this.SetRestoreFailure(failedReference, configurationManager.GetConfiguration(failedReference.ParentModuleUri), failureBuilder);

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -205,7 +206,7 @@ namespace Bicep.Core.Registry
 
         public override async Task<IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>> InvalidateModulesCache(IEnumerable<OciArtifactModuleReference> references)
         {
-            return await base.InvalidateModulesCacheInternal(configuration, references);
+            return await base.InvalidateModulesCacheInternal(references);
         }
 
         public override async Task PublishModule(OciArtifactModuleReference moduleReference, Stream compiled, string? documentationUri, string? description)

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -125,7 +125,7 @@ namespace Bicep.Core.Registry
 
         public override async Task<IDictionary<ModuleReference, DiagnosticBuilder.ErrorBuilderDelegate>> InvalidateModulesCache(IEnumerable<TemplateSpecModuleReference> references)
         {
-            return await base.InvalidateModulesCacheInternal(configuration, references);
+            return await base.InvalidateModulesCacheInternal(references);
         }
 
         public override string? TryGetDocumentationUri(TemplateSpecModuleReference moduleReference) => null;

--- a/src/Bicep.Core/Semantics/Compilation.cs
+++ b/src/Bicep.Core/Semantics/Compilation.cs
@@ -16,6 +16,7 @@ namespace Bicep.Core.Semantics
 {
     public class Compilation
     {
+        // Stores semantic model for each source file (map exists for all source files, but semantic model created only when indexed)
         private readonly ImmutableDictionary<ISourceFile, Lazy<ISemanticModel>> lazySemanticModelLookup;
         private readonly IConfigurationManager configurationManager;
         private readonly IFeatureProviderFactory featureProviderFactory;
@@ -35,7 +36,7 @@ namespace Bicep.Core.Semantics
                 sourceFile => sourceFile,
                 sourceFile => (modelLookup is not null && modelLookup.TryGetValue(sourceFile, out var existingModel)) ?
                     new(existingModel) :
-                    new Lazy<ISemanticModel>(() => sourceFile switch
+                    new Lazy<ISemanticModel>(() => sourceFile switch // semantic model doesn't yet exist for file, create it
                     {
                         BicepFile bicepFile => CreateSemanticModel(bicepFile),
                         BicepParamFile bicepParamFile => CreateSemanticModel(bicepParamFile),

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -28,14 +28,14 @@ namespace Bicep.Core.Workspaces
 
         private readonly bool forceModulesRestore;
 
-        private SourceFileGroupingBuilder(IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace, bool forceforceModulesRestore = false)
+        private SourceFileGroupingBuilder(IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace, bool forceModulesRestore = false)
         {
             this.fileResolver = fileResolver;
             this.moduleDispatcher = moduleDispatcher;
             this.workspace = workspace;
             this.uriResultByModule = new();
             this.fileResultByUri = new();
-            this.forceModulesRestore = forceforceModulesRestore;
+            this.forceModulesRestore = forceModulesRestore;
         }
 
         private SourceFileGroupingBuilder(IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IReadOnlyWorkspace workspace, SourceFileGrouping current, bool forceforceModulesRestore = false)
@@ -66,7 +66,7 @@ namespace Bicep.Core.Workspaces
                 builder.uriResultByModule[sourceFile].Remove(module);
             }
 
-            // Rebuild source files that contains external module references restored during the inital build.
+            // Rebuild source files that contain external module references restored during the inital build.
             var sourceFilesToRebuild = current.SourceFiles
                 .Where(sourceFile => GetModuleDeclarations(sourceFile).Any(moduleDeclaration => modulesToRestore.Contains(new(moduleDeclaration, sourceFile))))
                 .ToImmutableHashSet()

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -95,7 +95,7 @@ namespace Bicep.LangServer.UnitTests
             var workspace = new Workspace();
             workspace.UpsertSourceFile(originalFile);
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -128,7 +128,7 @@ namespace Bicep.LangServer.UnitTests
             var uri = CreateUri(languageId);
             var workspace = new Workspace();
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -172,7 +172,7 @@ namespace Bicep.LangServer.UnitTests
             var uri = CreateUri(languageId);
             var workspace = new Workspace();
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -239,7 +239,7 @@ namespace Bicep.LangServer.UnitTests
             var uri = CreateUri(languageId);
             var workspace = new Workspace();
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             // first get should not return anything
             manager.GetCompilation(uri).Should().BeNull();
@@ -299,7 +299,7 @@ namespace Bicep.LangServer.UnitTests
         {
             var server = Repository.Create<ILanguageServerFacade>();
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             var uri = DocumentUri.File($"{TestContext.TestName}.bicep");
 
@@ -314,7 +314,7 @@ namespace Bicep.LangServer.UnitTests
             var document = BicepCompilationManagerHelper.CreateMockDocument(p => receivedParams = p);
             var server = BicepCompilationManagerHelper.CreateMockServer(document);
 
-            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             var uri = DocumentUri.File($"{TestContext.TestName}.bicep");
 
@@ -350,7 +350,7 @@ namespace Bicep.LangServer.UnitTests
             var uri = CreateUri(languageId);
             var workspace = new Workspace();
 
-            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             // upsert should fail because of the mock fatal exception
             manager.OpenCompilation(uri, BaseVersion, "fake", languageId);
@@ -411,7 +411,7 @@ namespace Bicep.LangServer.UnitTests
 
             var workspace = new Workspace();
 
-            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var manager = new BicepCompilationManager(server.Object, provider.Object, workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             // upsert should fail because of the mock fatal exception
             manager.OpenCompilation(uri, version, "fake", languageId);
@@ -509,7 +509,7 @@ module moduleB './moduleB.bicep' = {
                 BicepTestConstants.BuiltInOnlyConfigurationManager,
                 BicepTestConstants.LinterAnalyzer);
 
-            var compilationManager = new BicepCompilationManager(server.Object, compilationProvider, new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            var compilationManager = new BicepCompilationManager(server.Object, compilationProvider, new Workspace(), BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
 
             diagsReceieved.Should().BeEmpty();
 
@@ -614,8 +614,7 @@ module moduleB './moduleB.bicep' = {
                 workspace: workspace,
                 scheduler: BicepCompilationManagerHelper.CreateMockScheduler().Object,
                 telemetryProvider: BicepTestConstants.CreateMockTelemetryProvider().Object,
-                LinterRulesProvider: linterRulesProvider,
-                bicepAnalyzer: BicepTestConstants.LinterAnalyzer);
+                LinterRulesProvider: linterRulesProvider);
 
             // first gets should not return anything
             manager.GetCompilation(bicepFileUri).Should().BeNull();
@@ -884,7 +883,7 @@ param location string = 'testLocation'";
             var uri = DocumentUri.File($"{TestContext.TestName}.bicep");
             var workspace = new Workspace();
 
-            return new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider, BicepTestConstants.LinterAnalyzer);
+            return new BicepCompilationManager(server.Object, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, linterRulesProvider);
         }
 
         private DocumentUri CreateUri(string languageId) => DocumentUri.File(this.TestContext.TestName + (languageId switch

--- a/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
@@ -236,7 +236,7 @@ namespace Bicep.LangServer.UnitTests.Configuration
             var workspace = new Workspace();
 
             var configurationManager = new ConfigurationManager(new IOFileSystem());
-            var bicepCompilationManager = new BicepCompilationManager(server, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(configurationManager), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, new LinterRulesProvider(), BicepTestConstants.LinterAnalyzer);
+            var bicepCompilationManager = new BicepCompilationManager(server, BicepCompilationManagerHelper.CreateEmptyCompilationProvider(configurationManager), workspace, BicepCompilationManagerHelper.CreateMockScheduler().Object, BicepTestConstants.CreateMockTelemetryProvider().Object, new LinterRulesProvider());
             bicepCompilationManager.OpenCompilation(DocumentUri.From(bicepFilePath), null, bicepFileContents, LanguageConstants.LanguageId);
 
             var bicepConfigDocumentUri = DocumentUri.FromFileSystemPath(bicepFilePath);

--- a/src/Bicep.LangServer.UnitTests/Helpers/CompilationHelperTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Helpers/CompilationHelperTests.cs
@@ -38,7 +38,7 @@ namespace Bicep.LangServer.UnitTests.Helpers
 
             compilationContext.Should().BeNull();
 
-            var compilation = await new CompilationHelper(bicepCompiler, bicepCompilationManager).GetCompilation(documentUri);
+            var compilation = await new CompilationHelper(bicepCompiler, bicepCompilationManager).GetRefreshedCompilation(documentUri);
 
             compilation.Should().NotBeNull();
         }
@@ -57,7 +57,7 @@ namespace Bicep.LangServer.UnitTests.Helpers
             // Upsert compilation. This will cause CompilationContext to be non null
             BicepCompilationManager bicepCompilationManager = BicepCompilationManagerHelper.CreateCompilationManager(documentUri, bicepFileContents, upsertCompilation: true);
 
-            var compilation = await new CompilationHelper(bicepCompiler, bicepCompilationManager).GetCompilation(documentUri);
+            var compilation = await new CompilationHelper(bicepCompiler, bicepCompilationManager).GetRefreshedCompilation(documentUri);
 
             compilation.Should().NotBeNull();
             compilation.Should().BeSameAs(bicepCompilationManager.GetCompilation(documentUri)!.Compilation);

--- a/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
+++ b/src/Bicep.LangServer/CompilationManager/ICompilationManager.cs
@@ -7,12 +7,13 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.CompilationManager
 {
-    // TODO: Get rid of the generic interface
-    public interface ICompilationManager<T>
+    public interface ICompilationManager
     {
         void HandleFileChanges(IEnumerable<FileEvent> fileEvents);
 
         void RefreshCompilation(DocumentUri uri);
+
+        void RefreshAllActiveCompilations();
 
         void OpenCompilation(DocumentUri uri, int? version, string text, string languageId);
 
@@ -20,11 +21,6 @@ namespace Bicep.LanguageServer.CompilationManager
 
         void CloseCompilation(DocumentUri uri);
 
-        T? GetCompilation(DocumentUri uri);
-    }
-
-    public interface ICompilationManager : ICompilationManager<CompilationContext>
-    {
-
+        CompilationContext? GetCompilation(DocumentUri uri);
     }
 }

--- a/src/Bicep.LangServer/Configuration/BicepConfigChangeHandler.cs
+++ b/src/Bicep.LangServer/Configuration/BicepConfigChangeHandler.cs
@@ -35,11 +35,7 @@ namespace Bicep.LanguageServer.Configuration
         public void RefreshCompilationOfSourceFilesInWorkspace()
         {
             configurationManager.PurgeCache();
-
-            foreach (Uri sourceFileUri in workspace.GetActiveSourceFilesByUri().Keys)
-            {
-                compilationManager.RefreshCompilation(DocumentUri.From(sourceFileUri));
-            }
+            compilationManager.RefreshAllActiveCompilations();
         }
 
         public void HandleBicepConfigOpenEvent(DocumentUri documentUri)
@@ -55,7 +51,7 @@ namespace Bicep.LanguageServer.Configuration
             configurationManager.PurgeLookupCache();
         }
 
-        private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri) 
+        private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri)
             => configurationManager.RefreshConfigCacheEntry(documentUri.ToUri());
 
         public void HandleBicepConfigSaveEvent(DocumentUri documentUri)

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -61,7 +61,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var fileUri = documentUri.ToUri();
 
-            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);
+            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
 
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
                 .FirstOrDefault(x => x.Key.FileUri == fileUri);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -55,7 +55,7 @@ namespace Bicep.LanguageServer.Handlers
             try
             {
                 var documentUri = request.TextDocument.Uri;
-                var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);
+                var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
 
                 // Cache the compilation so that it can be reused by BicepDeploymentParametersHandler
                 deploymentFileCompilationCache.CacheCompilation(documentUri, compilation);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -178,7 +178,7 @@ namespace Bicep.LanguageServer.Handlers
         public async Task<BicepparamCompilationResult> TryCompileBicepparamFile(string parametersFilePath)
         {
             var documentUri = DocumentUri.FromFileSystemPath(parametersFilePath);
-            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);
+            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
 
             var paramsModel = compilation.GetEntrypointSemanticModel();
 

--- a/src/Bicep.LangServer/Handlers/BicepForceModulesRestoreCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepForceModulesRestoreCommandHandler.cs
@@ -22,12 +22,14 @@ namespace Bicep.LanguageServer.Handlers
     {
         private readonly IFileResolver fileResolver;
         private readonly IModuleDispatcher moduleDispatcher;
+        private readonly IWorkspace workspace;
 
-        public BicepForceModulesRestoreCommandHandler(ISerializer serializer, IFileResolver fileResolver, IModuleDispatcher moduleDispatcher)
+        public BicepForceModulesRestoreCommandHandler(ISerializer serializer, IFileResolver fileResolver, IModuleDispatcher moduleDispatcher, IWorkspace workspace)
             : base(LangServerConstants.ForceModulesRestoreCommand, serializer)
         {
             this.fileResolver = fileResolver;
             this.moduleDispatcher = moduleDispatcher;
+            this.workspace = workspace;
         }
 
         public override Task<string> Handle(string bicepFilePath, CancellationToken cancellationToken)
@@ -38,16 +40,15 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             DocumentUri documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            Task<string> restoreOutput = GenerateForceModulesRestoreOutputMessage(bicepFilePath, documentUri);
+            Task<string> restoreOutput = ForceModulesRestoreAndGenerateOutputMessage(documentUri);
 
             return restoreOutput;
         }
 
-        private async Task<string> GenerateForceModulesRestoreOutputMessage(string bicepFilePath, DocumentUri documentUri)
+        private async Task<string> ForceModulesRestoreAndGenerateOutputMessage(DocumentUri documentUri)
         {
             var fileUri = documentUri.ToUri();
 
-            Workspace workspace = new Workspace();
             SourceFileGrouping sourceFileGrouping = SourceFileGroupingBuilder.Build(this.fileResolver, this.moduleDispatcher, workspace, fileUri);
 
             // Ignore modules to restore logic, include all modules to be restored
@@ -59,7 +60,8 @@ namespace Bicep.LanguageServer.Handlers
                 .Distinct()
                 .OrderBy(key => key.FullyQualifiedReference);
 
-            if (!modulesToRestoreReferences.Any()) {
+            if (!modulesToRestoreReferences.Any())
+            {
                 return $"Restore (force) skipped. No modules references in input file.";
             }
 
@@ -68,10 +70,14 @@ namespace Bicep.LanguageServer.Handlers
 
             // if all are marked as success
             var sbRestoreSummary = new StringBuilder();
-            foreach(var module in modulesToRestoreReferences) {
+            foreach (var module in modulesToRestoreReferences)
+            {
                 var restoreStatus = this.moduleDispatcher.GetModuleRestoreStatus(module, out _);
                 sbRestoreSummary.Append($"{Environment.NewLine}  * {module.FullyQualifiedReference}: {restoreStatus}");
             }
+
+            // Have to actually update compilations to pick up new modules' contents
+            workspace.UpsertSourceFiles(sourceFileGrouping.SourceFiles);
 
             return $"Restore (force) summary: {sbRestoreSummary}";
         }

--- a/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
@@ -67,7 +67,7 @@ namespace Bicep.LanguageServer.Handlers
                 return "Generating parameters file failed. The file \"" + compiledFile + "\" already exists but does not contain the schema for a parameters file. If overwriting the file is intended, delete it manually and retry the Generate Parameters command.";
             }
 
-            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetCompilation(documentUri);
+            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
             var fileUri = documentUri.ToUri();
 
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()

--- a/src/Bicep.LangServer/Utils/CompilationHelper.cs
+++ b/src/Bicep.LangServer/Utils/CompilationHelper.cs
@@ -20,12 +20,13 @@ namespace Bicep.LanguageServer.Utils
             this.compilationManager = compilationManager;
         }
 
-        public async Task<Compilation> GetCompilation(DocumentUri documentUri)
+        public async Task<Compilation> GetRefreshedCompilation(DocumentUri documentUri)
         {
             // Bicep file could contain load functions like loadTextContent(..). We'll refresh compilation to detect changes in files referenced in load functions.
             var fileUri = documentUri.ToUri();
             compilationManager.RefreshCompilation(fileUri);
             var context = compilationManager.GetCompilation(documentUri);
+
             // CompilationContext will be null if the file is not open in the editor.
             // E.g. When user right clicks on a file from the explorer context menu without opening the file and invokes build/deploy
             if (context is null)

--- a/src/vscode-bicep/src/commands/forceModulesRestore.ts
+++ b/src/vscode-bicep/src/commands/forceModulesRestore.ts
@@ -11,7 +11,7 @@ export class ForceModulesRestoreCommand implements Command {
   public constructor(
     private readonly client: LanguageClient,
     private readonly outputChannelManager: OutputChannelManager
-  ) {}
+  ) { }
 
   public async execute(
     _context: IActionContext,
@@ -37,6 +37,12 @@ export class ForceModulesRestoreCommand implements Command {
     }
 
     try {
+      this.outputChannelManager.appendToOutputChannel(
+        `Force restoring modules in ${
+          documentUri.fsPath ?? documentUri.toString()
+        }...`
+      );
+
       const forceModulesRestoreOutput: string = await this.client.sendRequest(
         "workspace/executeCommand",
         {


### PR DESCRIPTION
Fixes #9580

Actual fix is in BicepForceModulesRestoreCommandHandler.ForceModulesRestoreAndGenerateOutputMessage.  The other changes are code/comment improvements

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10829)