### PR TITLE
Get Parameters and Semantic Model for SourceFile for each Test Declaration

### DIFF
--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -91,6 +91,15 @@ namespace Bicep.Cli.Services
             var compilation = await bicepCompiler.CreateCompilation(inputUri, this.workspace, skipRestore, forceModulesRestore: false);
             var semantic_model = compilation.GetEntrypointSemanticModel();
 
+            var declarations = semantic_model.Root.TestDeclarations;
+
+            foreach(var declaration in declarations)
+            {
+                declaration.TryGetSemanticModel(out var declarationSemanticModel, out var declarationDiagnostics);
+                var parameters = declaration.DeclaringTest.GetParameters();
+                
+            }
+
             LogDiagnostics(compilation);
 
             return compilation;

--- a/src/Bicep.Core/Registry/IModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/IModuleDispatcher.cs
@@ -21,6 +21,8 @@ namespace Bicep.Core.Registry
 
         bool TryGetModuleReference(ModuleDeclarationSyntax module, Uri parentModuleUri, [NotNullWhen(true)] out ModuleReference? moduleReference, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);
 
+        bool TryGetModuleReference(TestDeclarationSyntax module, Uri parentModuleUri, [NotNullWhen(true)] out ModuleReference? moduleReference, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder);
+
         RegistryCapabilities GetRegistryCapabilities(ModuleReference moduleReference);
 
         ModuleRestoreStatus GetModuleRestoreStatus(ModuleReference moduleReference, out DiagnosticBuilder.ErrorBuilderDelegate? errorDetailBuilder);

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -101,6 +101,19 @@ namespace Bicep.Core.Registry
 
             return this.TryGetModuleReference(moduleReferenceString, parentModuleUri, out moduleReference, out failureBuilder);
         }
+        
+        public bool TryGetModuleReference(TestDeclarationSyntax module, Uri parentModuleUri, [NotNullWhen(true)] out ModuleReference? moduleReference, [NotNullWhen(false)] out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            var moduleReferenceString = SyntaxHelper.TryGetModulePath(module, out var getModulePathFailureBuilder);
+            if (moduleReferenceString is null)
+            {
+                failureBuilder = getModulePathFailureBuilder ?? throw new InvalidOperationException($"Expected {nameof(SyntaxHelper.TryGetModulePath)} to provide failure diagnostics.");
+                moduleReference = null;
+                return false;
+            }
+
+            return this.TryGetModuleReference(moduleReferenceString, parentModuleUri, out moduleReference, out failureBuilder);
+        }
 
         public RegistryCapabilities GetRegistryCapabilities(ModuleReference moduleReference)
         {

--- a/src/Bicep.Core/Syntax/SyntaxHelper.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHelper.cs
@@ -49,7 +49,25 @@ namespace Bicep.Core.Syntax
             failureBuilder = null;
             return pathValue;
         }
+        public static string? TryGetModulePath(TestDeclarationSyntax moduleDeclarationSyntax, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
+        {
+            var pathSyntax = moduleDeclarationSyntax.TryGetPath();
+            if (pathSyntax == null)
+            {
+                failureBuilder = x => x.ModulePathHasNotBeenSpecified();
+                return null;
+            }
 
+            var pathValue = pathSyntax.TryGetLiteralValue();
+            if (pathValue == null)
+            {
+                failureBuilder = x => x.FilePathInterpolationUnsupported();
+                return null;
+            }
+
+            failureBuilder = null;
+            return pathValue;
+        }
         public static string? TryGetUsingPath(UsingDeclarationSyntax usingDeclarationSyntax, out DiagnosticBuilder.ErrorBuilderDelegate? failureBuilder)
         {
             var pathSyntax = usingDeclarationSyntax.TryGetPath();

--- a/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
@@ -53,9 +53,31 @@ namespace Bicep.Core.Syntax
                 // blocked by assert in the constructor
                 _ => throw new NotImplementedException($"Unexpected type of test value '{this.Value.GetType().Name}'.")
             };
+        
+        public ObjectSyntax? TryGetParameters(ObjectPropertySyntax property)=>
+            property.Value switch
+            {
+                ObjectSyntax @object => @object,
+                SkippedTriviaSyntax => null,
+
+                // blocked by assert in the constructor
+                _ => throw new NotImplementedException($"Unexpected type of params value '{this.Value.GetType().Name}'.")
+            };
+        
 
         public ObjectSyntax GetBody() =>
             this.TryGetBody() ?? throw new InvalidOperationException($"A valid test body is not available on this test due to errors. Use {nameof(TryGetBody)}() instead.");
+
+        public ObjectSyntax GetParameters(){
+            var body = this.GetBody();
+            foreach(var property in body.Properties){
+                if(property.TryGetKeyText() == "params"){
+                    return this.TryGetParameters(property) ??  throw new InvalidOperationException($"A valid parameters body is not available on this test due to errors. Use {nameof(TryGetParameters)}() instead."); ;
+                }
+            }
+            return body;
+        }
+
 
     }
 }

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -155,6 +155,26 @@ namespace Bicep.Core.Workspaces
 
                         fileResultByUri[uriResult.FileUri] = childResult;
                     }
+                    foreach (var childModule in bicepFile.ProgramSyntax.Declarations.OfType<TestDeclarationSyntax>())
+                    {
+                        
+                        var (childModuleReference, uriResult) = GetModuleRestoreResult(fileUri, childModule);
+
+                        uriResultByModule.GetOrAdd(bicepFile, f => new())[childModule] = uriResult;
+                        if (uriResult.FileUri is null)
+                        {
+                            continue;
+                        }
+
+                        if (!fileResultByUri.TryGetValue(uriResult.FileUri, out var childResult) ||
+                            (childResult.File is not null && sourceFileToRebuild is not null && sourceFileToRebuild.Contains(childResult.File)))
+                        {
+                            // only recurse if we've not seen this file before - to avoid infinite loops
+                            childResult = PopulateRecursive(uriResult.FileUri, childModuleReference, sourceFileToRebuild);
+                        }
+
+                        fileResultByUri[uriResult.FileUri] = childResult;
+                    }
                     break;
                 }
                 case BicepParamFile paramsFile:
@@ -225,6 +245,44 @@ namespace Bicep.Core.Workspaces
 
             return (moduleReference, new(module, moduleFileUri, false, null));
         }
+
+        
+        private (ModuleReference? reference, UriResolutionResult result) GetModuleRestoreResult(Uri parentFileUri, TestDeclarationSyntax module)
+        {
+            if (!moduleDispatcher.TryGetModuleReference(module, parentFileUri, out var moduleReference, out var referenceResolutionError))
+            {
+                // module reference is not valid
+                return (null, new(module, null, false, referenceResolutionError));
+            }
+
+            if (!moduleDispatcher.TryGetLocalModuleEntryPointUri(moduleReference, out var moduleFileUri, out var moduleGetPathFailureBuilder))
+            {
+                return (moduleReference, new(module, null, false, moduleGetPathFailureBuilder));
+            }
+
+            if (forceModulesRestore)
+            {
+                //override the status to force restore
+                return (moduleReference, new(module, moduleFileUri, true, x => x.ModuleRequiresRestore(moduleReference.FullyQualifiedReference)));
+            }
+
+            var restoreStatus = moduleDispatcher.GetModuleRestoreStatus(moduleReference, out var restoreErrorBuilder);
+            switch (restoreStatus)
+            {
+                case ModuleRestoreStatus.Unknown:
+                    // we have not yet attempted to restore the module, so let's do it
+                    return (moduleReference, new(module, moduleFileUri, true, x => x.ModuleRequiresRestore(moduleReference.FullyQualifiedReference)));
+                case ModuleRestoreStatus.Failed:
+                    // the module has not yet been restored or restore failed
+                    // in either case, set the error
+                    return (moduleReference, new(module, null, false, restoreErrorBuilder));
+                default:
+                    break;
+            }
+
+            return (moduleReference, new(module, moduleFileUri, false, null));
+        }
+        
 
         private ILookup<ISourceFile, ISourceFile> ReportFailuresForCycles()
         {


### PR DESCRIPTION
-  Add the Test Declaration paths to the SourceFileGroupingBuilder
- Get the SemanticModel of each Test Declaration path
- Get the parameters from each Test Declaration
