### PR TITLE
Allow specifying metadata in bicep in addition to metadata.json

### DIFF
--- a/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/ValidateCommandTests.cs
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/Commands/ValidateCommandTests.cs
@@ -42,6 +42,7 @@ namespace Bicep.RegistryModuleTool.IntegrationTests.Commands
   ""resources"": []
 }";
 
+        // TODO: This test doesn't catch if main.json does not match the compiled main.bicep
         [TestMethod]
         public void Invoke_ValidFiles_ReturnsZero()
         {
@@ -92,7 +93,7 @@ The file ""{fileSystem.Path.GetFullPath(MainBicepFile.FileName)}"" is invalid. D
                 $@"The file ""{fileSystem.Path.GetFullPath(MetadataFile.FileName)}"" is invalid:
   #/summary: Value is not longer than or equal to 10 characters
 ".ReplaceLineEndings(),
-                $@"The file ""{fileSystem.Path.GetFullPath(ReadmeFile.FileName)}"" is modified or outdated. Please regenerate the file to fix it.
+                $@"The file ""{fileSystem.Path.GetFullPath(ReadmeFile.FileName)}"" is modified or outdated. Please run `brm generate` to regenerate it.
 ".ReplaceLineEndings(),
                 $@"The file ""{fileSystem.Path.GetFullPath(VersionFile.FileName)}"" is invalid:
   #: Required properties [""$schema"",""version"",""pathFilters""] were not present

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Modified/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Modified/main.bicep
@@ -1,27 +1,32 @@
-@description('The dns prefix')
+metadata name = 'Sample module'
+metadata description = 'Sample summary'
+metadata owner = 'test'
+
+// TODO: Remove "sys." everywhere once bicep v0.18 ships
+@sys.description('The dns prefix')
 param dnsPrefix string
 
-@description('The linux administrator username')
+@sys.description('The linux administrator username')
 param linuxAdminUsername string
 
-@description('The RSA public key for SSH')
+@sys.description('The RSA public key for SSH')
 param sshRSAPublicKey string
 
-@description('The service principal client ID')
+@sys.description('The service principal client ID')
 param servicePrincipalClientId string
 
-@description('The service principal client secret')
+@sys.description('The service principal client secret')
 @secure()
 param servicePrincipalClientSecret string
 
 // optional params
-@description('The cluster name')
+@sys.description('The cluster name')
 param clusterName string = 'aks101cluster'
 
-@description('The deployment location')
+@sys.description('The deployment location')
 param location string = resourceGroup().location
 
-@description('''
+@sys.description('''
 The OS disk size (in GB)
 - Minimum value is 0
 - Maximum value is 1023
@@ -30,12 +35,13 @@ The OS disk size (in GB)
 @maxValue(1023)
 param osDiskSizeGB int
 
-@description('The agent count')
+@sys.description('The agent count')
 @minValue(1)
 @maxValue(50)
+// TODO: Causes error during build
 param agentCount int = 0
 
-@description('The agent VM size')
+@sys.description('The agent VM size')
 param agentVMSize string = 'Standard_DS2_v2'
 // osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test
 
@@ -71,5 +77,5 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
   }
 }
 
-@description('The control plane FQDN')
+@sys.description('The control plane FQDN')
 output controlPlaneFQDN string = aks.properties.fqdn

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/main.bicep
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/main.bicep
@@ -1,27 +1,32 @@
-@description('The dns prefix')
+metadata name = 'Sample module'
+metadata description = 'Sample summary'
+metadata owner = 'test'
+
+// TODO: Remove "sys." everywhere once bicep v0.18 ships
+@sys.description('The dns prefix')
 param dnsPrefix string
 
-@description('The linux administrator username')
+@sys.description('The linux administrator username')
 param linuxAdminUsername string
 
-@description('The RSA public key for SSH')
+@sys.description('The RSA public key for SSH')
 param sshRSAPublicKey string
 
-@description('The service principal client ID')
+@sys.description('The service principal client ID')
 param servicePrincipalClientId string
 
-@description('The service principal client secret')
+@sys.description('The service principal client secret')
 @secure()
 param servicePrincipalClientSecret string
 
 // optional params
-@description('The cluster name')
+@sys.description('The cluster name')
 param clusterName string = 'aks101cluster'
 
-@description('The deployment location')
+@sys.description('The deployment location')
 param location string = resourceGroup().location
 
-@description('''
+@sys.description('''
 The OS disk size (in GB)
 - Minimum value is 0
 - Maximum value is 1023
@@ -30,12 +35,13 @@ The OS disk size (in GB)
 @maxValue(1023)
 param osDiskSizeGB int
 
-@description('The agent count')
+@sys.description('The agent count')
 @minValue(1)
 @maxValue(50)
+// TODO: Causes error during build
 param agentCount int = 0
 
-@description('The agent VM size')
+@sys.description('The agent VM size')
 param agentVMSize string = 'Standard_DS2_v2'
 // osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test
 
@@ -71,5 +77,5 @@ resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
   }
 }
 
-@description('The control plane FQDN')
+@sys.description('The control plane FQDN')
 output controlPlaneFQDN string = aks.properties.fqdn

--- a/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/main.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/SampleFiles/Valid/main.json
@@ -4,9 +4,12 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.5.6.12127",
-      "templateHash": "16759655392678672335"
-    }
+      "version": "0.17.1.54307",
+      "templateHash": "10412415083708682261"
+    },
+    "name": "Sample module",
+    "description": "Sample summary",
+    "owner": "test"
   },
   "parameters": {
     "dnsPrefix": {
@@ -58,7 +61,7 @@
       "maxValue": 1023,
       "minValue": 0,
       "metadata": {
-        "description": "The OS disk size (in GB)\n- Minimum value is 0\n- Maximum value is 1023\n"
+        "description": "The OS disk size (in GB)\r\n- Minimum value is 0\r\n- Maximum value is 1023\r\n"
       }
     },
     "agentCount": {
@@ -116,10 +119,10 @@
   "outputs": {
     "controlPlaneFQDN": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))).fqdn]",
       "metadata": {
         "description": "The control plane FQDN"
-      }
+      },
+      "value": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2020-09-01').fqdn]"
     }
   }
 }

--- a/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/DiffValidatorTests.cs
+++ b/src/Bicep.RegistryModuleTool.UnitTests/ModuleValidators/DiffValidatorTests.cs
@@ -48,7 +48,7 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 
             Invoking(() => this.sut.Validate(fileToValidate)).Should()
                 .Throw<InvalidModuleException>()
-                .WithMessage($"The file \"{fileToValidate.Path}\" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
+                .WithMessage($"The file \"{fileToValidate.Path}\" is modified or outdated. Please run `brm generate` to regenerate it.{Environment.NewLine}");
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 
             Invoking(() => this.sut.Validate(fileToValidate)).Should()
                 .Throw<InvalidModuleException>()
-                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
+                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please run `brm generate` to regenerate it.{Environment.NewLine}");
         }
 
         [DataTestMethod]
@@ -81,7 +81,7 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 
             Invoking(() => this.sut.Validate(fileToValidate)).Should()
                 .Throw<InvalidModuleException>()
-                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
+                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please run `brm generate` to regenerate it.{Environment.NewLine}");
         }
 
         [TestMethod]
@@ -107,7 +107,7 @@ namespace Bicep.RegistryModuleTool.UnitTests.ModuleValidators
 
             Invoking(() => this.sut.Validate(fileToValidate)).Should()
                 .Throw<InvalidModuleException>()
-                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please regenerate the file to fix it.{Environment.NewLine}");
+                .WithMessage($@"The file ""{fileToValidate.Path}"" is modified or outdated. Please run `brm generate` to regenerate it.{Environment.NewLine}");
         }
 
         private static IEnumerable<object[]> GetEmptyExamplesSectionData()

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MainArmTemplateFile.cs
@@ -36,6 +36,10 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         private readonly Lazy<string> lazyTemplateHash;
 
+        private readonly Lazy<string?> lazyNameMetadata;
+        private readonly Lazy<string?> lazyOwnerMetadata;
+        private readonly Lazy<string?> lazyDescriptionMetadata;
+
         public MainArmTemplateFile(string path, string content)
             : base(path)
         {
@@ -51,6 +55,9 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
                 ? Enumerable.Empty<MainArmTemplateOutput>()
                 : outputsElement.EnumerateObject().Select(ToOutput));
             this.lazyTemplateHash = new(() => lazyRootElement.Value.GetPropertyByPath("metadata._generator.templateHash").ToNonNullString());
+            this.lazyNameMetadata = new(() => lazyRootElement.Value.TryGetPropertyByPath("metadata.name")?.ToNonNullString());
+            this.lazyOwnerMetadata= new(() => lazyRootElement.Value.TryGetPropertyByPath("metadata.owner")?.ToNonNullString());
+            this.lazyDescriptionMetadata = new(() => lazyRootElement.Value.TryGetPropertyByPath("metadata.description")?.ToNonNullString());
         }
 
         private static string GetPrimitiveTypeName(ITypeReference typeRef) => typeRef.Type switch {
@@ -78,6 +85,12 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
         public IEnumerable<MainArmTemplateOutput> Outputs => this.lazyOutputs.Value;
 
         public string TemplateHash => this.lazyTemplateHash.Value;
+
+        public string? NameMetadata => this.lazyNameMetadata.Value;
+
+        public string? OwnerMetadata => this.lazyOwnerMetadata.Value;
+
+        public string? DescriptionMetadata => this.lazyDescriptionMetadata.Value;
 
         public static MainArmTemplateFile Generate(IFileSystem fileSystem, BicepCliProxy bicepCliProxy, MainBicepFile mainBicepFile)
         {

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/MetadataFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/MetadataFile.cs
@@ -36,6 +36,8 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         public string? Summary => this.RootElement.TryGetProperty("summary", out var element) ? element.GetString() : null;
 
+        public string? Owner => this.RootElement.TryGetProperty("owner", out var element) ? element.GetString() : null;
+
         public static MetadataFile EnsureInFileSystem(IFileSystem fileSystem)
         {
             var path = fileSystem.Path.GetFullPath(FileName);

--- a/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFiles/ReadmeFile.cs
@@ -19,6 +19,7 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
     {
         public const string FileName = "README.md";
 
+        // TODO: rename to "Details"
         private static readonly string DescriptionSectionTemplate = @"## Description
 {{ Add detailed description for the module. }}".ReplaceLineEndings();
 
@@ -40,13 +41,34 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
         public static ReadmeFile Generate(IFileSystem fileSystem, MetadataFile metadataFile, MainArmTemplateFile mainArmTemplateFile)
         {
+            // TODO: rename to "Details"
             var descriptionSection = DescriptionSectionTemplate;
             var examplesSection = ExamplesSectionTemplate;
+
+            var moduleName = mainArmTemplateFile.NameMetadata ?? metadataFile.Name ?? "MISSING Name";
+            var moduleOwner = mainArmTemplateFile.OwnerMetadata ?? metadataFile.Owner ?? "MISSING Owner";
+            // TODO: rename to "Description"
+            var moduleSummary = mainArmTemplateFile.DescriptionMetadata ?? metadataFile.Summary ?? "MISSING Summary";
+
+            // TODO: remove support for metadata.json, or generate it from bicep metadata
+            if (!moduleName.Equals(metadataFile.Name, StringComparison.InvariantCulture))
+            {
+                throw new ArgumentException("The `name` property in metadata.json does not match `metadata name` in the bicep file. If both are specified, they must be the same.");
+            }
+            if (!moduleOwner.Equals(metadataFile.Owner, StringComparison.InvariantCulture))
+            {
+                throw new ArgumentException("The `owner` property in metadata.json does not match `metadata owner` in the bicep file. If both are specified, they must be the same.");
+            }
+            if (!moduleSummary.Equals(metadataFile.Summary, StringComparison.InvariantCulture))
+            {
+                throw new ArgumentException("The `summary` property in metadata.json does not match `metadata description` in the bicep file. If both are specified, they must be the same.");
+            }
 
             try
             {
                 var existingFile = ReadFromFileSystem(fileSystem);
 
+                // TODO: rename to "Details"
                 UseExistingSectionIfNotEmpty(existingFile, "## Description", ref descriptionSection);
                 UseExistingSectionIfNotEmpty(existingFile, "## Examples", ref examplesSection);
             }
@@ -57,10 +79,10 @@ namespace Bicep.RegistryModuleTool.ModuleFiles
 
             var builder = new StringBuilder();
 
-            builder.AppendLine($"# {metadataFile.Name}");
+            builder.AppendLine($"# {moduleName}");
             builder.AppendLine();
 
-            builder.AppendLine(metadataFile.Summary);
+            builder.AppendLine(moduleSummary);
             builder.AppendLine();
 
             builder.AppendLine(descriptionSection);

--- a/src/Bicep.RegistryModuleTool/ModuleValidators/DiffValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleValidators/DiffValidator.cs
@@ -47,7 +47,7 @@ namespace Bicep.RegistryModuleTool.ModuleValidators
 
             if (DiffLines(newContent, oldContent))
             {
-                throw new InvalidModuleException($"The file \"{filePath}\" is modified or outdated. Please regenerate the file to fix it.");
+                throw new InvalidModuleException($"The file \"{filePath}\" is modified or outdated. Please run `brm generate` to regenerate it.");
             }
         }
 


### PR DESCRIPTION
This is meant to ease the conversion away from metadata.json and to using metadata in the bicep file.  It changes:

1) Picks up metadata in bicep, if present, when generating readme.md
2) If metadata present in bicep, enforces that it's the same as what's in metadata.json

Right now the metadata.json file is still required, the metadata in bicep is optional (but if present, will get picked up by Bicep for hover).