### PR TITLE
Added Experimental Feature Flag for Test Syntax

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/RootConfigurationAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/RootConfigurationAssertions.cs
@@ -5,6 +5,8 @@ using Bicep.Core.Configuration;
 using Bicep.Core.Parsing;
 using FluentAssertions;
 using FluentAssertions.Primitives;
+using Newtonsoft.Json.Linq;
+
 
 namespace Bicep.Core.UnitTests.Assertions
 {
@@ -24,11 +26,9 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<RootConfigurationAssertions> HaveContents(string contents, string because = "", params object[] becauseArgs)
         {
-            string actual = StringUtils.ReplaceNewlines(Subject.ToUtf8Json(), "\n");
-            string expected = StringUtils.ReplaceNewlines(contents, "\n");
-
-            actual.Should().Be(expected, because, becauseArgs);
-
+            var actual = JToken.Parse(Subject.ToUtf8Json());
+            var expected = JToken.Parse(contents);
+            actual.Should().DeepEqual(expected, because, becauseArgs);
             return new AndConstraint<RootConfigurationAssertions>(this);
         }
     }

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -102,7 +102,8 @@ namespace Bicep.Core.UnitTests.Configuration
                     "sourceMapping": false,
                     "userDefinedTypes": false,
                     "userDefinedFunctions": false,
-                    "prettyPrinting": false
+                    "prettyPrinting": false, 
+                    "testFramework": false
                   },
                   "formatting": {
                     "indentKind": "Space",
@@ -170,7 +171,8 @@ namespace Bicep.Core.UnitTests.Configuration
                     "sourceMapping": false,
                     "userDefinedTypes": false,
                     "userDefinedFunctions": false,
-                    "prettyPrinting": false
+                    "prettyPrinting": false, 
+                    "testFramework": false
                   },
                   "formatting": {
                     "indentKind": "Space",
@@ -263,7 +265,8 @@ namespace Bicep.Core.UnitTests.Configuration
                     "sourceMapping": false,
                     "userDefinedTypes": false,
                     "userDefinedFunctions": false,
-                    "prettyPrinting": false
+                    "prettyPrinting": false,
+                    "testFramework": false
                   },
                   "formatting": {
                     "indentKind": "Space",
@@ -587,7 +590,8 @@ namespace Bicep.Core.UnitTests.Configuration
                     "sourceMapping": false,
                     "userDefinedTypes": false,
                     "userDefinedFunctions": false,
-                    "prettyPrinting": false
+                    "prettyPrinting": false, 
+                    "testFramework": false
                   },
                   "formatting": {
                     "indentKind": "Space",

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -17,6 +17,7 @@ public record FeatureProviderOverrides(
     bool? UserDefinedTypesEnabled = default,
     bool? UserDefinedFunctionsEnabled = default,
     bool? PrettyPrintingEnabled = default,
+    bool? TestSyntaxEnabled = default,
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion)
 {
     public FeatureProviderOverrides(
@@ -30,6 +31,7 @@ public record FeatureProviderOverrides(
         bool? UserDefinedTypesEnabled = default,
         bool? UserDefinedFunctionsEnabled = default,
         bool? PrettyPrintingEnabled = default,
+        bool? TestSyntaxEnabled = default,
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion
     ) : this(
         FileHelper.GetCacheRootPath(testContext),
@@ -42,5 +44,6 @@ public record FeatureProviderOverrides(
         UserDefinedTypesEnabled,
         UserDefinedFunctionsEnabled,
         PrettyPrintingEnabled,
+        TestSyntaxEnabled,
         AssemblyVersion) {}
 }

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -17,7 +17,7 @@ public record FeatureProviderOverrides(
     bool? UserDefinedTypesEnabled = default,
     bool? UserDefinedFunctionsEnabled = default,
     bool? PrettyPrintingEnabled = default,
-    bool? TestSyntaxEnabled = default,
+    bool? TestFrameworkEnabled = default,
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion)
 {
     public FeatureProviderOverrides(
@@ -31,7 +31,7 @@ public record FeatureProviderOverrides(
         bool? UserDefinedTypesEnabled = default,
         bool? UserDefinedFunctionsEnabled = default,
         bool? PrettyPrintingEnabled = default,
-        bool? TestSyntaxEnabled = default,
+        bool? TestFrameworkEnabled = default,
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion
     ) : this(
         FileHelper.GetCacheRootPath(testContext),
@@ -44,6 +44,6 @@ public record FeatureProviderOverrides(
         UserDefinedTypesEnabled,
         UserDefinedFunctionsEnabled,
         PrettyPrintingEnabled,
-        TestSyntaxEnabled,
+        TestFrameworkEnabled,
         AssemblyVersion) {}
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -34,5 +34,5 @@ public class OverriddenFeatureProvider : IFeatureProvider
 
     public bool PrettyPrintingEnabled => overrides.PrettyPrintingEnabled ?? features.PrettyPrintingEnabled;
     
-    public bool TestSyntaxEnabled => overrides.TestSyntaxEnabled ?? features.TestSyntaxEnabled;
+    public bool TestFrameworkEnabled => overrides.TestFrameworkEnabled ?? features.TestFrameworkEnabled;
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -33,4 +33,6 @@ public class OverriddenFeatureProvider : IFeatureProvider
     public bool UserDefinedFunctionsEnabled => overrides.UserDefinedFunctionsEnabled ?? features.UserDefinedFunctionsEnabled;
 
     public bool PrettyPrintingEnabled => overrides.PrettyPrintingEnabled ?? features.PrettyPrintingEnabled;
+    
+    public bool TestSyntaxEnabled => overrides.TestSyntaxEnabled ?? features.TestSyntaxEnabled;
 }

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -14,7 +14,8 @@ public record ExperimentalFeaturesEnabled(
     bool SourceMapping,
     bool UserDefinedTypes,
     bool UserDefinedFunctions,
-    bool PrettyPrinting)
+    bool PrettyPrinting,
+    bool TestSyntax)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -15,7 +15,7 @@ public record ExperimentalFeaturesEnabled(
     bool UserDefinedTypes,
     bool UserDefinedFunctions,
     bool PrettyPrinting,
-    bool TestSyntax)
+    bool TestFramework)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.Features
 
         public bool PrettyPrintingEnabled => this.configuration.ExperimentalFeaturesEnabled.PrettyPrinting;
         
-        public bool TestSyntaxEnabled => this.configuration.ExperimentalFeaturesEnabled.TestSyntax;
+        public bool TestFrameworkEnabled => this.configuration.ExperimentalFeaturesEnabled.TestFramework;
 
         public static bool TracingEnabled => ReadBooleanEnvVar("BICEP_TRACING_ENABLED", defaultValue: false);
 

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -33,6 +33,8 @@ namespace Bicep.Core.Features
         public bool UserDefinedFunctionsEnabled => configuration.ExperimentalFeaturesEnabled.UserDefinedFunctions;
 
         public bool PrettyPrintingEnabled => this.configuration.ExperimentalFeaturesEnabled.PrettyPrinting;
+        
+        public bool TestSyntaxEnabled => this.configuration.ExperimentalFeaturesEnabled.TestSyntax;
 
         public static bool TracingEnabled => ReadBooleanEnvVar("BICEP_TRACING_ENABLED", defaultValue: false);
 

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -23,6 +23,6 @@ namespace Bicep.Core.Features
 
         bool PrettyPrintingEnabled { get; }
 
-        bool TestSyntaxEnabled { get; }
+        bool TestFrameworkEnabled { get; }
     }
 }

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -22,5 +22,7 @@ namespace Bicep.Core.Features
         bool UserDefinedFunctionsEnabled { get; }
 
         bool PrettyPrintingEnabled { get; }
+
+        bool TestSyntaxEnabled { get; }
     }
 }

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -601,6 +601,9 @@
         },
         "prettyPrinting": {
           "type": "boolean"
+        },
+        "TestFramework": {
+          "type": "boolean"
         }
       }
     },

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -602,7 +602,7 @@
         "prettyPrinting": {
           "type": "boolean"
         },
-        "TestFramework": {
+        "testFramework": {
           "type": "boolean"
         }
       }


### PR DESCRIPTION
# Contributing a Pull Request
## Contributing a feature

Included Experimental Feature Flag for the new Unit Test Framework
This feature may be configured through the bicep configuration file under the flag "TestSyntax"



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/11136)