### PR TITLE
Fix deploy bicep file vs code action bug

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentStartCommandHandler.cs
@@ -86,7 +86,8 @@ namespace Bicep.LanguageServer.Handlers
 
             var credential = new CredentialFromTokenAndTimeStamp(request.token, request.expiresOnTimestamp);
             var armClient = armClientProvider.createArmClient(credential, default, options);
-
+            
+            //starting with empty valid json (that can be parsed) for deployments with no parameters 
             string parametersFileJson = "{}";
             
             if(request.parametersFilePath is { })

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -352,7 +352,6 @@ export class DeployCommand implements Command {
       this.outputChannelManager.appendToOutputChannel(
         `No parameter file was provided`
       );
-      parametersFilePath = "";
     } else {
       context.telemetry.properties.parameterFileProvided = "true";
     }
@@ -366,12 +365,14 @@ export class DeployCommand implements Command {
       const expiresOnTimestamp = String(accessToken.expiresOnTimestamp);
       const portalUrl = subscription.environment.portalUrl;
 
-      let parametersFileName: string | null;
+      let parametersFileName: string | undefined;
       let updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
       let parametersFileUpdateOption = ParametersFileUpdateOption.None;
 
-      if (parametersFilePath.endsWith(".bicepparam")) {
-        parametersFileName = null;
+      //if no parameter file or bicepparam file is provided then we don't do the  
+      //prerequisite steps for updating the parameter file on the disk 
+      if (parametersFilePath === undefined || parametersFilePath.endsWith(".bicepparam")) {
+        parametersFileName = undefined;
         updatedDeploymentParameters = [];
       } else {
         [parametersFileName, updatedDeploymentParameters] =
@@ -428,7 +429,8 @@ export class DeployCommand implements Command {
       // open it in vscode.
       if (
         parametersFileUpdateOption !== ParametersFileUpdateOption.None &&
-        parametersFileName !== null
+        parametersFileName !== undefined &&
+        parametersFilePath !== undefined
       ) {
         if (
           parametersFileUpdateOption === ParametersFileUpdateOption.Create ||

--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -369,9 +369,9 @@ export class DeployCommand implements Command {
       let updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
       let parametersFileUpdateOption = ParametersFileUpdateOption.None;
 
-      //if no parameter file or bicepparam file is provided then we don't do the  
-      //prerequisite steps for updating the parameter file on the disk 
-      if (parametersFilePath === undefined || parametersFilePath.endsWith(".bicepparam")) {
+      //if no parameter file or bicepparam file is provided then we don't do the
+      //prerequisite steps for updating the parameter file on the disk
+      if (!parametersFilePath || parametersFilePath.endsWith(".bicepparam")) {
         parametersFileName = undefined;
         updatedDeploymentParameters = [];
       } else {
@@ -429,8 +429,8 @@ export class DeployCommand implements Command {
       // open it in vscode.
       if (
         parametersFileUpdateOption !== ParametersFileUpdateOption.None &&
-        parametersFileName !== undefined &&
-        parametersFilePath !== undefined
+        parametersFileName &&
+        parametersFilePath
       ) {
         if (
           parametersFileUpdateOption === ParametersFileUpdateOption.Create ||

--- a/src/vscode-bicep/src/commands/pasteAsBicep.ts
+++ b/src/vscode-bicep/src/commands/pasteAsBicep.ts
@@ -13,7 +13,7 @@ import {
   MessageItem,
   ConfigurationTarget,
   ProgressLocation,
-  Position
+  Position,
 } from "vscode";
 import { Command } from "./types";
 import { LanguageClient } from "vscode-languageclient/node";
@@ -21,14 +21,14 @@ import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
 import {
   callWithTelemetryAndErrorHandling,
   IActionContext,
-  parseError
+  parseError,
 } from "@microsoft/vscode-azext-utils";
 import { areEqualIgnoringWhitespace } from "../utils/areEqualIgnoringWhitespace";
 import { getTextAfterFormattingChanges } from "../utils/getTextAfterFormattingChanges";
 import { bicepConfigurationKeys, bicepLanguageId } from "../language/constants";
 import {
   BicepDecompileForPasteCommandParams,
-  BicepDecompileForPasteCommandResult
+  BicepDecompileForPasteCommandResult,
 } from "../language";
 import { OutputChannelManager } from "../utils/OutputChannelManager";
 import { getBicepConfiguration } from "../language/getBicepConfiguration";
@@ -163,7 +163,7 @@ export class PasteAsBicepCommand implements Command {
       {
         location: ProgressLocation.Notification,
         title:
-          "Decompiling clipboard text into Bicep is taking longer than expected..."
+          "Decompiling clipboard text into Bicep is taking longer than expected...",
       },
       async () => {
         const decompileParams: BicepDecompileForPasteCommandParams = {
@@ -172,12 +172,12 @@ export class PasteAsBicepCommand implements Command {
           rangeOffset,
           rangeLength,
           jsonContent,
-          queryCanPaste
+          queryCanPaste,
         };
         const decompileResult: BicepDecompileForPasteCommandResult =
           await this.client.sendRequest("workspace/executeCommand", {
             command: "decompileForPaste",
-            arguments: [decompileParams]
+            arguments: [decompileParams],
           });
 
         context.telemetry.properties.pasteType = decompileResult.pasteType;
@@ -423,10 +423,10 @@ export class PasteAsBicepCommand implements Command {
     }
 
     const dontShowAgain: MessageItem = {
-      title: "Never show again"
+      title: "Never show again",
     };
     const disable: MessageItem = {
-      title: "Disable automatic decompile on paste"
+      title: "Disable automatic decompile on paste",
     };
 
     this.disclaimerShownThisSession = true;

--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -58,7 +58,7 @@ export interface BicepDeploymentScopeResponse {
 
 export interface BicepDeploymentStartParams {
   documentPath: string;
-  parametersFilePath: string;
+  parametersFilePath: string | undefined;
   id: string;
   deploymentScope: string;
   location: string;
@@ -68,7 +68,7 @@ export interface BicepDeploymentStartParams {
   deployId: string;
   deploymentName: string;
   portalUrl: string;
-  parametersFileName: string | null;
+  parametersFileName: string | undefined;
   parametersFileUpdateOption: ParametersFileUpdateOption;
   updatedDeploymentParameters: BicepUpdatedDeploymentParameter[];
   resourceManagerEndpointUrl: string;

--- a/src/vscode-bicep/src/test/e2e/buildParams.test.ts
+++ b/src/vscode-bicep/src/test/e2e/buildParams.test.ts
@@ -23,7 +23,10 @@ describe("buildParams", (): void => {
     await executeBuildParamsCommand(textDocument.uri);
 
     const folderContainingSourceFile = path.dirname(examplePath);
-    const compiledFilePath = path.join(folderContainingSourceFile, "main.parameters.json");
+    const compiledFilePath = path.join(
+      folderContainingSourceFile,
+      "main.parameters.json"
+    );
 
     expect(fs.existsSync(compiledFilePath)).toBe(true);
 

--- a/src/vscode-bicep/src/utils/telemetry.ts
+++ b/src/vscode-bicep/src/utils/telemetry.ts
@@ -31,12 +31,16 @@ export async function activateWithTelemetryAndErrorHandling(
 }
 
 // Creates a possible telemetry event scope.  But the event is only sent if there is a cancel or an error
-export async function callWithTelemetryAndErrorHandlingOnlyOnErrors<T>(callbackId: string, callback: (context: IActionContext) => T | PromiseLike<T>): Promise<T | undefined> {
+export async function callWithTelemetryAndErrorHandlingOnlyOnErrors<T>(
+  callbackId: string,
+  callback: (context: IActionContext) => T | PromiseLike<T>
+): Promise<T | undefined> {
   return await callWithTelemetryAndErrorHandling<T | undefined>(
     callbackId,
     async (context): Promise<T | undefined> => {
       context.telemetry.suppressIfSuccessful = true;
 
       return await callback(context);
-    });
+    }
+  );
 }


### PR DESCRIPTION
When a bicep file deploy using a vscode action, an error is thrown when `None` option is picked by the user

fixes #10985

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/11099)