### PR TITLE
Fix an error in `bicepconfig.schema.json`

### DIFF
--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -623,7 +623,7 @@
           "description": "The indentation size (applicable when \"indentKind\" is set to \"Space\")"
         },
         "width": {
-          "type": "string",
+          "type": "integer",
           "description": "The maximum number of characters that should appear on a line"
         },
         "insertFinalNewline": {


### PR DESCRIPTION
`formatting.width` should be an integer

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/11095)