### PR TITLE
Fix hover with escaped chars in published doclink

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Completions/ModuleReferenceCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/ModuleReferenceCompletionProviderTests.cs
@@ -27,7 +27,7 @@ using IOFileSystem = System.IO.Abstractions.FileSystem;
 namespace Bicep.LangServer.UnitTests.Completions
 {
     [TestClass]
-    public class ModuleReferenceCompletionProviderTests
+    public class ModuleReferenceCompletionProviderTests //asdfg
     {
         [NotNull]
         public TestContext? TestContext { get; set; }
@@ -581,7 +581,7 @@ namespace Bicep.LangServer.UnitTests.Completions
   }
 }";
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<PublicRegistryModuleVersion> { new("1.0.2", null, null), new("1.0.1", "d2", "contoso.com/help2") });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<PublicRegistryModuleVersion> { new("1.0.2", null, null), new("1.0.1", "d2", "contoso.com/help%20page.html") });
 
             var completionContext = GetBicepCompletionContext(inputWithCursors, bicepConfigFileContents, out DocumentUri documentUri);
             var moduleReferenceCompletionProvider = new ModuleReferenceCompletionProvider(
@@ -611,7 +611,7 @@ namespace Bicep.LangServer.UnitTests.Completions
                 x.InsertText == null &&
                 x.SortText == expectedSortText2 &&
                 x.Detail == "d2" &&
-                x.Documentation!.MarkupContent!.Value == "[View Documentation](contoso.com/help2)" &&
+                x.Documentation!.MarkupContent!.Value == "[View Documentation](contoso.com/help%20page.html)" &&
                 x.TextEdit!.TextEdit!.NewText == expectedCompletionText2 &&
                 x.TextEdit!.TextEdit!.Range.Start.Line == 0 &&
                 x.TextEdit!.TextEdit!.Range.Start.Character == 12 &&

--- a/src/Bicep.LangServer.UnitTests/Completions/ModuleReferenceCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/ModuleReferenceCompletionProviderTests.cs
@@ -27,7 +27,7 @@ using IOFileSystem = System.IO.Abstractions.FileSystem;
 namespace Bicep.LangServer.UnitTests.Completions
 {
     [TestClass]
-    public class ModuleReferenceCompletionProviderTests //asdfg
+    public class ModuleReferenceCompletionProviderTests
     {
         [NotNull]
         public TestContext? TestContext { get; set; }

--- a/src/Bicep.LangServer/Utils/MarkdownHelper.cs
+++ b/src/Bicep.LangServer/Utils/MarkdownHelper.cs
@@ -24,7 +24,7 @@ namespace Bicep.LanguageServer.Utils
 
         public static string? GetDocumentationLink(string? documentationUri)
         {
-            return documentationUri is null ? null : $"[View Documentation]({Uri.UnescapeDataString(documentationUri)})";
+            return documentationUri is null ? null : $"[View Documentation]({documentationUri})";
         }
     }
 }


### PR DESCRIPTION
Fixes #10567
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11365&drop=dogfoodAlpha