### PR TITLE
Display Bicep build errors in the UI

### DIFF
--- a/src/vscode-bicep/src/language/protocol.ts
+++ b/src/vscode-bicep/src/language/protocol.ts
@@ -46,13 +46,14 @@ export interface GetDeploymentDataRequest {
 }
 
 export interface GetDeploymentDataResponse {
-  templateJson: string;
+  templateJson?: string;
   parametersJson?: string;
+  errorMessage?: string;
 }
 
 export const getDeploymentDataRequestType = new ProtocolRequestType<
   GetDeploymentDataRequest,
-  GetDeploymentDataResponse | null,
+  GetDeploymentDataResponse,
   never,
   void,
   void

--- a/src/vscode-bicep/src/panes/deploy/app/components/App.tsx
+++ b/src/vscode-bicep/src/panes/deploy/app/components/App.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { FC } from "react";
+import { FC, useState } from "react";
 import { VSCodeButton, VSCodeDivider, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import "./index.css";
 import { ParamData } from "../../models";
@@ -15,13 +15,14 @@ import { DeploymentScopeInputView } from "./sections/DeploymentScopeInputView";
 import { FormSection } from "./sections/FormSection";
 
 export const App: FC = () => {
-  const messages = useMessageHandler();
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const messages = useMessageHandler({ setErrorMessage });
   const azure = useAzure({
     scope: messages.scope,
     acquireAccessToken: messages.acquireAccessToken,
     templateMetadata: messages.templateMetadata,
     parametersMetadata: messages.paramsMetadata,
-    showErrorDialog: messages.showErrorDialog
+    setErrorMessage
   });
 
   function setParamValue(key: string, data: ParamData) {
@@ -67,6 +68,17 @@ export const App: FC = () => {
         onPickParametersFile={messages.pickParamsFile} />
 
       <FormSection title="Actions">
+        {errorMessage && <div
+          style={{
+            color: "var(--vscode-statusBarItem-errorForeground)",
+            backgroundColor: "var(--vscode-statusBarItem-errorBackground)",
+            padding: '5px 10px',
+            borderRadius: '4px',
+            fontSize: '14px',
+            alignSelf: 'center'
+          }}>
+          {errorMessage}
+        </div>}
         <div className="controls">
           <VSCodeButton onClick={handleDeployClick} disabled={azureDisabled}>Deploy</VSCodeButton>
           <VSCodeButton onClick={handleValidateClick} disabled={azureDisabled}>Validate</VSCodeButton>

--- a/src/vscode-bicep/src/panes/deploy/app/components/ParamInputBox.tsx
+++ b/src/vscode-bicep/src/panes/deploy/app/components/ParamInputBox.tsx
@@ -75,7 +75,7 @@ export const ParamInputBox: FC<ParamInputBoxProps> = (props) => {
           <VSCodeTextArea
             className="code-textarea-container"
             resize="vertical"
-            value={JSON.stringify(value, null, 2)}
+            value={value ? JSON.stringify(value, null, 2) : ''}
             onChange={e => handleValueChange(JSON.parse((e.currentTarget as HTMLInputElement).value))}
             disabled={disabled}>
             {name}

--- a/src/vscode-bicep/src/panes/deploy/app/components/hooks/useAzure.ts
+++ b/src/vscode-bicep/src/panes/deploy/app/components/hooks/useAzure.ts
@@ -24,7 +24,7 @@ export interface UseAzureProps {
   templateMetadata?: TemplateMetadata;
   parametersMetadata: ParametersMetadata;
   acquireAccessToken: () => Promise<AccessToken>;
-  showErrorDialog: (callbackId: string, error: UntypedError) => void;
+  setErrorMessage: (message?: string) => void;
 }
 
 export function useAzure(props: UseAzureProps) {
@@ -33,7 +33,7 @@ export function useAzure(props: UseAzureProps) {
     templateMetadata,
     parametersMetadata,
     acquireAccessToken,
-    showErrorDialog,
+    setErrorMessage,
   } = props;
   const deploymentName = "bicep-deploy";
   const [operations, setOperations] = useState<DeploymentOperation[]>();
@@ -66,6 +66,7 @@ export function useAzure(props: UseAzureProps) {
     }
 
     try {
+      setErrorMessage(undefined);
       clearState();
       setRunning(true);
 
@@ -76,8 +77,8 @@ export function useAzure(props: UseAzureProps) {
       const accessToken = await acquireAccessToken();
       const armClient = getArmClient(scope, accessToken);
       await operation(armClient, deployment);
-    } catch (e) {
-      showErrorDialog("doDeploymentOperation", e);
+    } catch (error) {
+      setErrorMessage(`Azure operation failed: ${error}`);
     } finally {
       setRunning(false);
     }

--- a/src/vscode-bicep/src/panes/deploy/messages.ts
+++ b/src/vscode-bicep/src/panes/deploy/messages.ts
@@ -19,19 +19,22 @@ export type DeploymentDataMessage = MessageWithPayload<
   "DEPLOYMENT_DATA",
   {
     documentPath: string;
-    templateJson: string;
+    templateJson?: string;
     parametersJson?: string;
+    errorMessage?: string;
   }
 >;
 export function createDeploymentDataMessage(
   documentPath: string,
-  templateJson: string,
+  templateJson?: string,
   parametersJson?: string,
+  errorMessage?: string,
 ): DeploymentDataMessage {
   return createMessageWithPayload("DEPLOYMENT_DATA", {
     documentPath,
     templateJson,
     parametersJson,
+    errorMessage,
   });
 }
 
@@ -140,23 +143,6 @@ export function createGetDeploymentScopeResultMessage(
   });
 }
 
-export type ShowUserErrorDialogMessage = MessageWithPayload<
-  "SHOW_USER_ERROR_DIALOG",
-  {
-    callbackId: string;
-    error: UntypedError;
-  }
->;
-export function createShowUserErrorDialogMessage(
-  callbackId: string,
-  error: UntypedError,
-): ShowUserErrorDialogMessage {
-  return createMessageWithPayload("SHOW_USER_ERROR_DIALOG", {
-    callbackId,
-    error,
-  });
-}
-
 export type PublishTelemetryMessage = MessageWithPayload<
   "PUBLISH_TELEMETRY",
   {
@@ -188,7 +174,6 @@ export type ViewMessage =
   | PickParamsFileMessage
   | GetAccessTokenMessage
   | GetDeploymentScopeMessage
-  | ShowUserErrorDialogMessage
   | PublishTelemetryMessage;
 
 function createSimpleMessage<T>(kind: T): SimpleMessage<T> {

--- a/src/vscode-bicep/src/panes/deploy/view.ts
+++ b/src/vscode-bicep/src/panes/deploy/view.ts
@@ -5,7 +5,6 @@ import fse from "fs-extra";
 import path from "path";
 import crypto from "crypto";
 import { LanguageClient } from "vscode-languageclient/node";
-
 import {
   createDeploymentDataMessage,
   createGetAccessTokenResultMessage,
@@ -25,7 +24,6 @@ import {
   IActionContext,
 } from "@microsoft/vscode-azext-utils";
 import { GlobalStateKeys } from "../../globalState";
-import { raiseErrorWithoutTelemetry } from "../../utils/telemetry";
 import { DeployPaneState } from "./models";
 
 export class DeployPaneView extends Disposable {
@@ -180,16 +178,13 @@ export class DeployPaneView extends Disposable {
       return;
     }
 
-    if (!deploymentData) {
-      return;
-    }
-
     try {
       await this.webviewPanel.webview.postMessage(
         createDeploymentDataMessage(
           this.documentUri.fsPath,
           deploymentData.templateJson,
           deploymentData.parametersJson,
+          deploymentData.errorMessage,
         ),
       );
     } catch (error) {
@@ -287,10 +282,6 @@ export class DeployPaneView extends Disposable {
           }),
         );
 
-        return;
-      }
-      case "SHOW_USER_ERROR_DIALOG": {
-        await raiseErrorWithoutTelemetry(message.callbackId, message.error);
         return;
       }
       case "PUBLISH_TELEMETRY": {


### PR DESCRIPTION
This change adds the red error box in the below screenshot if there are errors building or deploying a file.

<img width="1290" alt="image" src="https://github.com/Azure/bicep/assets/38542602/2c2d04c0-94e2-47da-9a77-11b0a1582e80">

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11372&drop=dogfoodAlpha