### PR TITLE
MAINT: Enhance test execution and reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -532,14 +532,14 @@ jobs:
         uses: actions/setup-dotnet@v3
 
       - name: Run Tests
-        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --settings ./.github/workflows/codecov.runsettings
+        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --settings ./.github/workflows/codecov.runsettings --results-directory ./TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.runtime.rid }}
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Bicep.TestResults.${{ matrix.runtime.rid }}
-          path: ./TestResults/**/*.trx
+          path: ./TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.runtime.rid }}/**/*.trx
           if-no-files-found: error
 
       - name: Download Bicep CLI
@@ -573,6 +573,36 @@ jobs:
         with:
           flags: dotnet
 
+  publish-test-results:
+    name: "Publish Tests Results (${{ matrix.rid }})"
+    needs: test-bicep
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      # only needed unless run with comment_mode: off
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: ["win-x64", "linux-x64", "linux-musl-x64", "osx-x64"]
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Bicep.TestResults.${{ matrix.rid }}
+          path: TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.rid }}
+
+      - name: List downloaded artifacts
+        run: ls -R TestResults/
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: "Test Results (${{ matrix.rid }})"
+          files: "TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.rid }}/**/*.trx"
+  
   can-run-live-tests:
     name: Check secret access
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.runsettings
+++ b/.github/workflows/codecov.runsettings
@@ -3,7 +3,6 @@
   <RunConfiguration>
     <!-- Break builds when no tests are discovered. -->
     <TreatNoTestsAsError>false</TreatNoTestsAsError>
-    <ResultsDirectory>../../TestResults</ResultsDirectory>
   </RunConfiguration>
   <DataCollectionRunSettings>
     <DataCollectors>


### PR DESCRIPTION
## Description
- Parallel execution of tests to increase CI speed
- Test reporting so we can see the test results directly from the PR 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10867)