### PR TITLE
Add test framework syntax under feature flag TestFrameworkEnabled

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -11,6 +11,7 @@ statement ->
   variableDecl |
   resourceDecl |
   moduleDecl |
+  testDecl |
   outputDecl |
   functionDecl |
   NL
@@ -37,6 +38,8 @@ variableDecl -> decorator* "variable" IDENTIFIER(name) "=" expression NL
 resourceDecl -> decorator* "resource" IDENTIFIER(name) interpString(type) "existing"? "=" (ifCondition | object | forExpression) NL
 
 moduleDecl -> decorator* "module" IDENTIFIER(name) interpString(type) "=" (ifCondition | object | forExpression) NL
+
+testDecl -> "test" IDENTIFIER(name) interpString(type) "=" (object) NL
 
 outputDecl ->
   decorator* "output" IDENTIFIER(name) IDENTIFIER(type) "=" expression NL

--- a/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
@@ -35,35 +35,35 @@ namespace Bicep.Core.IntegrationTests
 test test1 'test1.bicep' = {}
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
             });
             result = CompilationHelper.Compile(@"
 test test1 'test1.bicep' =
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
-                ("BCP345", DiagnosticLevel.Error, "Expected the \"{\" character at this location."),
+                ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP018", DiagnosticLevel.Error, "Expected the \"{\" character at this location."),
             });
             result = CompilationHelper.Compile(@"
 test test1 'test1.bicep'
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
                 ("BCP018", DiagnosticLevel.Error, "Expected the \"=\" character at this location."),
             });
             result = CompilationHelper.Compile(@"
 test test1
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
-                ("BCP0348", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
+                ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
             });
             result = CompilationHelper.Compile(@"
 test
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
-                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test identifier at this location."),
+                ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP0346", DiagnosticLevel.Error,  "Expected a test identifier at this location."),
             });
         }
 
@@ -74,14 +74,14 @@ test
 test
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test identifier at this location."),
+                ("BCP0346", DiagnosticLevel.Error,  "Expected a test identifier at this location."),
             });
 
             result = CompilationHelper.Compile(ServicesWithTestFramework, @"
 test test1
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP0348", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
+                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
             });
 
             result = CompilationHelper.Compile(ServicesWithTestFramework, @"

--- a/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.Features;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class TestFrameworkTests
+    {
+        private ServiceBuilder ServicesWithTestFramework => new ServiceBuilder()
+            .WithFeatureOverrides(new(TestContext, TestFrameworkEnabled: true));
+
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        [TestMethod]
+        public void TestFramework_is_disabled_unless_feature_is_enabled()
+        {
+            var result = CompilationHelper.Compile(@"
+test test1 'test1.bicep' = {}
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+            });
+            result = CompilationHelper.Compile(@"
+test test1 'test1.bicep' =
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP345", DiagnosticLevel.Error, "Expected the \"{\" character at this location."),
+            });
+            result = CompilationHelper.Compile(@"
+test test1 'test1.bicep'
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP018", DiagnosticLevel.Error, "Expected the \"=\" character at this location."),
+            });
+            result = CompilationHelper.Compile(@"
+test test1
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP0348", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
+            });
+            result = CompilationHelper.Compile(@"
+test
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP349", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
+                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test identifier at this location."),
+            });
+        }
+
+        [TestMethod]
+        public void TestFramework_statement_parse_diagnostics_are_guiding()
+        {
+            var result = CompilationHelper.Compile(ServicesWithTestFramework, @"
+test
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test identifier at this location."),
+            });
+
+            result = CompilationHelper.Compile(ServicesWithTestFramework, @"
+test test1
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP0348", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
+            });
+
+            result = CompilationHelper.Compile(ServicesWithTestFramework, @"
+test test1 ''
+");
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP018", DiagnosticLevel.Error, "Expected the \"=\" character at this location."),
+            });
+               
+        }
+        
+    }
+}

--- a/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
@@ -56,7 +56,7 @@ test test1
 ");
             result.Should().HaveDiagnostics(new[] {
                 ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
-                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
+                ("BCP0347", DiagnosticLevel.Error,  "Expected a test path string at this location."),
             });
             result = CompilationHelper.Compile(@"
 test
@@ -81,7 +81,7 @@ test
 test test1
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP0347", DiagnosticLevel.Error,  "Expected a Test Path String at this location."),
+                ("BCP0347", DiagnosticLevel.Error,  "Expected a test path string at this location."),
             });
 
             result = CompilationHelper.Compile(ServicesWithTestFramework, @"

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1934,7 +1934,7 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic TestDeclarationMustReferenceBicepTest() => new(
                 TextSpan,
                 "BCP345",
-                "A Test declaration can only reference a Bicep File, an ARM template, a registry reference or a template spec reference.");
+                "A Test declaration can only reference a Bicep File");
 
             public ErrorDiagnostic ExpectedTestIdentifier() => new(
                 TextSpan,

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1949,6 +1949,10 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP0348",
                 "Expected a Test Path String at this location.");
+            public ErrorDiagnostic TestDeclarationStatementsUnsupported() => new(
+                TextSpan,
+                "BCP349",
+                $@"Using a test declaration statement requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.TestFramework)}"".");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1934,7 +1934,7 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic TestDeclarationMustReferenceBicepTest() => new(
                 TextSpan,
                 "BCP345",
-                "A Test declaration can only reference a Bicep File");
+                "A test declaration can only reference a Bicep File");
 
             public ErrorDiagnostic ExpectedTestIdentifier() => new(
                 TextSpan,
@@ -1944,7 +1944,7 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic ExpectedTestPathString() => new(
                 TextSpan,
                 "BCP0347",
-                "Expected a Test Path String at this location.");
+                "Expected a test path string at this location.");
             public ErrorDiagnostic TestDeclarationStatementsUnsupported() => new(
                 TextSpan,
                 "BCP348",

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1931,27 +1931,23 @@ namespace Bicep.Core.Diagnostics
                 "BCP343",
                 $@"Using a func declaration statement requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.UserDefinedFunctions)}"".");
         
-            public ErrorDiagnostic ExpectBodyStart() => new(
-                TextSpan,
-                "BCP345",
-                "Expected the \"{\" character at this location.");
             public ErrorDiagnostic TestDeclarationMustReferenceBicepTest() => new(
                 TextSpan,
-                "BCP346",
+                "BCP345",
                 "A Test declaration can only reference a Bicep File, an ARM template, a registry reference or a template spec reference.");
 
             public ErrorDiagnostic ExpectedTestIdentifier() => new(
                 TextSpan,
-                "BCP0347",
+                "BCP0346",
                 "Expected a test identifier at this location.");
 
             public ErrorDiagnostic ExpectedTestPathString() => new(
                 TextSpan,
-                "BCP0348",
+                "BCP0347",
                 "Expected a Test Path String at this location.");
             public ErrorDiagnostic TestDeclarationStatementsUnsupported() => new(
                 TextSpan,
-                "BCP349",
+                "BCP348",
                 $@"Using a test declaration statement requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.TestFramework)}"".");
         }
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1930,6 +1930,25 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP343",
                 $@"Using a func declaration statement requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.UserDefinedFunctions)}"".");
+        
+            public ErrorDiagnostic ExpectBodyStart() => new(
+                TextSpan,
+                "BCP345",
+                "Expected the \"{\" character at this location.");
+            public ErrorDiagnostic TestDeclarationMustReferenceBicepTest() => new(
+                TextSpan,
+                "BCP346",
+                "A Test declaration can only reference a Bicep File, an ARM template, a registry reference or a template spec reference.");
+
+            public ErrorDiagnostic ExpectedTestIdentifier() => new(
+                TextSpan,
+                "BCP0347",
+                "Expected a Test identifier at this location.");
+
+            public ErrorDiagnostic ExpectedTestPathString() => new(
+                TextSpan,
+                "BCP0348",
+                "Expected a Test Path String at this location.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1943,7 +1943,7 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic ExpectedTestIdentifier() => new(
                 TextSpan,
                 "BCP0347",
-                "Expected a Test identifier at this location.");
+                "Expected a test identifier at this location.");
 
             public ErrorDiagnostic ExpectedTestPathString() => new(
                 TextSpan,

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -49,6 +49,7 @@ namespace Bicep.Core.Emit
             BlockSafeDereferenceOfModuleOrResourceCollectionMember(model, diagnostics);
             BlockCyclicAggregateTypeReferences(model, diagnostics);
             BlockUserDefinedFunctionsWithoutExperimentalFeaure(model, diagnostics);
+            BlockTestFrameworkWithoutExperimentalFeaure(model, diagnostics);
             BlockUserDefinedTypesWithUserDefinedFunctions(model, diagnostics);
             var paramAssignments = CalculateParameterAssignments(model, diagnostics);
 
@@ -529,6 +530,17 @@ namespace Bicep.Core.Emit
                 if (!model.Features.UserDefinedFunctionsEnabled)
                 {
                     diagnostics.Write(function.DeclaringFunction, x => x.FuncDeclarationStatementsUnsupported());
+                }
+            }
+        }
+
+        private static void BlockTestFrameworkWithoutExperimentalFeaure(SemanticModel model, IDiagnosticWriter diagnostics)
+        {
+            foreach (var test in model.Root.TestDeclarations)
+            {
+                if (!model.Features.TestFrameworkEnabled)
+                {
+                    diagnostics.Write(test.DeclaringTest, x => x.TestDeclarationStatementsUnsupported());
                 }
             }
         }

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -56,6 +56,7 @@ namespace Bicep.Core
         public const string VariableKeyword = "var";
         public const string ResourceKeyword = "resource";
         public const string ModuleKeyword = "module";
+        public const string TestKeyword = "test";
         public const string FunctionKeyword = "func";
         public const string ExistingKeyword = "existing";
         public const string ImportKeyword = "import";

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -259,9 +259,6 @@ namespace Bicep.Core.Parsing
                 TokenType.Assignment, TokenType.NewLine);
 
             var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(path), TokenType.LeftBrace, TokenType.NewLine);
-            var newlines = reader.Peek(skipNewlines: true).IsKeyword(LanguageConstants.IfKeyword)
-                ? this.NewLines().ToImmutableArray()
-                : ImmutableArray<Token>.Empty;
 
             var value = this.WithRecovery(() =>
                 {

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -266,7 +266,7 @@ namespace Bicep.Core.Parsing
                     return current.Type switch
                     {
                         TokenType.LeftBrace => this.Object(ExpressionFlags.AllowComplexLiterals),
-                        _ => throw new ExpectedTokenException(current, b => b.ExpectBodyStart())
+                        _ => throw new ExpectedTokenException(current, b => b.ExpectedCharacter("{"))
                     };
                 },
                 GetSuppressionFlag(assignment),

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -275,7 +275,7 @@ namespace Bicep.Core.Parsing
                 GetSuppressionFlag(assignment),
                 TokenType.NewLine);
 
-            return new TestDeclarationSyntax(leadingNodes, keyword, name, path, assignment, newlines, value);
+            return new TestDeclarationSyntax(leadingNodes, keyword, name, path, assignment, value);
         }
         private ImportDeclarationSyntax ImportDeclaration(IEnumerable<SyntaxBase> leadingNodes)
         {

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.SyntaxVisitor.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.SyntaxVisitor.cs
@@ -77,6 +77,8 @@ namespace Bicep.Core.PrettyPrintV2
 
         public void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax) => this.Apply(syntax, this.LayoutModuleDeclarationSyntax);
 
+        public void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax) => this.Apply(syntax, this.LayoutTestDeclarationSyntax);
+
         public void VisitNonNullAssertionSyntax(NonNullAssertionSyntax syntax) => this.Apply(syntax, this.LayoutNonNullAssertionSyntax);
 
         public void VisitNullableTypeSyntax(NullableTypeSyntax syntax) => this.Apply(syntax, this.LayoutNullableTypeSyntax);

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
@@ -179,15 +179,15 @@ namespace Bicep.Core.PrettyPrintV2
                 syntax.Newlines,
                 syntax.Value);
 
-        private IEnumerable<Document> LayoutTestDeclarationSyntax(TestDeclarationSyntax syntax) =>
-            this.LayoutResourceOrModuleDeclarationSyntax(
-                syntax.LeadingNodes,
-                syntax.Keyword,
-                syntax.Name,
-                syntax.Path,
-                syntax.Assignment,
-                syntax.Newlines,
-                syntax.Value);
+        private IEnumerable<Document> LayoutTestDeclarationSyntax(TestDeclarationSyntax syntax){
+            return this.LayoutLeadingNodes(syntax.LeadingNodes)
+                .Concat(this.Spread(
+                    syntax.Keyword,
+                    syntax.Name,
+                    syntax.Path,
+                    syntax.Assignment,
+                    syntax.Value));
+        }
 
         private IEnumerable<Document> LayoutNonNullAssertionSyntax(NonNullAssertionSyntax syntax) =>
             this.Glue(syntax.BaseExpression, syntax.AssertionOperator);

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
@@ -179,6 +179,16 @@ namespace Bicep.Core.PrettyPrintV2
                 syntax.Newlines,
                 syntax.Value);
 
+        private IEnumerable<Document> LayoutTestDeclarationSyntax(TestDeclarationSyntax syntax) =>
+            this.LayoutResourceOrModuleDeclarationSyntax(
+                syntax.LeadingNodes,
+                syntax.Keyword,
+                syntax.Name,
+                syntax.Path,
+                syntax.Assignment,
+                syntax.Newlines,
+                syntax.Value);
+
         private IEnumerable<Document> LayoutNonNullAssertionSyntax(NonNullAssertionSyntax syntax) =>
             this.Glue(syntax.BaseExpression, syntax.AssertionOperator);
 

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -132,13 +132,9 @@ namespace Bicep.Core.Semantics
         public override void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax)
         {
             base.VisitTestDeclarationSyntax(syntax);
-            // TypeSymbol declaredType;
-            // declaredType = ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).ImportsAreDisabled());
-    
-            var symbol = new TestSymbol(this.context, syntax.Name.IdentifierName, syntax);
-            DeclareSymbol(symbol);
 
-            
+            var symbol = new TestSymbol(this.context, syntax.Name.IdentifierName, syntax);
+            DeclareSymbol(symbol);            
         }
 
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -129,6 +129,18 @@ namespace Bicep.Core.Semantics
             DeclareSymbol(symbol);
         }
 
+        public override void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax)
+        {
+            base.VisitTestDeclarationSyntax(syntax);
+            // TypeSymbol declaredType;
+            // declaredType = ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).ImportsAreDisabled());
+    
+            var symbol = new TestSymbol(this.context, syntax.Name.IdentifierName, syntax);
+            DeclareSymbol(symbol);
+
+            
+        }
+
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {
             base.VisitOutputDeclarationSyntax(syntax);

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -47,7 +47,7 @@ namespace Bicep.Core.Semantics
             this.ModuleDeclarations = fileScope.Declarations.OfType<ModuleSymbol>().ToImmutableArray();
             this.OutputDeclarations = fileScope.Declarations.OfType<OutputSymbol>().ToImmutableArray();
             this.ParameterAssignments = fileScope.Declarations.OfType<ParameterAssignmentSymbol>().ToImmutableArray();
-
+            this.TestDeclarations = fileScope.Declarations.OfType<TestSymbol>().ToImmutableArray();
             this.declarationsByName = this.Declarations.ToLookup(decl => decl.Name, LanguageConstants.IdentifierComparer);
 
             this.usingDeclarationLazy = new Lazy<UsingDeclarationSyntax?>(() => this.Syntax.Children.OfType<UsingDeclarationSyntax>().FirstOrDefault());
@@ -102,6 +102,8 @@ namespace Bicep.Core.Semantics
         public ImmutableArray<ModuleSymbol> ModuleDeclarations { get; }
 
         public ImmutableArray<OutputSymbol> OutputDeclarations { get; }
+
+        public ImmutableArray<TestSymbol> TestDeclarations { get; }
 
         public ImmutableArray<ParameterAssignmentSymbol> ParameterAssignments { get; }
 

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -151,6 +151,17 @@ namespace Bicep.Core.Semantics
             this.Visit(syntax.Value);
             allowedFlags = FunctionFlags.Default;
         }
+        public override void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax)
+        {
+            this.VisitNodes(syntax.LeadingNodes);
+            this.Visit(syntax.Keyword);
+            this.Visit(syntax.Name);
+            this.Visit(syntax.Path);
+            this.Visit(syntax.Assignment);
+            allowedFlags = FunctionFlags.RequiresInlining;
+            this.Visit(syntax.Value);
+            allowedFlags = FunctionFlags.Default;
+        }
 
         public override void VisitIfConditionSyntax(IfConditionSyntax syntax)
         {

--- a/src/Bicep.Core/Semantics/SymbolKind.cs
+++ b/src/Bicep.Core/Semantics/SymbolKind.cs
@@ -11,6 +11,7 @@ namespace Bicep.Core.Semantics
         Variable,
         Resource,
         Module,
+        Test,
         Output,
         Namespace,
         ImportedNamespace,

--- a/src/Bicep.Core/Semantics/SymbolVisitor.cs
+++ b/src/Bicep.Core/Semantics/SymbolVisitor.cs
@@ -56,6 +56,11 @@ namespace Bicep.Core.Semantics
             VisitDescendants(symbol);
         }
 
+        public virtual void VisitTestSymbol(TestSymbol symbol)
+        {
+            VisitDescendants(symbol);
+        }
+        
         public virtual void VisitOutputSymbol(OutputSymbol symbol)
         {
             VisitDescendants(symbol);

--- a/src/Bicep.Core/Semantics/TestSymbol.cs
+++ b/src/Bicep.Core/Semantics/TestSymbol.cs
@@ -32,7 +32,7 @@ namespace Bicep.Core.Semantics
                 return false;
             }
 
-            // SourceFileGroupingBuilder should have already visited every module declaration and either recorded a failure or mapped it to a syntax tree.
+            // SourceFileGroupingBuilder should have already visited every test declaration and either recorded a failure or mapped it to a syntax tree.
             // So it is safe to assume that this lookup will succeed without throwing an exception.
             var sourceFile = Context.Compilation.SourceFileGrouping.TryGetSourceFile(this.DeclaringTest) ?? throw new InvalidOperationException($"Failed to find source file for Test");
 
@@ -59,7 +59,7 @@ namespace Bicep.Core.Semantics
             }
         }
 
-        public bool IsCollection => this.Type is ArrayType;
+        // public bool IsCollection => this.Type is ArrayType;
 
         // public TestType? TryGetModuleType() => TestType.TryUnwrap(this.Type);
 

--- a/src/Bicep.Core/Semantics/TestSymbol.cs
+++ b/src/Bicep.Core/Semantics/TestSymbol.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.Workspaces;
+
+namespace Bicep.Core.Semantics
+{
+    public class TestSymbol : DeclaredSymbol
+    {
+        public TestSymbol(ISymbolContext context, string name, TestDeclarationSyntax declaringSyntax)
+            : base(context, name, declaringSyntax, declaringSyntax.Name)
+        {
+        }
+
+        public TestDeclarationSyntax DeclaringTest => (TestDeclarationSyntax)this.DeclaringSyntax;
+
+        public override void Accept(SymbolVisitor visitor) => visitor.VisitTestSymbol(this);
+
+        public override SymbolKind Kind => SymbolKind.Test;
+
+        public bool TryGetSemanticModel([NotNullWhen(true)] out ISemanticModel? semanticModel, [NotNullWhen(false)] out ErrorDiagnostic? failureDiagnostic)
+        {
+            if (Context.Compilation.SourceFileGrouping.TryGetErrorDiagnostic(this.DeclaringTest) is {} errorBuilder)
+            {
+                semanticModel = null;
+                failureDiagnostic = errorBuilder(DiagnosticBuilder.ForPosition(DeclaringTest.Path));
+                return false;
+            }
+
+            // SourceFileGroupingBuilder should have already visited every module declaration and either recorded a failure or mapped it to a syntax tree.
+            // So it is safe to assume that this lookup will succeed without throwing an exception.
+            var sourceFile = Context.Compilation.SourceFileGrouping.TryGetSourceFile(this.DeclaringTest) ?? throw new InvalidOperationException($"Failed to find source file for Test");
+
+            // when we inevitably add a third language ID,
+            // the inclusion list style below will prevent the new language ID from being
+            // automatically allowed to be referenced via module declarations
+            if (sourceFile is not BicepFile and not ArmTemplateFile and not TemplateSpecFile)
+            {
+                semanticModel = null;
+                failureDiagnostic = DiagnosticBuilder.ForPosition(DeclaringTest.Path).TestDeclarationMustReferenceBicepTest();
+                return false;
+            }
+
+            failureDiagnostic = null;
+            semanticModel = Context.Compilation.GetSemanticModel(sourceFile);
+            return true;
+        }
+
+        public override IEnumerable<Symbol> Descendants
+        {
+            get
+            {
+                yield return this.Type;
+            }
+        }
+
+        public bool IsCollection => this.Type is ArrayType;
+
+        // public TestType? TryGetModuleType() => TestType.TryUnwrap(this.Type);
+
+        // public ObjectType? TryGetBodyObjectType() => this.TryGetModuleType()?.Body.Type as ObjectType;
+    }
+}

--- a/src/Bicep.Core/Semantics/TestSymbol.cs
+++ b/src/Bicep.Core/Semantics/TestSymbol.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.Semantics
             // when we inevitably add a third language ID,
             // the inclusion list style below will prevent the new language ID from being
             // automatically allowed to be referenced via module declarations
-            if (sourceFile is not BicepFile and not ArmTemplateFile and not TemplateSpecFile)
+            if (sourceFile is not BicepFile)
             {
                 semanticModel = null;
                 failureDiagnostic = DiagnosticBuilder.ForPosition(DeclaringTest.Path).TestDeclarationMustReferenceBicepTest();

--- a/src/Bicep.Core/Semantics/TestSymbol.cs
+++ b/src/Bicep.Core/Semantics/TestSymbol.cs
@@ -59,10 +59,5 @@ namespace Bicep.Core.Semantics
             }
         }
 
-        // public bool IsCollection => this.Type is ArrayType;
-
-        // public TestType? TryGetModuleType() => TestType.TryUnwrap(this.Type);
-
-        // public ObjectType? TryGetBodyObjectType() => this.TryGetModuleType()?.Body.Type as ObjectType;
     }
 }

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -99,6 +99,13 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Path);
             this.Visit(syntax.Value);
         }
+        public override void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax)
+        {
+            this.VisitNodes(syntax.LeadingNodes);
+            this.Visit(syntax.Name);
+            this.Visit(syntax.Path);
+            this.Visit(syntax.Value);
+        }
 
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {

--- a/src/Bicep.Core/Syntax/CstVisitor.cs
+++ b/src/Bicep.Core/Syntax/CstVisitor.cs
@@ -112,7 +112,6 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Name);
             this.Visit(syntax.Path);
             this.Visit(syntax.Assignment);
-            this.VisitNodes(syntax.Newlines);
             this.Visit(syntax.Value);
         }
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)

--- a/src/Bicep.Core/Syntax/CstVisitor.cs
+++ b/src/Bicep.Core/Syntax/CstVisitor.cs
@@ -105,7 +105,16 @@ namespace Bicep.Core.Syntax
             this.VisitNodes(syntax.Newlines);
             this.Visit(syntax.Value);
         }
-
+        public override void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax)
+        {
+            this.VisitNodes(syntax.LeadingNodes);
+            this.Visit(syntax.Keyword);
+            this.Visit(syntax.Name);
+            this.Visit(syntax.Path);
+            this.Visit(syntax.Assignment);
+            this.VisitNodes(syntax.Newlines);
+            this.Visit(syntax.Value);
+        }
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {
             this.VisitNodes(syntax.LeadingNodes);

--- a/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
@@ -28,6 +28,8 @@ namespace Bicep.Core.Syntax
 
         void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax);
 
+        void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax);
+
         void VisitNullableTypeSyntax(NullableTypeSyntax syntax);
 
         void VisitNullLiteralSyntax(NullLiteralSyntax syntax);

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -290,7 +290,6 @@ namespace Bicep.Core.Syntax
             hasChanges |= TryRewriteStrict(syntax.Name, out var name);
             hasChanges |= TryRewrite(syntax.Path, out var path);
             hasChanges |= TryRewrite(syntax.Assignment, out var assignment);
-            hasChanges |= TryRewrite(syntax.Newlines, out var newlines);
             hasChanges |= TryRewrite(syntax.Value, out var value);
 
             if (!hasChanges)
@@ -298,7 +297,7 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new TestDeclarationSyntax(leadingNodes, keyword, name, path, assignment, newlines.Cast<Token>().ToImmutableArray(), value);
+            return new TestDeclarationSyntax(leadingNodes, keyword, name, path, assignment, value);
         }
         void ISyntaxVisitor.VisitTestDeclarationSyntax(TestDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceTestDeclarationSyntax);
         

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -283,6 +283,25 @@ namespace Bicep.Core.Syntax
         }
         void ISyntaxVisitor.VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceModuleDeclarationSyntax);
 
+        protected virtual SyntaxBase ReplaceTestDeclarationSyntax(TestDeclarationSyntax syntax)
+        {
+            var hasChanges = TryRewrite(syntax.LeadingNodes, out var leadingNodes);
+            hasChanges |= TryRewriteStrict(syntax.Keyword, out var keyword);
+            hasChanges |= TryRewriteStrict(syntax.Name, out var name);
+            hasChanges |= TryRewrite(syntax.Path, out var path);
+            hasChanges |= TryRewrite(syntax.Assignment, out var assignment);
+            hasChanges |= TryRewrite(syntax.Newlines, out var newlines);
+            hasChanges |= TryRewrite(syntax.Value, out var value);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new TestDeclarationSyntax(leadingNodes, keyword, name, path, assignment, newlines.Cast<Token>().ToImmutableArray(), value);
+        }
+        void ISyntaxVisitor.VisitTestDeclarationSyntax(TestDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceTestDeclarationSyntax);
+        
         protected virtual SyntaxBase ReplaceOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {
             var hasChanges = TryRewrite(syntax.LeadingNodes, out var leadingNodes);

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -57,6 +57,8 @@ namespace Bicep.Core.Syntax
 
         public abstract void VisitModuleDeclarationSyntax(ModuleDeclarationSyntax syntax);
 
+        public abstract void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax);
+
         public abstract void VisitNonNullAssertionSyntax(NonNullAssertionSyntax syntax);
 
         public abstract void VisitNullableTypeSyntax(NullableTypeSyntax syntax);

--- a/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
@@ -20,7 +20,7 @@ namespace Bicep.Core.Syntax
             AssertTokenType(keyword, nameof(keyword), TokenType.Identifier);
             AssertSyntaxType(assignment, nameof(assignment), typeof(Token), typeof(SkippedTriviaSyntax));
             AssertTokenType(assignment as Token, nameof(assignment), TokenType.Assignment);
-            AssertSyntaxType(value, nameof(value), typeof(SkippedTriviaSyntax), typeof(ObjectSyntax), typeof(IfConditionSyntax), typeof(ForSyntax));
+            AssertSyntaxType(value, nameof(value), typeof(SkippedTriviaSyntax), typeof(ObjectSyntax));
 
             this.Keyword = keyword;
             this.Name = name;

--- a/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
@@ -15,7 +15,6 @@ namespace Bicep.Core.Syntax
             : base(leadingNodes)
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.TestKeyword);
-            AssertSyntaxType(name, nameof(name), typeof(IdentifierSyntax));
             AssertSyntaxType(path, nameof(path), typeof(StringSyntax), typeof(SkippedTriviaSyntax));
             AssertTokenType(keyword, nameof(keyword), TokenType.Identifier);
             AssertSyntaxType(assignment, nameof(assignment), typeof(Token), typeof(SkippedTriviaSyntax));

--- a/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.Syntax
 {
     public class TestDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
-        public TestDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase path, SyntaxBase assignment, ImmutableArray<Token> newlines, SyntaxBase value)
+        public TestDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase path, SyntaxBase assignment, SyntaxBase value)
             : base(leadingNodes)
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.TestKeyword);
@@ -26,7 +26,6 @@ namespace Bicep.Core.Syntax
             this.Name = name;
             this.Path = path;
             this.Assignment = assignment;
-            this.Newlines = newlines;
             this.Value = value;
         }
 
@@ -37,8 +36,6 @@ namespace Bicep.Core.Syntax
         public SyntaxBase Path { get; }
 
         public SyntaxBase Assignment { get; }
-
-        public ImmutableArray<Token> Newlines { get; }
 
         public SyntaxBase Value { get; }
 

--- a/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Navigation;
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class TestDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
+    {
+        public TestDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase path, SyntaxBase assignment, ImmutableArray<Token> newlines, SyntaxBase value)
+            : base(leadingNodes)
+        {
+            AssertKeyword(keyword, nameof(keyword), LanguageConstants.TestKeyword);
+            AssertSyntaxType(name, nameof(name), typeof(IdentifierSyntax));
+            AssertSyntaxType(path, nameof(path), typeof(StringSyntax), typeof(SkippedTriviaSyntax));
+            AssertTokenType(keyword, nameof(keyword), TokenType.Identifier);
+            AssertSyntaxType(assignment, nameof(assignment), typeof(Token), typeof(SkippedTriviaSyntax));
+            AssertTokenType(assignment as Token, nameof(assignment), TokenType.Assignment);
+            AssertSyntaxType(value, nameof(value), typeof(SkippedTriviaSyntax), typeof(ObjectSyntax), typeof(IfConditionSyntax), typeof(ForSyntax));
+
+            this.Keyword = keyword;
+            this.Name = name;
+            this.Path = path;
+            this.Assignment = assignment;
+            this.Newlines = newlines;
+            this.Value = value;
+        }
+
+        public Token Keyword { get; }
+
+        public IdentifierSyntax Name { get; }
+
+        public SyntaxBase Path { get; }
+
+        public SyntaxBase Assignment { get; }
+
+        public ImmutableArray<Token> Newlines { get; }
+
+        public SyntaxBase Value { get; }
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitTestDeclarationSyntax(this);
+
+        public override TextSpan Span => TextSpan.Between(this.LeadingNodes.FirstOrDefault() ?? this.Keyword, this.Value);
+
+        public StringSyntax? TryGetPath() => Path as StringSyntax;
+
+        public ObjectSyntax? TryGetBody() =>
+            this.Value switch
+            {
+                ObjectSyntax @object => @object,
+                SkippedTriviaSyntax => null,
+
+                // blocked by assert in the constructor
+                _ => throw new NotImplementedException($"Unexpected type of test value '{this.Value.GetType().Name}'.")
+            };
+
+        public ObjectSyntax GetBody() =>
+            this.TryGetBody() ?? throw new InvalidOperationException($"A valid test body is not available on this test due to errors. Use {nameof(TryGetBody)}() instead.");
+
+    }
+}

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -393,6 +393,18 @@ namespace Bicep.LanguageServer.Completions
                 // we are in a token that is inside a StringSyntax node, which is inside a module declaration
                 return BicepCompletionContextKind.ModulePath;
             }
+            
+            if (SyntaxMatcher.IsTailMatch<TestDeclarationSyntax>(matchingNodes, test => CheckTypeIsExpected(test.Name, test.Path)) ||
+                SyntaxMatcher.IsTailMatch<TestDeclarationSyntax, StringSyntax, Token>(matchingNodes, (_, _, token) => token.Type == TokenType.StringComplete) ||
+                SyntaxMatcher.IsTailMatch<TestDeclarationSyntax, SkippedTriviaSyntax, Token>(matchingNodes, (test, skipped, _) => test.Path == skipped))
+            {
+                // the most specific matching node is a test declaration
+                // the declaration syntax is "test <identifier> '<path>' ..."
+                // the cursor position is on the type if we have an identifier (non-zero length span) and the offset matches the path position
+                // OR
+                // we are in a token that is inside a StringSyntax node, which is inside a module declaration
+                return BicepCompletionContextKind.TestPath;
+            }
 
             return BicepCompletionContextKind.None;
         }

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -420,7 +420,7 @@ namespace Bicep.LanguageServer.Completions
             SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax, SkippedTriviaSyntax, Token>(matchingNodes, (resource, skipped, token) => resource.Assignment == skipped && token.Type == TokenType.Identifier) ||
             // resource foo '...' |=
             SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax, Token>(matchingNodes, (resource, token) => resource.Assignment == token && token.Type == TokenType.Assignment && offset == token.Span.Position);
-
+        
         private static bool IsTargetScopeContext(List<SyntaxBase> matchingNodes, int offset) =>
             SyntaxMatcher.IsTailMatch<TargetScopeSyntax>(matchingNodes, targetScope =>
                 !targetScope.Assignment.Span.ContainsInclusive(offset) &&

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -215,5 +215,11 @@ namespace Bicep.LanguageServer.Completions
         /// Cursor is on a typed lambda output type.
         /// </summary>
         TypedLambdaOutputType = 1UL << 39,
+
+        /// <summary>
+        /// The current location needs a module path (local or remote)
+        /// </summary>
+        TestPath = 1UL << 40,
+        
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -219,7 +219,6 @@ namespace Bicep.LanguageServer.Completions
         /// <summary>
         /// The current location needs a module path (local or remote)
         /// </summary>
-        TestPath = 1UL << 40,
-        
+        TestPath = 1UL << 40,        
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -937,7 +937,7 @@ namespace Bicep.LanguageServer.Completions
             // The value type of resource/module.dependsOn items can only be a resource or module symbol so prioritize them higher than anything else.
             // Expressions can also be accepted in this context so other completion items will still be available, just lower in the list.
             if (context.Kind.HasFlag(BicepCompletionContextKind.ExpectsResourceSymbolicReference)
-                && symbol is ResourceSymbol or ModuleSymbol or TestSymbol)
+                && symbol is ResourceSymbol or ModuleSymbol)
             {
                 // parent resource symbols of the current resource should not be prioritized but are still provided for use in expressions
                 var enclosingResourceMetadata = model.DeclaredResources.FirstOrDefault((drm) => drm.Symbol == enclosingDeclarationSymbol);

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -731,10 +731,9 @@ namespace Bicep.LanguageServer.Completions
 
                 // Prioritize .bicep files higher than other files.
                 var bicepFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsBicepFile, CompletionPriority.High);
-                var armTemplateFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsArmTemplateFileLike, CompletionPriority.Medium);
                 var dirItems = CreateDirectoryCompletionItems(replacementRange, fileCompletionInfo);
 
-                return bicepFileItems.Concat(armTemplateFileItems).Concat(dirItems);
+                return bicepFileItems;
             }
             catch (DirectoryNotFoundException)
             {
@@ -743,36 +742,7 @@ namespace Bicep.LanguageServer.Completions
 
             // Local functions.
 
-            bool IsBicepFile(Uri fileUri) => PathHelper.HasBicepExtension(fileUri);
-
-            bool IsArmTemplateFileLike(Uri fileUri)
-            {
-                if (PathHelper.HasExtension(fileUri, LanguageConstants.ArmTemplateFileExtension))
-                {
-                    return true;
-                }
-
-                if (model.Compilation.SourceFileGrouping.SourceFiles.Any(sourceFile =>
-                        sourceFile is ArmTemplateFile &&
-                        sourceFile.FileUri.LocalPath.Equals(fileUri.LocalPath, PathHelper.PathComparison)))
-                {
-                    return true;
-                }
-
-                if (!PathHelper.HasExtension(fileUri, LanguageConstants.JsonFileExtension) &&
-                    !PathHelper.HasExtension(fileUri, LanguageConstants.JsoncFileExtension))
-                {
-                    return false;
-                }
-
-                if (FileResolver.TryReadAtMostNCharacters(fileUri, Encoding.UTF8, 2000, out var fileContents) &&
-                    LanguageConstants.ArmTemplateSchemaRegex.IsMatch(fileContents))
-                {
-                    return true;
-                }
-
-                return false;
-            }
+            bool IsBicepFile(Uri fileUri) => PathHelper.HasBicepExtension(fileUri);      
         }
 
         private bool IsOciModuleRegistryReference(BicepCompletionContext context)

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -175,6 +175,11 @@ namespace Bicep.LanguageServer.Completions
                             yield return CreateKeywordCompletion(LanguageConstants.ImportKeyword, "Import keyword", context.ReplacementRange);
                         }
 
+                        if (model.Features.TestFrameworkEnabled)
+                        {
+                            yield return CreateKeywordCompletion(LanguageConstants.TestKeyword, "Test keyword", context.ReplacementRange);
+                        }
+
                         if (model.Features.UserDefinedFunctionsEnabled)
                         {
                             yield return CreateContextualSnippetCompletion(

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -177,6 +177,13 @@ namespace Bicep.LanguageServer
             base.VisitModuleDeclarationSyntax(syntax);
         }
 
+        public override void VisitTestDeclarationSyntax(TestDeclarationSyntax syntax)
+        {
+            AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);
+            AddTokenType(syntax.Name, SemanticTokenType.Variable);
+            base.VisitTestDeclarationSyntax(syntax);
+        }
+
         public override void VisitIfConditionSyntax(IfConditionSyntax syntax)
         {
             AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);


### PR DESCRIPTION
## Test Framework Syntax
* Added the Test Framework syntax under an experimental feature flag
* Added integration tests for the feature flag and the syntax
* Added Syntax highlighting functionality and autocomplete for keyword and path


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/Azure/bicep/pull/11147)