### PR TITLE
MAINT: Increase default timeout to add stability to ci on MSTest

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/IntegrationTestHelper.cs
@@ -12,7 +12,7 @@ namespace Bicep.LangServer.IntegrationTests
 {
     public static class IntegrationTestHelper
     {
-        private const int DefaultTimeout = 30000;
+        private const int DefaultTimeout = 60000;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Not an issue in test code.")]
         public static async Task<T> WithTimeoutAsync<T>(Task<T> task, int timeout = DefaultTimeout)

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultipleMessageListener.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultipleMessageListener.cs
@@ -11,7 +11,7 @@ namespace Bicep.LangServer.IntegrationTests
     /// </summary>
     public class MultipleMessageListener<T>
     {
-        private const int DefaultTimeout = 30000;
+        private const int DefaultTimeout = 60000;
 
         private readonly object lockObj = new();
         private readonly List<TaskCompletionSource<T>> completionSources = new();


### PR DESCRIPTION
## Description

- Increased default timeout for the integration tests to help solve the instability in CI
- We tried to investigate the root cause and ruled out the dynamic type loading as a source of instability

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10834)