### PR TITLE
Expand leading `~` in `RootConfiguration.CacheRootDirectory`

### DIFF
--- a/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
@@ -38,6 +38,8 @@ public class RootConfigurationTests
         return new[]
         {
             new object[] { "~", homeDirectory },
+            new object[] { "~/", $"{homeDirectory}/" },
+            new object[] { "~\\", $"{homeDirectory}\\" },
             new object[] { "~/foo/bar", $"{homeDirectory}/foo/bar" },
             new object[] { "~\\foo/bar", $"{homeDirectory}\\foo/bar" },
         };

--- a/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Bicep.Core.Configuration;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Configuration;
+
+[TestClass]
+public class RootConfigurationTests
+{
+    [DataTestMethod]
+    [DynamicData(nameof(GetTestData), DynamicDataSourceType.Method)]
+    public void RootConfiguration_LeadingTildeInCacheRootDirectory_ExpandPath(string cacheRootDirectory, string expectedExpandedDirectory)
+    {
+        var configuration = new RootConfiguration(
+                BicepTestConstants.BuiltInConfiguration.Cloud,
+                BicepTestConstants.BuiltInConfiguration.ModuleAliases,
+                BicepTestConstants.BuiltInConfiguration.Analyzers,
+                cacheRootDirectory,
+                BicepTestConstants.BuiltInConfiguration.ExperimentalFeaturesEnabled,
+                BicepTestConstants.BuiltInConfiguration.Formatting,
+                BicepTestConstants.BuiltInConfiguration.ConfigurationPath,
+                BicepTestConstants.BuiltInConfiguration.DiagnosticBuilders);
+
+        configuration.CacheRootDirectory.Should().Be(expectedExpandedDirectory);
+    }
+
+    private static IEnumerable<object[]> GetTestData()
+    {
+        var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        return new[]
+        {
+            new object[] { "~", homeDirectory },
+            new object[] { "~/foo/bar", $"{homeDirectory}/foo/bar" },
+            new object[] { "~\\foo/bar", $"{homeDirectory}\\foo/bar" },
+        };
+    }
+}

--- a/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/RootConfigurationTests.cs
@@ -41,6 +41,7 @@ public class RootConfigurationTests
             new object[] { "~/", $"{homeDirectory}/" },
             new object[] { "~\\", $"{homeDirectory}\\" },
             new object[] { "~/foo/bar", $"{homeDirectory}/foo/bar" },
+            new object[] { "~\\foo\\bar", $"{homeDirectory}\\foo\\bar" },
             new object[] { "~\\foo/bar", $"{homeDirectory}\\foo/bar" },
         };
     }


### PR DESCRIPTION
Closes https://github.com/Azure/bicep/issues/10935.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/11047)