### PR TITLE
Ensure unions with a single member (after deduplication) are compiled correctly

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -10,6 +10,7 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.IntegrationTests;
 
@@ -730,5 +731,23 @@ param myParam string
         {
             ("BCP025", DiagnosticLevel.Error, "The property \"bar\" is declared multiple times in this object. Remove or rename the duplicate properties.")
         });
+    }
+
+    [TestMethod]
+    public void Union_types_with_single_normalized_member_raise_diagnostics()
+    {
+        var result = CompilationHelper.Compile(ServicesWithUserDefinedTypes, """
+            type union = 'a' | 'a'
+            """);
+
+        result.Should().NotHaveAnyDiagnostics();
+
+        result.Template.Should().NotBeNull();
+        result.Template!.Should().HaveValueAtPath("definitions.union", JToken.Parse("""
+            {
+                "type": "string",
+                "allowedValues": ["a"]
+            }
+            """));
     }
 }

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -238,35 +238,26 @@ public class ExpressionBuilder
     }
 
     private TypeExpression ConvertTypeWithoutLowering(SyntaxBase syntax)
-    {
-        switch (Context.SemanticModel.Binder.GetSymbolInfo(syntax))
+        => syntax switch
         {
-            case AmbientTypeSymbol ambientType:
-                return new AmbientTypeReferenceExpression(syntax, ambientType.Name, ambientType.Type);
-            case TypeAliasSymbol typeAlias:
-                return new TypeAliasReferenceExpression(syntax, typeAlias.Name, typeAlias.Type);
-            case Symbol otherwise:
-                throw new ArgumentException($"Encountered unexpected symbol of type {otherwise.GetType()} in a type expression.");
-        }
-
-        switch (Context.SemanticModel.GetTypeInfo(syntax))
-        {
-            case StringLiteralType @string:
-                return new StringLiteralTypeExpression(syntax, @string);
-            case IntegerLiteralType @int:
-                return new IntegerLiteralTypeExpression(syntax, @int);
-            case BooleanLiteralType @bool:
-                return new BooleanLiteralTypeExpression(syntax, @bool);
-            case NullType @null:
-                return new NullLiteralTypeExpression(syntax, @null);
-            case ResourceType resource:
-                return new ResourceTypeExpression(syntax, resource);
-        }
-        var symbol = Context.SemanticModel.GetSymbolInfo(syntax);
-        var typeInfo = Context.SemanticModel.GetTypeInfo(syntax);
-
-        return syntax switch
-        {
+            VariableAccessSyntax variableAccess => Context.SemanticModel.Binder.GetSymbolInfo(syntax) switch
+            {
+                AmbientTypeSymbol ambientType => new AmbientTypeReferenceExpression(syntax, ambientType.Name, ambientType.Type),
+                TypeAliasSymbol typeAlias => new TypeAliasReferenceExpression(syntax, typeAlias.Name, typeAlias.Type),
+                Symbol otherwise => throw new ArgumentException($"Encountered unexpected symbol of type {otherwise.GetType()} in a type expression."),
+                _ => throw new ArgumentException($"Unable to locate symbol for name '{variableAccess.Name.IdentifierName}'.")
+            },
+            StringSyntax @string => new StringLiteralTypeExpression(@string, GetTypeInfo<StringLiteralType>(@string)),
+            IntegerLiteralSyntax @int => new IntegerLiteralTypeExpression(@int, GetTypeInfo<IntegerLiteralType>(@int)),
+            BooleanLiteralSyntax @bool => new BooleanLiteralTypeExpression(@bool, GetTypeInfo<BooleanLiteralType>(@bool)),
+            UnaryOperationSyntax unaryOperation => Context.SemanticModel.GetTypeInfo(unaryOperation) switch
+            {
+                IntegerLiteralType intOperation => new IntegerLiteralTypeExpression(syntax, intOperation),
+                BooleanLiteralType boolOperation => new BooleanLiteralTypeExpression(syntax, boolOperation),
+                _ => throw new ArgumentException($"Failed to convert syntax of type {syntax.GetType()}"),
+            },
+            NullLiteralSyntax @null => new NullLiteralTypeExpression(@null, GetTypeInfo<NullType>(@null)),
+            ResourceTypeSyntax resource => new ResourceTypeExpression(resource, GetTypeInfo<ResourceType>(resource)),
             ObjectTypeSyntax objectTypeSyntax => new ObjectTypeExpression(syntax,
                 GetTypeInfo<ObjectType>(syntax),
                 objectTypeSyntax.Properties.Select(p => ConvertWithoutLowering<ObjectTypePropertyExpression>(p)).ToImmutableArray(),
@@ -280,9 +271,17 @@ public class ExpressionBuilder
                 GetTypeInfo<ArrayType>(syntax),
                 ConvertTypeWithoutLowering(arrayTypeSyntax.Item.Value)),
             NullableTypeSyntax nullableTypeSyntax => new NullableTypeExpression(syntax, ConvertTypeWithoutLowering(nullableTypeSyntax.Base)),
-            UnionTypeSyntax unionTypeSyntax => new UnionTypeExpression(syntax,
-                GetTypeInfo<UnionType>(syntax),
-                unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)).ToImmutableArray()),
+            UnionTypeSyntax unionTypeSyntax when Context.SemanticModel.GetTypeInfo(unionTypeSyntax) is UnionType unionType
+                => new UnionTypeExpression(syntax, unionType, unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)).ToImmutableArray()),
+            UnionTypeSyntax unionTypeSyntax => Context.SemanticModel.GetTypeInfo(unionTypeSyntax) switch
+            {
+                ErrorType errorType => throw new ArgumentException($"Failed to convert syntax of type {syntax.GetType()}"),
+                UnionType unionType => new UnionTypeExpression(syntax, unionType, ImmutableArray.CreateRange(unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)))),
+                // If a union type expression's members all refer to the same literal value, the type of the expression will be a single literal rather than a union
+                TypeSymbol otherwise => new UnionTypeExpression(syntax,
+                    new UnionType(string.Empty, ImmutableArray.Create<ITypeReference>(otherwise)),
+                    ImmutableArray.CreateRange(unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)))),
+            },
             ParenthesizedExpressionSyntax parenthesizedExpression => ConvertTypeWithoutLowering(parenthesizedExpression.Expression),
             NonNullAssertionSyntax nonNullAssertion => new NonNullableTypeExpression(nonNullAssertion, ConvertTypeWithoutLowering(nonNullAssertion.BaseExpression)),
             PropertyAccessSyntax propertyAccess when Context.SemanticModel.GetSymbolInfo(propertyAccess.BaseExpression) is BuiltInNamespaceSymbol namespaceSymbol &&
@@ -291,7 +290,6 @@ public class ExpressionBuilder
                 => new FullyQualifiedAmbientTypeReferenceExpression(propertyAccess, namespaceSymbol.Type.ProviderName, property.Name, property.TypeReference.Type),
             _ => throw new ArgumentException($"Failed to convert syntax of type {syntax.GetType()}"),
         };
-    }
 
     private TExpression ConvertWithoutLowering<TExpression>(SyntaxBase syntax)
         where TExpression : Expression


### PR DESCRIPTION
Resolves #11358 

`TypeHelper.CreateTypeUnion` will deduplicate the supplied member types, so an expression like `type foo = 'foo' | 'foo'` will be assigned a string literal type rather than a union type. This works fine until you get to the TemplateWriter, which expects a `UnionTypeSyntax` node that compiled without errors to be a `UnionType`.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11375&drop=dogfoodAlpha