### PR TITLE
Support instance functions on resource-typed params

### DIFF
--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -491,25 +491,34 @@ public class ExpressionBuilder
                 var (baseSyntax, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(method.BaseExpression);
                 var baseSymbol = Context.SemanticModel.GetSymbolInfo(baseSyntax);
 
-                switch (baseSymbol)
+                if (baseSymbol is INamespaceSymbol namespaceSymbol)
                 {
-                    case INamespaceSymbol namespaceSymbol:
-                        Debug.Assert(indexExpression is null, "Indexing into a namespace should have been blocked by type analysis");
-                        return new FunctionCallExpression(
-                            method,
-                            method.Name.IdentifierName,
-                            method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
-                    case { } _ when Context.SemanticModel.ResourceMetadata.TryLookup(baseSyntax) is DeclaredResourceMetadata resource:
-                        var indexContext = TryGetReplacementContext(resource.NameSyntax, indexExpression, method);
-
-                        // Handle list<method_name>(...) method on resource symbol - e.g. stgAcc.listKeys()
-                        // This is also used for kv.getSecret() - for passing secure values to module parameters
-                        return new ResourceFunctionCallExpression(
-                            method,
-                            new ResourceReferenceExpression(method.BaseExpression, resource, indexContext),
-                            method.Name.IdentifierName,
-                            method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                    Debug.Assert(indexExpression is null, "Indexing into a namespace should have been blocked by type analysis");
+                    return new FunctionCallExpression(
+                        method,
+                        method.Name.IdentifierName,
+                        method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
                 }
+
+                var resource = Context.SemanticModel.ResourceMetadata.TryLookup(baseSyntax);
+                var indexContext = resource switch
+                {
+                    DeclaredResourceMetadata declaredResource => TryGetReplacementContext(declaredResource.NameSyntax, indexExpression, method),
+                    ModuleOutputResourceMetadata moduleOutputResource => TryGetReplacementContext(moduleOutputResource.Module, indexExpression, method),
+                    _ => null,
+                };
+
+                if (resource is not null)
+                {
+                    // Handle list<method_name>(...) method on resource symbol - e.g. stgAcc.listKeys()
+                    // This is also used for kv.getSecret() - for passing secure values to module parameters
+                    return new ResourceFunctionCallExpression(
+                        method,
+                        new ResourceReferenceExpression(method.BaseExpression, resource, indexContext),
+                        method.Name.IdentifierName,
+                        method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                }
+
                 throw new InvalidOperationException($"Unrecognized base expression {baseSymbol?.Kind}");
             default:
                 throw new NotImplementedException($"Cannot emit unexpected expression of type {functionCall.GetType().Name}");

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1180,10 +1180,12 @@ namespace Bicep.LanguageServer.Completions
             }).Where(p => !p.Flags.HasFlag(TypePropertyFlags.FallbackProperty));
         }
 
-        private static IEnumerable<FunctionSymbol> GetMethods(TypeSymbol? type) =>
-            type is ObjectType objectType
-                ? objectType.MethodResolver.GetKnownFunctions().Values
-                : Enumerable.Empty<FunctionSymbol>();
+        private static IEnumerable<FunctionSymbol> GetMethods(TypeSymbol? type) => type switch
+        {
+            ObjectType objectType => objectType.MethodResolver.GetKnownFunctions().Values,
+            ResourceType resourceType => GetMethods(resourceType.Body.Type),
+            _ => Enumerable.Empty<FunctionSymbol>(),
+        };
 
         private static DeclaredTypeAssignment? GetDeclaredTypeAssignment(SemanticModel model, SyntaxBase? syntax) => syntax == null
             ? null


### PR DESCRIPTION
Resolves #10994 

Although instance functions on resource-typed outputs and parameters currently raise no diagnostics, they are not proposed as completions and lead to an unhandled exception when the syntax is converted to the Bicep IR. 

This PR fixes up resource-typed params and outputs instance function support with three changes:
* The IR conversion for `InstanceFunctionCallSyntax` is updated to support all resources, not just those of type `DeclaredResourceMetadata`.
* A check is added to `EmitLimitationCalculator` to raise an error diagnostic when an instance function is called on a resource-typed module output, as `list*(reference(...).outputs. ...)` is blocked by ARM's dependency graph processor. (The `getSecret()` function doesn't result in nested runtime functions and so is permitted.)
* The language server completion provider is updated to suggest known resource functions on resource-typed params and outputs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/11031)