### PR TITLE
Handle duplicate properties in object type definition with a diagnostics, not an exception

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -714,4 +714,21 @@ param myParam string
             ("BCP331", DiagnosticLevel.Error, "A type's \"minLength\" must be less than or equal to its \"maxLength\", but a minimum of 1 and a maximum of 0 were specified."),
         });
     }
+
+    [TestMethod]
+    public void Duplicate_property_names_should_raise_descriptive_diagnostic()
+    {
+        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes,
+            """
+            type foo = {
+                bar: bool
+                bar: string
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP025", DiagnosticLevel.Error, "The property \"bar\" is declared multiple times in this object. Remove or rename the duplicate properties.")
+        });
+    }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -549,6 +549,7 @@ namespace Bicep.Core.TypeSystem
                 return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).TypedObjectDeclarationsUnsupported());
             }
 
+            HashSet<string> propertyNamesEncountered = new();
             List<TypeProperty> properties = new();
             List<ErrorDiagnostic> diagnostics = new();
             ObjectTypeNameBuilder nameBuilder = new();
@@ -560,6 +561,14 @@ namespace Bicep.Core.TypeSystem
 
                 if (prop.TryGetKeyText() is string propertyName)
                 {
+                    if (propertyNamesEncountered.Contains(propertyName))
+                    {
+                        // if there is already a property with this name declared, log an error and move on
+                        diagnostics.Add(DiagnosticBuilder.ForPosition(prop.Key).PropertyMultipleDeclarations(propertyName));
+                        continue;
+                    }
+                    propertyNamesEncountered.Add(propertyName);
+
                     properties.Add(new(propertyName, propertyType, TypePropertyFlags.Required, DescriptionHelper.TryGetFromDecorator(binder, typeManager, prop)));
                     nameBuilder.AppendProperty(propertyName, GetPropertyTypeName(prop.Value, propertyType));
                 } else


### PR DESCRIPTION
Resolves #10742 

When a object type declaration contains multiple properties with the same name, the object type constructor is surfacing an exception from a Linq dictionary comprehension. This PR updates the DeclaredTypeManager to instead detect duplicate properties and raise a diagnostic.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/10983)