### PR TITLE
Create Validation and  template Evaluation Classes

### DIFF
--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -1,33 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Deployments.Templates.Engines;
 using Bicep.Cli.Logging;
 using Bicep.Core;
-using Bicep.Core.Analyzers.Interfaces;
-using Bicep.Core.Analyzers.Linter.ApiVersions;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Emit;
-using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
-using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 using Bicep.Decompiler;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.ResourceStack.Common.Collections;
+
 
 namespace Bicep.Cli.Services
 {
@@ -99,12 +90,7 @@ namespace Bicep.Cli.Services
             var semantic_model = compilation.GetEntrypointSemanticModel();
 
             var declarations = semantic_model.Root.TestDeclarations;
-            var templateOutputBuffer = new StringBuilder();
-            using var textWriter = new StringWriter(templateOutputBuffer);
-            foreach(var declaration in declarations)
-            {
-                // Evaluate the test declaration
-            }
+            ValidationService.Validate(declarations);
 
             LogDiagnostics(compilation);
 

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -6,7 +6,6 @@ using Bicep.Core;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
-using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -18,7 +18,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 
-
 namespace Bicep.Cli.Services
 {
     public class CompilationService

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.Deployments.Templates.Engines;
 using Bicep.Cli.Logging;
 using Bicep.Core;
 using Bicep.Core.Analyzers.Interfaces;
@@ -8,6 +9,7 @@ using Bicep.Core.Analyzers.Linter.ApiVersions;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
+using Bicep.Core.Emit;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
@@ -16,11 +18,16 @@ using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 using Bicep.Core.Workspaces;
 using Bicep.Decompiler;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.WindowsAzure.ResourceStack.Common.Collections;
 
 namespace Bicep.Cli.Services
 {
@@ -92,7 +99,8 @@ namespace Bicep.Cli.Services
             var semantic_model = compilation.GetEntrypointSemanticModel();
 
             var declarations = semantic_model.Root.TestDeclarations;
-
+            var templateOutputBuffer = new StringBuilder();
+            using var textWriter = new StringWriter(templateOutputBuffer);
             foreach(var declaration in declarations)
             {
                 // Evaluate the test declaration

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -19,11 +19,11 @@ namespace Bicep.Cli.Services
 {
     public class TemplateEvaluatorService
     {
-        const string TestTenantId = "d4c73686-f7cd-458e-b377-67adcd46b624";
-        const string TestManagementGroupName = "3fc9f36e-8699-43af-b038-1c103980942f";
-        const string TestSubscriptionId = "f91a30fd-f403-4999-ae9f-ec37a6d81e13";
-        const string TestResourceGroupName = "testResourceGroup";
-        const string TestLocation = "West US";
+        private const string TestTenantId = "";
+        private const string TestManagementGroupName = "";
+        private const string TestSubscriptionId = "";
+        private const string TestResourceGroupName = "";
+        private const string TestLocation = "";
 
         public delegate JToken OnListDelegate(string functionName, string resourceId, string apiVersion, JToken? body);
 

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -92,7 +92,7 @@ namespace Bicep.Cli.Services
                 {
                     var resourceId = parameters[0].Token.ToString();
                     var apiVersion = parameters.Length > 1 ? parameters[1].Token.ToString() : null;
-                    var fullBody = parameters.Length > 2 ? parameters[2].Token.ToString().EqualsOrdinalInsensitively("Full") : false;
+                    var fullBody = parameters.Length > 2 && parameters[2].Token.ToString().EqualsOrdinalInsensitively("Full");
 
                     if (apiVersion is not null && config.OnReferenceFunc is not null)
                     {

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -195,10 +195,9 @@ namespace Bicep.Cli.Services
             {
                 var template = TemplateEngine.ParseTemplate(templateJtoken.ToString());
                 var parameters = ParseParametersFile(parametersJToken);
-                // var parameters = new InsensitiveDictionary<JToken>();
-
+                
                 TemplateEngine.ValidateTemplate(template, "2020-10-01", deploymentScope);
-                TemplateEngine.ParameterizeTemplate(template, new InsensitiveDictionary<JToken>(parameters), metadata, null, new InsensitiveDictionary<JToken>());
+                TemplateEngine.ParameterizeTemplate(template, new InsensitiveDictionary<JToken>(parameters), new InsensitiveDictionary<JToken>(), null, new InsensitiveDictionary<JToken>());
 
                 TemplateEngine.ProcessTemplateLanguageExpressions(config.ManagementGroup, config.SubscriptionId, config.ResourceGroup, template, "2020-10-01", null);
 

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -158,38 +158,7 @@ namespace Bicep.Cli.Services
 
             var deploymentScope = GetDeploymentScope(templateJtoken["$schema"]!.ToString());
 
-            var metadata = new InsensitiveDictionary<JToken>(config.Metadata);
-            if (deploymentScope == TemplateDeploymentScope.Subscription || deploymentScope == TemplateDeploymentScope.ResourceGroup)
-            {
-                metadata["subscription"] = new JObject
-                {
-                    ["id"] = $"/subscriptions/{config.SubscriptionId}",
-                    ["subscriptionId"] = config.SubscriptionId,
-                    ["tenantId"] = config.TenantId,
-                };
-            }
-            if (deploymentScope == TemplateDeploymentScope.ResourceGroup)
-            {
-                metadata["resourceGroup"] = new JObject
-                {
-                    ["id"] = $"/subscriptions/{config.SubscriptionId}/resourceGroups/{config.ResourceGroup}",
-                    ["location"] = config.RgLocation,
-                };
-            };
-            if (deploymentScope == TemplateDeploymentScope.ManagementGroup)
-            {
-                metadata["managementGroup"] = new JObject
-                {
-                    ["id"] = $"/providers/Microsoft.Management/managementGroups/{config.ManagementGroup}",
-                    ["name"] = config.ManagementGroup,
-                    ["type"] = "Microsoft.Management/managementGroups",
-                };
-            };
-            // tenant() function is available at all scopes
-            metadata["tenant"] = new JObject
-            {
-                ["tenantId"] = config.TenantId,
-            };
+            var metadata = new InsensitiveDictionary<JToken>();
 
             try
             {
@@ -197,7 +166,7 @@ namespace Bicep.Cli.Services
                 var parameters = ParseParametersFile(parametersJToken);
                 
                 TemplateEngine.ValidateTemplate(template, "2020-10-01", deploymentScope);
-                TemplateEngine.ParameterizeTemplate(template, new InsensitiveDictionary<JToken>(parameters), new InsensitiveDictionary<JToken>(), null, new InsensitiveDictionary<JToken>());
+                TemplateEngine.ParameterizeTemplate(template, new InsensitiveDictionary<JToken>(parameters), metadata, null, new InsensitiveDictionary<JToken>());
 
                 TemplateEngine.ProcessTemplateLanguageExpressions(config.ManagementGroup, config.SubscriptionId, config.ResourceGroup, template, "2020-10-01", null);
 

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -19,11 +19,11 @@ namespace Bicep.Cli.Services
 {
     public class TemplateEvaluatorService
     {
-        private const string TestTenantId = "";
-        private const string TestManagementGroupName = "";
-        private const string TestSubscriptionId = "";
-        private const string TestResourceGroupName = "";
-        private const string TestLocation = "";
+        private const string DummyTenantId = "";
+        private const string DummyManagementGroupName = "";
+        private const string DummySubscriptionId = "";
+        private const string DummyResourceGroupName = "";
+        private const string DummyLocation = "";
 
         public delegate JToken OnListDelegate(string functionName, string resourceId, string apiVersion, JToken? body);
 
@@ -40,11 +40,11 @@ namespace Bicep.Cli.Services
             OnReferenceDelegate? OnReferenceFunc)
         {
             public static EvaluationConfiguration Default = new(
-                TestTenantId,
-                TestManagementGroupName,
-                TestSubscriptionId,
-                TestResourceGroupName,
-                TestLocation,
+                DummyTenantId,
+                DummyManagementGroupName,
+                DummySubscriptionId,
+                DummyResourceGroupName,
+                DummyLocation,
                 new(),
                 null,
                 null

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System;
+using Newtonsoft.Json.Linq;
+using Azure.Deployments.Core.Configuration;
+using Azure.Deployments.Core.Definitions.Schema;
+using Azure.Deployments.Templates.Engines;
+using Azure.Deployments.Expression.Engines;
+using System.Linq;
+using Azure.Deployments.Expression.Expressions;
+using Azure.Deployments.Core.ErrorResponses;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using Microsoft.WindowsAzure.ResourceStack.Common.Collections;
+using System.Collections.Immutable;
+using Bicep.Core;
+
+namespace Bicep.Cli.Services
+{
+    public class TemplateEvaluatorService
+    {
+        const string TestTenantId = "d4c73686-f7cd-458e-b377-67adcd46b624";
+        const string TestManagementGroupName = "3fc9f36e-8699-43af-b038-1c103980942f";
+        const string TestSubscriptionId = "f91a30fd-f403-4999-ae9f-ec37a6d81e13";
+        const string TestResourceGroupName = "testResourceGroup";
+        const string TestLocation = "West US";
+
+        public delegate JToken OnListDelegate(string functionName, string resourceId, string apiVersion, JToken? body);
+
+        public delegate JToken OnReferenceDelegate(string resourceId, string apiVersion, bool fullBody);
+
+        public record EvaluationConfiguration(
+            string TenantId,
+            string ManagementGroup,
+            string SubscriptionId,
+            string ResourceGroup,
+            string RgLocation,
+            Dictionary<string, JToken> Metadata,
+            OnListDelegate? OnListFunc,
+            OnReferenceDelegate? OnReferenceFunc)
+        {
+            public static EvaluationConfiguration Default = new(
+                TestTenantId,
+                TestManagementGroupName,
+                TestSubscriptionId,
+                TestResourceGroupName,
+                TestLocation,
+                new(),
+                null,
+                null
+            );
+        }
+
+        private static string GetResourceId(string scopeString, TemplateResource resource)
+        {
+            var typeSegments = resource.Type.Value.Split('/');
+            var nameSegments = resource.Name.Value.Split('/');
+
+            var types = new[] { typeSegments.First() }
+                .Concat(typeSegments.Skip(1).Zip(nameSegments, (type, name) => $"{type}/{name}"));
+
+            return $"{scopeString}providers/{string.Join('/', types)}";
+        }
+
+        private static void ProcessTemplateLanguageExpressions(Template template, EvaluationConfiguration config, TemplateDeploymentScope deploymentScope)
+        {
+            var scopeString = deploymentScope switch
+            {
+                TemplateDeploymentScope.Tenant => "/",
+                TemplateDeploymentScope.ManagementGroup => $"/providers/Microsoft.Management/managementGroups/{config.ManagementGroup}/",
+                TemplateDeploymentScope.Subscription => $"/subscriptions/{config.SubscriptionId}/",
+                TemplateDeploymentScope.ResourceGroup => $"/subscriptions/{config.SubscriptionId}/resourceGroups/{config.ResourceGroup}/",
+                _ => throw new InvalidOperationException(),
+            };
+
+            var resourceLookup = template.Resources.ToOrdinalInsensitiveDictionary(x => GetResourceId(scopeString, x));
+
+            var evaluationContext = TemplateEngine.GetExpressionEvaluationContext(config.ManagementGroup, config.SubscriptionId, config.ResourceGroup, template, null);
+            var defaultEvaluateFunction = evaluationContext.EvaluateFunction;
+            evaluationContext.EvaluateFunction = (FunctionExpression functionExpression, FunctionArgument[] parameters, TemplateErrorAdditionalInfo additionalInfo) =>
+            {
+                if (functionExpression.Function.StartsWithOrdinalInsensitively(LanguageConstants.ListFunctionPrefix) && config.OnListFunc is not null)
+                {
+                    return config.OnListFunc(
+                        functionExpression.Function,
+                        parameters[0].Token.ToString(),
+                        parameters[1].Token.ToString(),
+                        parameters.Length > 2 ? parameters[2].Token : null);
+                }
+
+                if (functionExpression.Function.EqualsOrdinalInsensitively("reference"))
+                {
+                    var resourceId = parameters[0].Token.ToString();
+                    var apiVersion = parameters.Length > 1 ? parameters[1].Token.ToString() : null;
+                    var fullBody = parameters.Length > 2 ? parameters[2].Token.ToString().EqualsOrdinalInsensitively("Full") : false;
+
+                    if (apiVersion is not null && config.OnReferenceFunc is not null)
+                    {
+                        return config.OnReferenceFunc(resourceId, apiVersion, fullBody);
+                    }
+
+                    if (resourceLookup.TryGetValue(resourceId, out var foundResource) &&
+                        (apiVersion is null || StringComparer.OrdinalIgnoreCase.Equals(apiVersion, foundResource.ApiVersion.Value)))
+                    {
+                        return fullBody ? foundResource.ToJToken() : foundResource.Properties.ToJToken();
+                    }
+                }
+
+                var value = defaultEvaluateFunction(functionExpression, parameters, additionalInfo);
+                return value;
+            };
+
+            for (int i = 0; i < template.Resources.Length; i++)
+            {
+                var resource = template.Resources[i];
+
+                if (resource.Properties is not null)
+                {
+                    var skipEvaluationPaths = new InsensitiveHashSet();
+                    if (resource.Type.Value.EqualsOrdinalInsensitively("Microsoft.Resources/deployments"))
+                    {
+                        skipEvaluationPaths.Add("template");
+                    };
+
+                    resource.Properties.Value = ExpressionsEngine.EvaluateLanguageExpressionsRecursive(
+                        root: resource.Properties.Value,
+                        evaluationContext: evaluationContext,
+                        skipEvaluationPaths: skipEvaluationPaths);
+                }
+            }
+
+            if (template.Outputs is not null && template.Outputs.Count > 0)
+            {
+                foreach (var outputKey in template.Outputs.Keys.ToList())
+                {
+                    template.Outputs[outputKey].Value.Value = ExpressionsEngine.EvaluateLanguageExpressionsRecursive(
+                        root: template.Outputs[outputKey].Value.Value,
+                        evaluationContext: evaluationContext);
+                }
+            }
+        }
+
+        public static JToken Evaluate(JToken? templateJtoken, JToken? parametersJToken = null, Func<EvaluationConfiguration, EvaluationConfiguration>? configBuilder = null)
+        {
+            var configuration = EvaluationConfiguration.Default;
+
+            if (configBuilder is not null)
+            {
+                configuration = configBuilder(configuration);
+            }
+
+            return EvaluateTemplate(templateJtoken, parametersJToken, configuration);
+        }
+
+        private static JToken EvaluateTemplate(JToken? templateJtoken, JToken? parametersJToken, EvaluationConfiguration config)
+        {
+            templateJtoken = templateJtoken ?? throw new ArgumentNullException(nameof(templateJtoken));
+
+            var deploymentScope = GetDeploymentScope(templateJtoken["$schema"]!.ToString());
+
+            var metadata = new InsensitiveDictionary<JToken>(config.Metadata);
+            if (deploymentScope == TemplateDeploymentScope.Subscription || deploymentScope == TemplateDeploymentScope.ResourceGroup)
+            {
+                metadata["subscription"] = new JObject
+                {
+                    ["id"] = $"/subscriptions/{config.SubscriptionId}",
+                    ["subscriptionId"] = config.SubscriptionId,
+                    ["tenantId"] = config.TenantId,
+                };
+            }
+            if (deploymentScope == TemplateDeploymentScope.ResourceGroup)
+            {
+                metadata["resourceGroup"] = new JObject
+                {
+                    ["id"] = $"/subscriptions/{config.SubscriptionId}/resourceGroups/{config.ResourceGroup}",
+                    ["location"] = config.RgLocation,
+                };
+            };
+            if (deploymentScope == TemplateDeploymentScope.ManagementGroup)
+            {
+                metadata["managementGroup"] = new JObject
+                {
+                    ["id"] = $"/providers/Microsoft.Management/managementGroups/{config.ManagementGroup}",
+                    ["name"] = config.ManagementGroup,
+                    ["type"] = "Microsoft.Management/managementGroups",
+                };
+            };
+            // tenant() function is available at all scopes
+            metadata["tenant"] = new JObject
+            {
+                ["tenantId"] = config.TenantId,
+            };
+
+            try
+            {
+                var template = TemplateEngine.ParseTemplate(templateJtoken.ToString());
+                var parameters = ParseParametersFile(parametersJToken);
+                // var parameters = new InsensitiveDictionary<JToken>();
+
+                TemplateEngine.ValidateTemplate(template, "2020-10-01", deploymentScope);
+                TemplateEngine.ParameterizeTemplate(template, new InsensitiveDictionary<JToken>(parameters), metadata, null, new InsensitiveDictionary<JToken>());
+
+                TemplateEngine.ProcessTemplateLanguageExpressions(config.ManagementGroup, config.SubscriptionId, config.ResourceGroup, template, "2020-10-01", null);
+
+                ProcessTemplateLanguageExpressions(template, config, deploymentScope);
+
+                TemplateEngine.ValidateProcessedTemplate(template, "2020-10-01", deploymentScope);
+
+                return template.ToJToken();
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidOperationException(
+                    $"Evaluating template failed: {exception.Message}." +
+                    $"\nTemplate file: {templateJtoken}" +
+                    (parametersJToken is null ? "" : $"\nParameters file: {parametersJToken}"),
+                    exception);
+            }
+        }
+
+        private static ImmutableDictionary<string, JToken> ParseParametersFile(JToken? parametersJToken)
+        {
+            if (parametersJToken is null)
+            {
+                return ImmutableDictionary<string, JToken>.Empty;
+            }
+
+            return parametersJToken.Cast<JProperty>().ToImmutableDictionary(x => x.Name, x => x.Value!);
+        }
+        private static TemplateDeploymentScope GetDeploymentScope(string templateSchema)
+            => templateSchema switch
+            {
+                "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#" => TemplateDeploymentScope.Tenant,
+                "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#" => TemplateDeploymentScope.ManagementGroup,
+                "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#" => TemplateDeploymentScope.Subscription,
+                "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#" => TemplateDeploymentScope.ResourceGroup,
+                _ => throw new InvalidOperationException($"Unrecognized schema: {templateSchema}"),
+            };
+    }
+}

--- a/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
+++ b/src/Bicep.Cli/Services/TemplateEvaluatorService.cs
@@ -133,7 +133,7 @@ namespace Bicep.Cli.Services
             {
                 foreach (var outputKey in template.Outputs.Keys.ToList())
                 {
-                    template.Outputs[outputKey].Value.Value = ExpressionsEngine.EvaluateLanguageExpressionsRecursive(
+                    template.Outputs[outputKey].Value.Value = ExpressionsEngine.EvaluateLanguageExpressionsOptimistically(
                         root: template.Outputs[outputKey].Value.Value,
                         evaluationContext: evaluationContext);
                 }

--- a/src/Bicep.Cli/Services/ValidationService.cs
+++ b/src/Bicep.Cli/Services/ValidationService.cs
@@ -17,7 +17,7 @@ namespace Bicep.Cli.Services
         public static void Validate(ImmutableArray<TestSymbol> testDeclarations)
         {
             var templateOutputBuffer = new StringBuilder();
-            using var textWriter = new StringWriter(templateOutputBuffer);
+            using var textWriter = new StringWriter();
 
             EvaluateTemplates(testDeclarations, textWriter);
 

--- a/src/Bicep.Cli/Services/ValidationService.cs
+++ b/src/Bicep.Cli/Services/ValidationService.cs
@@ -25,7 +25,6 @@ namespace Bicep.Cli.Services
         }
         private static void EvaluateTemplates(ImmutableArray<TestSymbol> testDeclarations, StringWriter textWriter)
         {
-
             var evaluatedTemplates =  new InsensitiveDictionary<JToken>();
 
             foreach(var testDeclaration  in testDeclarations)

--- a/src/Bicep.Cli/Services/ValidationService.cs
+++ b/src/Bicep.Cli/Services/ValidationService.cs
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Text;
 using Bicep.Core.Emit;
+using Bicep.Core.Intermediate;
 using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
 using Microsoft.WindowsAzure.ResourceStack.Common.Collections;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -29,34 +33,58 @@ namespace Bicep.Cli.Services
 
             foreach(var testDeclaration  in testDeclarations)
             {
-                testDeclaration.TryGetSemanticModel(out var semanticModel, out var failureDiagnostic);
-
-                var parameters = testDeclaration.DeclaringTest.TryGetParameters();
-
-                if (semanticModel is SemanticModel testSemanticModel)
+                if (testDeclaration.TryGetSemanticModel(out var semanticModel, out var failureDiagnostic) &&
+                    semanticModel is SemanticModel testSemanticModel)
                 {
-                    var sourceFileToTrack = testSemanticModel.Features.SourceMappingEnabled ? testSemanticModel.SourceFile : default;
+                    var parameters = TryGetParameters(testSemanticModel, testDeclaration);
+                    var template = GetTemplate(testSemanticModel, testDeclaration);
 
-                    using var writer = new SourceAwareJsonTextWriter(testSemanticModel.FileResolver, textWriter, sourceFileToTrack)
-                    {
-                        // don't close the textWriter when writer is disposed
-                        CloseOutput = false,
-                        Formatting = Formatting.Indented
-
-                    };
-
-                    var templateWriter = new TemplateWriter(testSemanticModel);
-
-                    var (_, templateJtoken) = templateWriter.GetTemplate(writer);
-
-                    var evaluatedTemplate = TemplateEvaluatorService.Evaluate(templateJtoken, parameters);
+                    var evaluatedTemplate = TemplateEvaluatorService.Evaluate(template, parameters);
 
                     evaluatedTemplates.Add(testDeclaration.Name, evaluatedTemplate);
-
+                
                 }
                 
             }
 
+        }
+
+        private static JToken GetTemplate(SemanticModel model, TestSymbol test)
+        {
+            var textWriter = new StringWriter();
+            using var writer = new SourceAwareJsonTextWriter(model.FileResolver, textWriter)
+            {
+                // don't close the textWriter when writer is disposed
+                CloseOutput = false,
+                Formatting = Formatting.Indented
+            };
+            var (_, template) = new TemplateWriter(model).GetTemplate(writer);
+
+            return template;
+        }
+
+        private static JObject? TryGetParameters(SemanticModel model, TestSymbol test)
+        {
+            if (test.DeclaringTest.GetBody() is { } body &&
+                body.TryGetPropertyByName("params") is { } paramsProperty)
+            {
+                var textWriter = new StringWriter();
+                using var writer = new PositionTrackingJsonTextWriter(model.FileResolver, textWriter)
+                {
+                    // don't close the textWriter when writer is disposed
+                    CloseOutput = false,
+                    Formatting = Formatting.Indented
+                };
+
+                var emitter = new ExpressionEmitter(writer, new(model));
+                var parametersExpression = new ExpressionBuilder(new(model)).Convert(paramsProperty.Value);
+                new TemplateWriter(model).EmitTestParameters(emitter, parametersExpression);
+                writer.Flush();
+
+                return textWriter.ToString().FromJson<JObject>();
+            }
+
+            return null;
         }
     }
 }

--- a/src/Bicep.Cli/Services/ValidationService.cs
+++ b/src/Bicep.Cli/Services/ValidationService.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Text;
+using Bicep.Core.Emit;
+using Bicep.Core.Semantics;
+using Microsoft.WindowsAzure.ResourceStack.Common.Collections;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Cli.Services
+{
+    public class ValidationService
+    {
+        public static void Validate(ImmutableArray<TestSymbol> testDeclarations)
+        {
+            var templateOutputBuffer = new StringBuilder();
+            using var textWriter = new StringWriter(templateOutputBuffer);
+
+            EvaluateTemplates(testDeclarations, textWriter);
+
+            
+        }
+        private static void EvaluateTemplates(ImmutableArray<TestSymbol> testDeclarations, StringWriter textWriter)
+        {
+
+            var evaluatedTemplates =  new InsensitiveDictionary<JToken>();
+
+            foreach(var testDeclaration  in testDeclarations)
+            {
+                testDeclaration.TryGetSemanticModel(out var semanticModel, out var failureDiagnostic);
+
+                var parameters = testDeclaration.DeclaringTest.TryGetParameters();
+
+                if (semanticModel is SemanticModel testSemanticModel)
+                {
+                    var sourceFileToTrack = testSemanticModel.Features.SourceMappingEnabled ? testSemanticModel.SourceFile : default;
+
+                    using var writer = new SourceAwareJsonTextWriter(testSemanticModel.FileResolver, textWriter, sourceFileToTrack)
+                    {
+                        // don't close the textWriter when writer is disposed
+                        CloseOutput = false,
+                        Formatting = Formatting.Indented
+
+                    };
+
+                    var templateWriter = new TemplateWriter(testSemanticModel);
+
+                    var (_, templateJtoken) = templateWriter.GetTemplate(writer);
+
+                    var evaluatedTemplate = TemplateEvaluatorService.Evaluate(templateJtoken, parameters);
+
+                    evaluatedTemplates.Add(testDeclaration.Name, evaluatedTemplate);
+
+                }
+                
+            }
+
+        }
+    }
+}

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -729,6 +729,28 @@ namespace Bicep.Core.Emit
             }, resource.SourceSyntax);
         }
 
+        public void EmitTestParameters(ExpressionEmitter emitter, Expression parameters)
+        {
+            if (parameters is not ObjectExpression paramsObject)
+            {
+                // 'params' is optional if the module has no required params
+                return;
+            }
+
+            emitter.EmitObject(() => {
+                foreach (var property in paramsObject.Properties)
+                {
+                    if (property.TryGetKeyText() is not {} keyName)
+                    {
+                        // should have been caught by earlier validation
+                        throw new ArgumentException("Disallowed interpolation in test parameter");
+                    }
+                    
+                    emitter.EmitProperty(keyName, property.Value);
+                }
+            }, paramsObject.SourceSyntax);
+        }
+        
         private void EmitModuleParameters(ExpressionEmitter emitter, DeclaredModuleExpression module)
         {
             if (module.Parameters is not ObjectExpression paramsObject)

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -100,6 +100,12 @@ namespace Bicep.Core.Emit
             writer.ProcessSourceMap(templateJToken);
         }
 
+        public (Template, JToken) GetTemplate(SourceAwareJsonTextWriter writer)
+        {
+            return GenerateTemplateWithoutHash(writer.TrackingJsonWriter);
+        }
+       
+
         private (Template, JToken) GenerateTemplateWithoutHash(PositionTrackingJsonTextWriter jsonWriter)
         {
             var emitter = new ExpressionEmitter(jsonWriter, this.Context);

--- a/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/TestDeclarationSyntax.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
-using Microsoft.WindowsAzure.ResourceStack.Common.Collections;
-using Microsoft.WindowsAzure.ResourceStack.Common.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.Syntax
 {
@@ -59,149 +55,6 @@ namespace Bicep.Core.Syntax
 
         public ObjectSyntax GetBody() =>
             this.TryGetBody() ?? throw new InvalidOperationException($"A valid test body is not available on this test due to errors. Use {nameof(TryGetBody)}() instead.");
-
-        public JToken? TryGetParameters(){
-            var body = this.GetBody();
-            foreach (var property in body.Properties) {
-                if (property.TryGetKeyText() == "params" && property.Value is ObjectSyntax paramsObject) 
-                {
-                    var parameters = new JObject();
-                    foreach (var parameter in paramsObject.Properties){
-                        var propertyName = parameter.TryGetKeyText();
-                        if (propertyName is null)
-                        {
-                            throw new NotImplementedException($"Error reading the parameter key");
-                        }
-                        else
-                        {
-                            switch (parameter.Value)
-                            {
-                                case StringSyntax stringSyntax:
-                                    parameters.Add(new JProperty(propertyName, stringSyntax.TryGetLiteralValue()));
-                                    break;
-
-                                case IntegerLiteralSyntax numericSyntax:
-                                    parameters[propertyName] = numericSyntax.Value;
-                                    break;
-
-                                case BooleanLiteralSyntax booleanSyntax:
-                                    parameters[propertyName] = booleanSyntax.Value;
-                                    break;
-                                
-                                case null:
-                                    parameters[propertyName] = JValue.CreateNull();
-                                    break;
-
-                                case ObjectSyntax objectSyntax:
-                                    parameters[propertyName] = ParseObjectSyntax(objectSyntax);
-                                    break;
-
-                                case ArraySyntax arraySyntax:
-                                    parameters[propertyName] = ParseArraySyntax(arraySyntax);
-                                    break;
-                                default:
-                                    throw new NotImplementedException($"Unexpected type of parameter value '{parameter.Value.GetType().Name}'.");
-                            }
-                        }
-                    }
-                    
-                    return parameters;
-                }
-            }
-            return null;
-        }
-        private static JArray ParseArraySyntax(ArraySyntax arraySyntax)
-        {
-            var array = new JArray();
-
-            foreach (var item in arraySyntax.Items)
-            {
-                switch (item.Value)
-                {
-                    case StringSyntax stringSyntax:
-                        array.Add(stringSyntax.TryGetLiteralValue());
-                        break;
-
-                    case IntegerLiteralSyntax numericSyntax:
-                        array.Add(numericSyntax.Value);
-                        break;
-
-                    case BooleanLiteralSyntax booleanSyntax:
-                        array.Add(booleanSyntax.Value);
-                        break;
-
-                    case null:
-                        array.Add(JValue.CreateNull());
-                        break;
-
-                    case ObjectSyntax objectSyntax:
-                        array.Add(ParseObjectSyntax(objectSyntax));
-                        break;
-
-                    case ArraySyntax nestedArraySyntax:
-                        array.Add(ParseArraySyntax(nestedArraySyntax));
-                        break;
-
-                    default:
-                        throw new NotImplementedException($"Unexpected type of array item '{item.GetType().Name}'.");
-                }
-            }
-
-            return array;
-        }
-
-        private static JObject ParseObjectSyntax(ObjectSyntax objectSyntax)
-        {
-            var obj = new JObject();
-
-            foreach (var property in objectSyntax.Properties)
-            {
-                var propertyName = property.TryGetKeyText();
-                var propertyValue = property.Value;
-                if (propertyName is null)
-                {
-                    throw new NotImplementedException($"Error reading the object property key");
-                }
-                
-                switch (propertyValue)
-                {
-                    case StringSyntax stringSyntax:
-                        obj.Add(propertyName, stringSyntax.TryGetLiteralValue());
-                        break;
-
-                    case IntegerLiteralSyntax numericSyntax:
-                        obj[propertyName] = numericSyntax.Value;
-                        break;
-
-                    case BooleanLiteralSyntax booleanSyntax:
-                        obj[propertyName] = booleanSyntax.Value;
-                        break;
-
-                    case null:
-                        obj[propertyName] = JValue.CreateNull();
-                        break;
-
-                    case ObjectSyntax nestedObjectSyntax:
-                        obj[propertyName] = ParseObjectSyntax(nestedObjectSyntax);
-                        break;
-
-                    case ArraySyntax nestedArraySyntax:
-                        obj[propertyName] = ParseArraySyntax(nestedArraySyntax);
-                        break;
-
-                    default:
-                        throw new NotImplementedException($"Unexpected type of object property value '{propertyValue.GetType().Name}'.");
-                }
-            }
-
-            return obj;
-        }
-
-
-        
-        
-
-
 
     }
 }


### PR DESCRIPTION
- Created a Class for Validation of the test declarations in a file.
- Created a Class to evaluate templates 
- Added Function to recursively parse the parameters and convert them to JToken
- Passed the template of the semantic model from the file specified in the test declaration and the parameters to the evaluator
- Throw error when template does not evaluate correctly (Eventually this would be logged to the console per template)

Fix #11306
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11318&drop=dogfoodAlpha