### PR TITLE
Make decorators order independent

### DIFF
--- a/src/Bicep.Core.Samples/Files/AKS_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/AKS_LF/main.sourcemap.bicep
@@ -37,9 +37,9 @@ param location string = resourceGroup().location
 //@    },
 
 @minValue(0)
-//@      "minValue": 0
+//@      "minValue": 0,
 @maxValue(1023)
-//@      "maxValue": 1023,
+//@      "maxValue": 1023
 param osDiskSizeGB int = 0
 //@    "osDiskSizeGB": {
 //@      "type": "int",
@@ -47,9 +47,9 @@ param osDiskSizeGB int = 0
 //@    },
 
 @minValue(1)
-//@      "minValue": 1
+//@      "minValue": 1,
 @maxValue(50)
-//@      "maxValue": 50,
+//@      "maxValue": 50
 param agentCount int = 3
 //@    "agentCount": {
 //@      "type": "int",

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.bicep
@@ -179,10 +179,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
     utcNow()
     newGuid()

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
@@ -170,6 +170,7 @@ param negativeValues int
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'
+//@[04:015) [no-conflicting-metadata (Warning)] The "description" metadata property conflicts with the "description" decorator and will be overwritten. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-conflicting-metadata)) |description|
     foo: 'something'
     bar: [
         {          }
@@ -208,6 +209,7 @@ param decoratedObject object = {
 
 @sys.metadata({
     description: 'I will be overrode.'
+//@[04:015) [no-conflicting-metadata (Warning)] The "description" metadata property conflicts with the "description" decorator and will be overwritten. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-conflicting-metadata)) |description|
 })
 @sys.maxLength(20)
 @sys.description('An array.')

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.diagnostics.bicep
@@ -207,10 +207,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
 //@[06:020) [no-unused-params (Warning)] Parameter "decoratedArray" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |decoratedArray|
     utcNow()

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.formatted.bicep
@@ -176,10 +176,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-  description: 'An array.'
+  description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
   utcNow()
   newGuid()

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.ir.bicep
@@ -381,16 +381,16 @@ param decoratedObject object = {
 
 @sys.metadata({
 //@[00:0174) └─DeclaredParameterExpression { Name = decoratedArray }
-//@[14:0048)   ├─ObjectExpression
-    description: 'An array.'
-//@[04:0028)   | └─ObjectPropertyExpression
+//@[14:0058)   ├─ObjectExpression
+    description: 'I will be overrode.'
+//@[04:0038)   | └─ObjectPropertyExpression
 //@[04:0015)   |   ├─StringLiteralExpression { Value = description }
-//@[17:0028)   |   └─StringLiteralExpression { Value = An array. }
+//@[17:0038)   |   └─StringLiteralExpression { Value = I will be overrode. }
 })
 @sys.maxLength(20)
 //@[15:0017)   ├─IntegerLiteralExpression { Value = 20 }
-@sys.description('I will be overrode.')
-//@[17:0038)   ├─StringLiteralExpression { Value = I will be overrode. }
+@sys.description('An array.')
+//@[17:0028)   ├─StringLiteralExpression { Value = An array. }
 param decoratedArray array = [
 //@[21:0026)   ├─AmbientTypeReferenceExpression { Name = array }
 //@[29:0062)   └─ArrayExpression

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.pprint.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.pprint.bicep
@@ -154,9 +154,9 @@ param decoratedObject object = {
 
 @sys.metadata(
   {
-    description: 'An array.'
+    description: 'I will be overrode.'
   }
 )
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [utcNow(), newGuid()]

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.sourcemap.bicep
@@ -136,9 +136,9 @@ param storageSku string
 
 // length constraint on a string
 @minLength(3)
-//@      "minLength": 3
+//@      "minLength": 3,
 @maxLength(24)
-//@      "maxLength": 24,
+//@      "maxLength": 24
 param storageName string
 //@    "storageName": {
 //@      "type": "string",
@@ -146,9 +146,9 @@ param storageName string
 
 // length constraint on an array
 @minLength(3)
-//@      "minLength": 3
+//@      "minLength": 3,
 @maxLength(24)
-//@      "maxLength": 24,
+//@      "maxLength": 24
 param someArray array
 //@    "someArray": {
 //@      "type": "array",
@@ -212,9 +212,9 @@ param additionalMetadata string
 @secure()
 //@      "type": "securestring",
 @minLength(3)
-//@      "minLength": 3
+//@      "minLength": 3,
 @maxLength(24)
-//@      "maxLength": 24,
+//@      "maxLength": 24
 @allowed([
 //@      "allowedValues": [
 //@      ],
@@ -273,9 +273,9 @@ param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 @secure()
 //@      "type": "securestring",
 @minLength(2)
-//@      "minLength": 2
+//@      "minLength": 2,
   @maxLength(10)
-//@      "maxLength": 10,
+//@      "maxLength": 10
 @allowed([
 //@      "allowedValues": [
 //@      ],
@@ -298,9 +298,9 @@ param decoratedInt int = 123
 
 // negative integer literals are allowed as decorator values
 @minValue(-10)
-//@      "minValue": -10
+//@      "minValue": -10,
 @maxValue(-3)
-//@      "maxValue": -3,
+//@      "maxValue": -3
 param negativeValues int
 //@    "negativeValues": {
 //@      "type": "int",
@@ -380,14 +380,14 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
-//@        "description": "An array."
+//@      "metadata": {
+//@      },
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
 //@      "maxLength": 20
-@sys.description('I will be overrode.')
-//@      "metadata": {
-//@      },
+@sys.description('An array.')
+//@        "description": "An array."
 param decoratedArray array = [
 //@    "decoratedArray": {
 //@      "type": "array",

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.symbols.bicep
@@ -207,10 +207,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
 //@[6:20) Parameter decoratedArray. Type: array. Declaration start char: 0, length: 174
     utcNow()

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.syntax.bicep
@@ -1165,9 +1165,9 @@ param decoratedObject object = {
 
 @sys.metadata({
 //@[00:0174) ├─ParameterDeclarationSyntax
-//@[00:0049) | ├─DecoratorSyntax
+//@[00:0059) | ├─DecoratorSyntax
 //@[00:0001) | | ├─Token(At) |@|
-//@[01:0049) | | └─InstanceFunctionCallSyntax
+//@[01:0059) | | └─InstanceFunctionCallSyntax
 //@[01:0004) | |   ├─VariableAccessSyntax
 //@[01:0004) | |   | └─IdentifierSyntax
 //@[01:0004) | |   |   └─Token(Identifier) |sys|
@@ -1175,18 +1175,18 @@ param decoratedObject object = {
 //@[05:0013) | |   ├─IdentifierSyntax
 //@[05:0013) | |   | └─Token(Identifier) |metadata|
 //@[13:0014) | |   ├─Token(LeftParen) |(|
-//@[14:0048) | |   ├─FunctionArgumentSyntax
-//@[14:0048) | |   | └─ObjectSyntax
+//@[14:0058) | |   ├─FunctionArgumentSyntax
+//@[14:0058) | |   | └─ObjectSyntax
 //@[14:0015) | |   |   ├─Token(LeftBrace) |{|
 //@[15:0017) | |   |   ├─Token(NewLine) |\r\n|
-    description: 'An array.'
-//@[04:0028) | |   |   ├─ObjectPropertySyntax
+    description: 'I will be overrode.'
+//@[04:0038) | |   |   ├─ObjectPropertySyntax
 //@[04:0015) | |   |   | ├─IdentifierSyntax
 //@[04:0015) | |   |   | | └─Token(Identifier) |description|
 //@[15:0016) | |   |   | ├─Token(Colon) |:|
-//@[17:0028) | |   |   | └─StringSyntax
-//@[17:0028) | |   |   |   └─Token(StringComplete) |'An array.'|
-//@[28:0030) | |   |   ├─Token(NewLine) |\r\n|
+//@[17:0038) | |   |   | └─StringSyntax
+//@[17:0038) | |   |   |   └─Token(StringComplete) |'I will be overrode.'|
+//@[38:0040) | |   |   ├─Token(NewLine) |\r\n|
 })
 //@[00:0001) | |   |   └─Token(RightBrace) |}|
 //@[01:0002) | |   └─Token(RightParen) |)|
@@ -1207,10 +1207,10 @@ param decoratedObject object = {
 //@[15:0017) | |   |   └─Token(Integer) |20|
 //@[17:0018) | |   └─Token(RightParen) |)|
 //@[18:0020) | ├─Token(NewLine) |\r\n|
-@sys.description('I will be overrode.')
-//@[00:0039) | ├─DecoratorSyntax
+@sys.description('An array.')
+//@[00:0029) | ├─DecoratorSyntax
 //@[00:0001) | | ├─Token(At) |@|
-//@[01:0039) | | └─InstanceFunctionCallSyntax
+//@[01:0029) | | └─InstanceFunctionCallSyntax
 //@[01:0004) | |   ├─VariableAccessSyntax
 //@[01:0004) | |   | └─IdentifierSyntax
 //@[01:0004) | |   |   └─Token(Identifier) |sys|
@@ -1218,11 +1218,11 @@ param decoratedObject object = {
 //@[05:0016) | |   ├─IdentifierSyntax
 //@[05:0016) | |   | └─Token(Identifier) |description|
 //@[16:0017) | |   ├─Token(LeftParen) |(|
-//@[17:0038) | |   ├─FunctionArgumentSyntax
-//@[17:0038) | |   | └─StringSyntax
-//@[17:0038) | |   |   └─Token(StringComplete) |'I will be overrode.'|
-//@[38:0039) | |   └─Token(RightParen) |)|
-//@[39:0041) | ├─Token(NewLine) |\r\n|
+//@[17:0028) | |   ├─FunctionArgumentSyntax
+//@[17:0028) | |   | └─StringSyntax
+//@[17:0028) | |   |   └─Token(StringComplete) |'An array.'|
+//@[28:0029) | |   └─Token(RightParen) |)|
+//@[29:0031) | ├─Token(NewLine) |\r\n|
 param decoratedArray array = [
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0020) | ├─IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_CRLF/main.tokens.bicep
@@ -742,11 +742,11 @@ param decoratedObject object = {
 //@[13:14) LeftParen |(|
 //@[14:15) LeftBrace |{|
 //@[15:17) NewLine |\r\n|
-    description: 'An array.'
+    description: 'I will be overrode.'
 //@[04:15) Identifier |description|
 //@[15:16) Colon |:|
-//@[17:28) StringComplete |'An array.'|
-//@[28:30) NewLine |\r\n|
+//@[17:38) StringComplete |'I will be overrode.'|
+//@[38:40) NewLine |\r\n|
 })
 //@[00:01) RightBrace |}|
 //@[01:02) RightParen |)|
@@ -760,15 +760,15 @@ param decoratedObject object = {
 //@[15:17) Integer |20|
 //@[17:18) RightParen |)|
 //@[18:20) NewLine |\r\n|
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 //@[00:01) At |@|
 //@[01:04) Identifier |sys|
 //@[04:05) Dot |.|
 //@[05:16) Identifier |description|
 //@[16:17) LeftParen |(|
-//@[17:38) StringComplete |'I will be overrode.'|
-//@[38:39) RightParen |)|
-//@[39:41) NewLine |\r\n|
+//@[17:28) StringComplete |'An array.'|
+//@[28:29) RightParen |)|
+//@[29:31) NewLine |\r\n|
 param decoratedArray array = [
 //@[00:05) Identifier |param|
 //@[06:20) Identifier |decoratedArray|

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.bicep
@@ -199,10 +199,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
     utcNow()
     newGuid()

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
@@ -228,10 +228,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
 //@[06:020) [no-unused-params (Warning)] Parameter "decoratedArray" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |decoratedArray|
     utcNow()

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.diagnostics.bicep
@@ -18,6 +18,7 @@ param myBool bool
 @sys.description('this is myString2')
 @metadata({
   description: 'overwrite but still valid'
+//@[02:013) [no-conflicting-metadata (Warning)] The "description" metadata property conflicts with the "description" decorator and will be overwritten. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-conflicting-metadata)) |description|
 })
 param myString2 string = 'string value'
 //@[06:015) [no-unused-params (Warning)] Parameter "myString2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |myString2|
@@ -34,6 +35,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 @sys.description('this is foo')
 @metadata({
   description: 'overwrite but still valid'
+//@[02:013) [no-conflicting-metadata (Warning)] The "description" metadata property conflicts with the "description" decorator and will be overwritten. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-conflicting-metadata)) |description|
   another: 'just for fun'
 })
 param foo object = {
@@ -191,6 +193,7 @@ param negativeValues int
 @sys.description('A boolean.')
 @metadata({
     description: 'I will be overrode.'
+//@[04:015) [no-conflicting-metadata (Warning)] The "description" metadata property conflicts with the "description" decorator and will be overwritten. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-conflicting-metadata)) |description|
     foo: 'something'
     bar: [
         {          }
@@ -229,6 +232,7 @@ param decoratedObject object = {
 
 @sys.metadata({
     description: 'I will be overrode.'
+//@[04:015) [no-conflicting-metadata (Warning)] The "description" metadata property conflicts with the "description" decorator and will be overwritten. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-conflicting-metadata)) |description|
 })
 @sys.maxLength(20)
 @sys.description('An array.')

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.formatted.bicep
@@ -196,10 +196,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-  description: 'An array.'
+  description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
   utcNow()
   newGuid()

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.ir.bicep
@@ -417,16 +417,16 @@ param decoratedObject object = {
 
 @sys.metadata({
 //@[000:0166) └─DeclaredParameterExpression { Name = decoratedArray }
-//@[014:0046)   ├─ObjectExpression
-    description: 'An array.'
-//@[004:0028)   | └─ObjectPropertyExpression
+//@[014:0056)   ├─ObjectExpression
+    description: 'I will be overrode.'
+//@[004:0038)   | └─ObjectPropertyExpression
 //@[004:0015)   |   ├─StringLiteralExpression { Value = description }
-//@[017:0028)   |   └─StringLiteralExpression { Value = An array. }
+//@[017:0038)   |   └─StringLiteralExpression { Value = I will be overrode. }
 })
 @sys.maxLength(20)
 //@[015:0017)   ├─IntegerLiteralExpression { Value = 20 }
-@sys.description('I will be overrode.')
-//@[017:0038)   ├─StringLiteralExpression { Value = I will be overrode. }
+@sys.description('An array.')
+//@[017:0028)   ├─StringLiteralExpression { Value = An array. }
 param decoratedArray array = [
 //@[021:0026)   ├─AmbientTypeReferenceExpression { Name = array }
 //@[029:0059)   └─ArrayExpression

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.pprint.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.pprint.bicep
@@ -174,9 +174,9 @@ param decoratedObject object = {
 
 @sys.metadata(
   {
-    description: 'An array.'
+    description: 'I will be overrode.'
   }
 )
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [utcNow(), newGuid()]

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.sourcemap.bicep
@@ -174,9 +174,9 @@ param intEnum int
 
 // length constraint on a string
 @minLength(3)
-//@      "minLength": 3
+//@      "minLength": 3,
 @maxLength(24)
-//@      "maxLength": 24,
+//@      "maxLength": 24
 param storageName string
 //@    "storageName": {
 //@      "type": "string",
@@ -184,9 +184,9 @@ param storageName string
 
 // length constraint on an array
 @minLength(3)
-//@      "minLength": 3
+//@      "minLength": 3,
 @maxLength(24)
-//@      "maxLength": 24,
+//@      "maxLength": 24
 param someArray array
 //@    "someArray": {
 //@      "type": "array",
@@ -250,9 +250,9 @@ param additionalMetadata string
 @secure()
 //@      "type": "securestring",
 @minLength(3)
-//@      "minLength": 3
+//@      "minLength": 3,
 @maxLength(24)
-//@      "maxLength": 24,
+//@      "maxLength": 24
 @allowed([
 //@      "allowedValues": [
 //@      ],
@@ -311,9 +311,9 @@ param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 @secure()
 //@      "type": "securestring",
 @minLength(2)
-//@      "minLength": 2
+//@      "minLength": 2,
   @maxLength(10)
-//@      "maxLength": 10,
+//@      "maxLength": 10
 @allowed([
 //@      "allowedValues": [
 //@      ],
@@ -336,9 +336,9 @@ param decoratedInt int = 123
 
 // negative integer literals are allowed as decorator values
 @minValue(-10)
-//@      "minValue": -10
+//@      "minValue": -10,
 @maxValue(-3)
-//@      "maxValue": -3,
+//@      "maxValue": -3
 param negativeValues int
 //@    "negativeValues": {
 //@      "type": "int",
@@ -418,14 +418,14 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
-//@        "description": "An array."
+//@      "metadata": {
+//@      },
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
 //@      "maxLength": 20
-@sys.description('I will be overrode.')
-//@      "metadata": {
-//@      },
+@sys.description('An array.')
+//@        "description": "An array."
 param decoratedArray array = [
 //@    "decoratedArray": {
 //@      "type": "array",

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.symbols.bicep
@@ -228,10 +228,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
 //@[6:20) Parameter decoratedArray. Type: array. Declaration start char: 0, length: 166
     utcNow()

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.syntax.bicep
@@ -1310,9 +1310,9 @@ param decoratedObject object = {
 
 @sys.metadata({
 //@[000:0166) ├─ParameterDeclarationSyntax
-//@[000:0047) | ├─DecoratorSyntax
+//@[000:0057) | ├─DecoratorSyntax
 //@[000:0001) | | ├─Token(At) |@|
-//@[001:0047) | | └─InstanceFunctionCallSyntax
+//@[001:0057) | | └─InstanceFunctionCallSyntax
 //@[001:0004) | |   ├─VariableAccessSyntax
 //@[001:0004) | |   | └─IdentifierSyntax
 //@[001:0004) | |   |   └─Token(Identifier) |sys|
@@ -1320,18 +1320,18 @@ param decoratedObject object = {
 //@[005:0013) | |   ├─IdentifierSyntax
 //@[005:0013) | |   | └─Token(Identifier) |metadata|
 //@[013:0014) | |   ├─Token(LeftParen) |(|
-//@[014:0046) | |   ├─FunctionArgumentSyntax
-//@[014:0046) | |   | └─ObjectSyntax
+//@[014:0056) | |   ├─FunctionArgumentSyntax
+//@[014:0056) | |   | └─ObjectSyntax
 //@[014:0015) | |   |   ├─Token(LeftBrace) |{|
 //@[015:0016) | |   |   ├─Token(NewLine) |\n|
-    description: 'An array.'
-//@[004:0028) | |   |   ├─ObjectPropertySyntax
+    description: 'I will be overrode.'
+//@[004:0038) | |   |   ├─ObjectPropertySyntax
 //@[004:0015) | |   |   | ├─IdentifierSyntax
 //@[004:0015) | |   |   | | └─Token(Identifier) |description|
 //@[015:0016) | |   |   | ├─Token(Colon) |:|
-//@[017:0028) | |   |   | └─StringSyntax
-//@[017:0028) | |   |   |   └─Token(StringComplete) |'An array.'|
-//@[028:0029) | |   |   ├─Token(NewLine) |\n|
+//@[017:0038) | |   |   | └─StringSyntax
+//@[017:0038) | |   |   |   └─Token(StringComplete) |'I will be overrode.'|
+//@[038:0039) | |   |   ├─Token(NewLine) |\n|
 })
 //@[000:0001) | |   |   └─Token(RightBrace) |}|
 //@[001:0002) | |   └─Token(RightParen) |)|
@@ -1352,10 +1352,10 @@ param decoratedObject object = {
 //@[015:0017) | |   |   └─Token(Integer) |20|
 //@[017:0018) | |   └─Token(RightParen) |)|
 //@[018:0019) | ├─Token(NewLine) |\n|
-@sys.description('I will be overrode.')
-//@[000:0039) | ├─DecoratorSyntax
+@sys.description('An array.')
+//@[000:0029) | ├─DecoratorSyntax
 //@[000:0001) | | ├─Token(At) |@|
-//@[001:0039) | | └─InstanceFunctionCallSyntax
+//@[001:0029) | | └─InstanceFunctionCallSyntax
 //@[001:0004) | |   ├─VariableAccessSyntax
 //@[001:0004) | |   | └─IdentifierSyntax
 //@[001:0004) | |   |   └─Token(Identifier) |sys|
@@ -1363,11 +1363,11 @@ param decoratedObject object = {
 //@[005:0016) | |   ├─IdentifierSyntax
 //@[005:0016) | |   | └─Token(Identifier) |description|
 //@[016:0017) | |   ├─Token(LeftParen) |(|
-//@[017:0038) | |   ├─FunctionArgumentSyntax
-//@[017:0038) | |   | └─StringSyntax
-//@[017:0038) | |   |   └─Token(StringComplete) |'I will be overrode.'|
-//@[038:0039) | |   └─Token(RightParen) |)|
-//@[039:0040) | ├─Token(NewLine) |\n|
+//@[017:0028) | |   ├─FunctionArgumentSyntax
+//@[017:0028) | |   | └─StringSyntax
+//@[017:0028) | |   |   └─Token(StringComplete) |'An array.'|
+//@[028:0029) | |   └─Token(RightParen) |)|
+//@[029:0030) | ├─Token(NewLine) |\n|
 param decoratedArray array = [
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0020) | ├─IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/Parameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Parameters_LF/main.tokens.bicep
@@ -832,11 +832,11 @@ param decoratedObject object = {
 //@[013:014) LeftParen |(|
 //@[014:015) LeftBrace |{|
 //@[015:016) NewLine |\n|
-    description: 'An array.'
+    description: 'I will be overrode.'
 //@[004:015) Identifier |description|
 //@[015:016) Colon |:|
-//@[017:028) StringComplete |'An array.'|
-//@[028:029) NewLine |\n|
+//@[017:038) StringComplete |'I will be overrode.'|
+//@[038:039) NewLine |\n|
 })
 //@[000:001) RightBrace |}|
 //@[001:002) RightParen |)|
@@ -850,15 +850,15 @@ param decoratedObject object = {
 //@[015:017) Integer |20|
 //@[017:018) RightParen |)|
 //@[018:019) NewLine |\n|
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 //@[000:001) At |@|
 //@[001:004) Identifier |sys|
 //@[004:005) Dot |.|
 //@[005:016) Identifier |description|
 //@[016:017) LeftParen |(|
-//@[017:038) StringComplete |'I will be overrode.'|
-//@[038:039) RightParen |)|
-//@[039:040) NewLine |\n|
+//@[017:028) StringComplete |'An array.'|
+//@[028:029) RightParen |)|
+//@[029:030) NewLine |\n|
 param decoratedArray array = [
 //@[000:005) Identifier |param|
 //@[006:020) Identifier |decoratedArray|

--- a/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/TypeDeclarations_LF/main.sourcemap.bicep
@@ -11,13 +11,13 @@ type foo = {
 //@      },
 //@    },
   @minLength(3)
-//@          "minLength": 3
+//@          "minLength": 3,
   @maxLength(10)
 //@          "maxLength": 10,
   @description('A string property')
 //@          "metadata": {
 //@            "description": "A string property"
-//@          },
+//@          }
   stringProp: string
 //@        "stringProp": {
 //@          "type": "string",
@@ -290,9 +290,9 @@ type stringStringDictionary = {
 }
 
 @minValue(1)
-//@      "minValue": 1
+//@      "minValue": 1,
 @maxValue(10)
-//@      "maxValue": 10,
+//@      "maxValue": 10
 type constrainedInt = int
 //@    "constrainedInt": {
 //@      "type": "int",

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Parameters/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Parameters/main.bicep
@@ -192,10 +192,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
     utcNow()
     newGuid()

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Parameters/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Parameters/main.bicep
@@ -208,10 +208,10 @@ param decoratedObject object = {
 }
 
 @sys.metadata({
-    description: 'An array.'
+    description: 'I will be overrode.'
 })
 @sys.maxLength(20)
-@sys.description('I will be overrode.')
+@sys.description('An array.')
 param decoratedArray array = [
     utcNow()
     newGuid()

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16249158578455604981"
+      "templateHash": "15585322861441161766"
     }
   },
   "parameters": {
@@ -425,11 +425,11 @@
     "numDataDisks": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
+      "maxValue": 64,
       "metadata": {
         "description": "Specifies the number of data disks of the virtual machine."
-      },
-      "maxValue": 64,
-      "minValue": 0
+      }
     },
     "osDiskSize": {
       "type": "int",
@@ -1164,11 +1164,11 @@
             "numDataDisks": {
               "type": "int",
               "defaultValue": 1,
+              "minValue": 0,
+              "maxValue": 64,
               "metadata": {
                 "description": "Specifies the number of data disks of the virtual machine."
-              },
-              "maxValue": 64,
-              "minValue": 0
+              }
             },
             "osDiskSize": {
               "type": "int",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -7,7 +7,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14082633431494757834"
+      "templateHash": "8526612719250933722"
     }
   },
   "parameters": {
@@ -427,11 +427,11 @@
     "numDataDisks": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
+      "maxValue": 64,
       "metadata": {
         "description": "Specifies the number of data disks of the virtual machine."
-      },
-      "maxValue": 64,
-      "minValue": 0
+      }
     },
     "osDiskSize": {
       "type": "int",
@@ -1201,11 +1201,11 @@
             "numDataDisks": {
               "type": "int",
               "defaultValue": 1,
+              "minValue": 0,
+              "maxValue": 64,
               "metadata": {
                 "description": "Specifies the number of data disks of the virtual machine."
-              },
-              "maxValue": 64,
-              "minValue": 0
+              }
             },
             "osDiskSize": {
               "type": "int",

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoConflictingMetadataRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoConflictingMetadataRuleTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Analyzers.Linter.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
+
+[TestClass]
+public class NoConflictingMetadataRuleTests : LinterRuleTestsBase
+{
+    private void CompileAndTest(string text, int expectedDiagnosticCount, Options? options = null)
+    {
+        AssertLinterRuleDiagnostics(NoConflictingMetadataRule.Code, text, expectedDiagnosticCount, options);
+    }
+
+    [DataRow("""
+        @metadata({
+            description: 'Description set in metadata'
+        })
+        @description('Description set via decorator')
+        param p string
+        """)]
+    [DataTestMethod]
+    public void If_UsesBothMetadataPropertyAndConflictingDecorator_ShouldRaise(string text)
+    {
+        CompileAndTest(text, 1);
+    }
+
+    [DataRow("""
+        @metadata({
+            description: 'Description set in metadata'
+        })
+        param p string
+        """)]
+    [DataTestMethod]
+    public void If_UsesBothMetadataPropertyWithoutConflictingDecorator_ShouldNotRaise(string text)
+    {
+        CompileAndTest(text, 0);
+    }
+}

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoConflictingMetadataRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoConflictingMetadataRule.cs
@@ -75,9 +75,8 @@ public sealed class NoConflictingMetadataRule : LinterRuleBase
         }
 
         private ObjectSyntax? GetMetadataObject(DecorableSyntax syntax)
-            => SemanticModelHelper.TryGetDecoratorInNamespace(model, syntax, SystemNamespaceType.BuiltInName, LanguageConstants.ParameterMetadataPropertyName) is {} mdDecorator &&
-                mdDecorator.Arguments.FirstOrDefault()?.Expression is ObjectSyntax objectArgument
-                    ? objectArgument
-                    : null;
+            => SemanticModelHelper.TryGetDecoratorInNamespace(model, syntax, SystemNamespaceType.BuiltInName, LanguageConstants.ParameterMetadataPropertyName) is {} mdDecorator
+                ? mdDecorator.Arguments.FirstOrDefault()?.Expression as ObjectSyntax
+                : null;
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoConflictingMetadataRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoConflictingMetadataRule.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Syntax;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.Analyzers.Linter.Rules;
+
+public sealed class NoConflictingMetadataRule : LinterRuleBase
+{
+    public new const string Code = "no-conflicting-metadata";
+
+    public NoConflictingMetadataRule() : base(
+        code: Code,
+        description: CoreResources.NoConflictingMetadataRuleDescription,
+        docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"),
+        diagnosticLevel: DiagnosticLevel.Warning) {}
+
+    public override string FormatMessage(params object[] values)
+        => string.Format(CoreResources.NoConflictingMetadataRuleMessageFormat, values);
+
+    public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
+        => Visitor.FindMetadataPropertiesInConflictWithDecorators(model)
+            .Select(conflict => CreateDiagnosticForSpan(diagnosticLevel,
+                conflict.OffendingMetadataProperty.Key.Span,
+                conflict.ConflictInfo.MetadataPropertyName,
+                conflict.ConflictInfo.DecoratorName));
+
+    private record MetadataPropertySetByDecorator(string MetadataPropertyName, string DecoratorNamespace, string DecoratorName) {}
+
+    private class Visitor : AstVisitor
+    {
+        private static readonly ImmutableArray<MetadataPropertySetByDecorator> metadataPropertySetByDecorators = ImmutableArray.CreateRange(new MetadataPropertySetByDecorator[]
+        {
+            new(LanguageConstants.MetadataDescriptionPropertyName, SystemNamespaceType.BuiltInName, LanguageConstants.MetadataDescriptionPropertyName),
+        });
+
+        private readonly List<(ObjectPropertySyntax, MetadataPropertySetByDecorator)> metadataPropertiesInConflictWithDecorators = new();
+        private readonly SemanticModel model;
+
+        private Visitor(SemanticModel model)
+        {
+            this.model = model;
+        }
+
+        public static IEnumerable<(ObjectPropertySyntax OffendingMetadataProperty, MetadataPropertySetByDecorator ConflictInfo)>
+        FindMetadataPropertiesInConflictWithDecorators(SemanticModel model)
+        {
+            Visitor visitor = new(model);
+            model.SourceFile.ProgramSyntax.Accept(visitor);
+
+            return visitor.metadataPropertiesInConflictWithDecorators;
+        }
+
+        protected override void VisitInternal(SyntaxBase node)
+        {
+            if (node is DecorableSyntax decorable && GetMetadataObject(decorable) is {} metadataObject)
+            {
+                foreach (var potentialConflict in metadataPropertySetByDecorators)
+                {
+                    metadataPropertiesInConflictWithDecorators.AddRange(metadataObject.Properties
+                        .Where(property => property.TryGetKeyText() is string keyName &&
+                            LanguageConstants.IdentifierComparer.Equals(keyName, potentialConflict.MetadataPropertyName) &&
+                            SemanticModelHelper.TryGetDecoratorInNamespace(model, decorable, potentialConflict.DecoratorNamespace, potentialConflict.DecoratorName) is not null)
+                        .Select(property => (property, potentialConflict)));
+                }
+            }
+        }
+
+        private ObjectSyntax? GetMetadataObject(DecorableSyntax syntax)
+            => SemanticModelHelper.TryGetDecoratorInNamespace(model, syntax, SystemNamespaceType.BuiltInName, LanguageConstants.ParameterMetadataPropertyName) is {} mdDecorator &&
+                mdDecorator.Arguments.FirstOrDefault()?.Expression is ObjectSyntax objectArgument
+                    ? objectArgument
+                    : null;
+    }
+}

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -304,6 +304,24 @@ namespace Bicep.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Metadata properties whose value is set by a separate decorator should not be set via the &quot;@metadata()&quot; decorator..
+        /// </summary>
+        internal static string NoConflictingMetadataRuleDescription {
+            get {
+                return ResourceManager.GetString("NoConflictingMetadataRuleDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &quot;{0}&quot; metadata property conflicts with the &quot;{1}&quot; decorator and will be overwritten..
+        /// </summary>
+        internal static string NoConflictingMetadataRuleMessageFormat {
+            get {
+                return ResourceManager.GetString("NoConflictingMetadataRuleMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A resource location should not use a hard-coded string or variable value. Change variable &apos;{0}&apos; into a parameter instead..
         /// </summary>
         internal static string NoHardcodedLocation_ErrorChangeVarToParam {

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -304,7 +304,7 @@ namespace Bicep.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Metadata properties whose value is set by a separate decorator should not be set via the &quot;@metadata()&quot; decorator..
+        ///   Looks up a localized string similar to Metadata properties whose value is set by a separate decorator should not be set via the &apos;@metadata()&apos; decorator..
         /// </summary>
         internal static string NoConflictingMetadataRuleDescription {
             get {

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -440,4 +440,10 @@
   <data name="MaxNumberAssertsRuleMessageFormat" xml:space="preserve">
     <value>Too many predeployment conditions. Number of 'assert' statements is limited to {0}.</value>
   </data>
+  <data name="NoConflictingMetadataRuleDescription" xml:space="preserve">
+    <value>Metadata properties whose value is set by a separate decorator should not be set via the "@metadata()" decorator.</value>
+  </data>
+  <data name="NoConflictingMetadataRuleMessageFormat" xml:space="preserve">
+    <value>The "{0}" metadata property conflicts with the "{1}" decorator and will be overwritten.</value>
+  </data>
 </root>

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -441,7 +441,7 @@
     <value>Too many predeployment conditions. Number of 'assert' statements is limited to {0}.</value>
   </data>
   <data name="NoConflictingMetadataRuleDescription" xml:space="preserve">
-    <value>Metadata properties whose value is set by a separate decorator should not be set via the "@metadata()" decorator.</value>
+    <value>Metadata properties whose value is set by a separate decorator should not be set via the '@metadata()' decorator.</value>
   </data>
   <data name="NoConflictingMetadataRuleMessageFormat" xml:space="preserve">
     <value>The "{0}" metadata property conflicts with the "{1}" decorator and will be overwritten.</value>

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -90,7 +90,7 @@ namespace Bicep.Core.Emit
         {
             return GenerateTemplateWithoutHash(writer.TrackingJsonWriter);
         }
-       
+
 
         private (Template, JToken) GenerateTemplateWithoutHash(PositionTrackingJsonTextWriter jsonWriter)
         {
@@ -183,15 +183,13 @@ namespace Bicep.Core.Emit
             });
         }
 
-        private record TypeModification(Expression? Modifier, Func<ObjectExpression, Expression, ObjectExpression> ModifyFunc) {}
-
-        private ObjectExpression ApplyTypeModifiers(TypeDeclaringExpression expression, ObjectExpression input)
+        private static ObjectExpression ApplyTypeModifiers(TypeDeclaringExpression expression, ObjectExpression input)
         {
-            List<TypeModification> modifications = new();
+            var result = input;
 
-            modifications.Add(new(expression.Secure, (result, secure) =>
+            if (expression.Secure is {} secure)
             {
-                return input.Properties.Where(p => p.Key is StringLiteralExpression { Value: string name} && name == "type").Single().Value switch
+                result = result.Properties.Where(p => p.Key is StringLiteralExpression { Value: string name} && name == "type").Single().Value switch
                 {
                     StringLiteralExpression { Value: string typeName } when typeName == LanguageConstants.TypeNameString
                         => result.MergeProperty("type", ExpressionFactory.CreateStringLiteral("securestring", secure.SourceSyntax)),
@@ -199,10 +197,12 @@ namespace Bicep.Core.Emit
                         => result.MergeProperty("type", ExpressionFactory.CreateStringLiteral("secureObject", secure.SourceSyntax)),
                     _ => result,
                 };
-            }));
+            }
 
-            modifications.Add(new(expression.Sealed,
-                (result, @sealed) => result.MergeProperty("additionalProperties", ExpressionFactory.CreateBooleanLiteral(false, @sealed.SourceSyntax))));
+            if (expression.Sealed is {} @sealed)
+            {
+                result = result.MergeProperty("additionalProperties", ExpressionFactory.CreateBooleanLiteral(false, @sealed.SourceSyntax));
+            }
 
             foreach (var (modifier, propertyName) in new[]
             {
@@ -212,48 +212,13 @@ namespace Bicep.Core.Emit
                 (expression.MinValue, LanguageConstants.ParameterMinValuePropertyName),
                 (expression.MaxValue, LanguageConstants.ParameterMaxValuePropertyName),
             }) {
-                modifications.Add(new(modifier, (result, nonNullModifier) => result.MergeProperty(propertyName, nonNullModifier)));
-            }
-
-            modifications.Add(new(expression.Description, (result, _) => ApplyDescription(expression, result)));
-
-            // Whether one decorator overrides another is determined by their order in the syntax tree
-            // TODO should we change this?
-            if (expression.SourceSyntax is DecorableSyntax decorable)
-            {
-                ConcurrentDictionary<TypeModification, int> modificationIndices = new();
-                int GetIndex(TypeModification modification)
+                if (modifier is not null)
                 {
-                    if (modification.Modifier?.SourceSyntax is {} sourceSyntax)
-                    {
-                        int idx = 0;
-                        foreach (var decorator in decorable.Decorators)
-                        {
-                            if (Context.SemanticModel.Binder.IsDescendant(sourceSyntax, decorator))
-                            {
-                                return idx;
-                            }
-
-                            idx++;
-                        }
-                    }
-
-                    return int.MaxValue;
-                }
-
-                modifications.Sort((a, b) => modificationIndices.GetOrAdd(b, GetIndex) - modificationIndices.GetOrAdd(a, GetIndex));
-            }
-
-            var result = input;
-            foreach (var modification in modifications)
-            {
-                if (modification.Modifier is not null)
-                {
-                    result = modification.ModifyFunc(result, modification.Modifier);
+                    result = result.MergeProperty(propertyName, modifier);
                 }
             }
 
-            return result;
+            return ApplyDescription(expression, result);
         }
 
         private static ObjectExpression ApplyDescription(DescribableExpression expression, ObjectExpression input) => expression.Description is {} description
@@ -333,7 +298,7 @@ namespace Bicep.Core.Emit
                 declaredType.SourceSyntax);
         }
 
-        private ObjectExpression TypePropertiesForTypeExpression(TypeExpression typeExpression) => typeExpression switch
+        private static ObjectExpression TypePropertiesForTypeExpression(TypeExpression typeExpression) => typeExpression switch
         {
             // references
             AmbientTypeReferenceExpression ambientTypeReference
@@ -425,7 +390,7 @@ namespace Bicep.Core.Emit
             });
         }
 
-        private ObjectExpression GetTypePropertiesForArrayType(ArrayTypeExpression expression)
+        private static ObjectExpression GetTypePropertiesForArrayType(ArrayTypeExpression expression)
         {
             var properties = new List<ObjectPropertyExpression> { TypeProperty(LanguageConstants.ArrayType, expression.SourceSyntax) };
 
@@ -458,7 +423,7 @@ namespace Bicep.Core.Emit
         private static ArrayExpression GetAllowedValuesForUnionType(UnionType unionType, SyntaxBase? sourceSyntax)
             => ExpressionFactory.CreateArray(unionType.Members.Select(ToLiteralValue), sourceSyntax);
 
-        private ObjectExpression GetTypePropertiesForObjectType(ObjectTypeExpression expression)
+        private static ObjectExpression GetTypePropertiesForObjectType(ObjectTypeExpression expression)
         {
             var properties = new List<ObjectPropertyExpression> { TypeProperty(LanguageConstants.ObjectType, expression.SourceSyntax) };
             List<ObjectPropertyExpression> propertySchemata = new();
@@ -485,7 +450,7 @@ namespace Bicep.Core.Emit
             return ExpressionFactory.CreateObject(properties, expression.SourceSyntax);
         }
 
-        private ObjectExpression GetTypePropertiesForTupleType(TupleTypeExpression expression) => ExpressionFactory.CreateObject(new[]
+        private static ObjectExpression GetTypePropertiesForTupleType(TupleTypeExpression expression) => ExpressionFactory.CreateObject(new[]
         {
             TypeProperty(LanguageConstants.ArrayType, expression.SourceSyntax),
             ExpressionFactory.CreateObjectProperty("prefixItems",
@@ -729,12 +694,12 @@ namespace Bicep.Core.Emit
                         // should have been caught by earlier validation
                         throw new ArgumentException("Disallowed interpolation in test parameter");
                     }
-                    
+
                     emitter.EmitProperty(keyName, property.Value);
                 }
             }, paramsObject.SourceSyntax);
         }
-        
+
         private void EmitModuleParameters(ExpressionEmitter emitter, DeclaredModuleExpression module)
         {
             if (module.Parameters is not ObjectExpression paramsObject)

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -305,6 +305,16 @@
                     }
                   ]
                 },
+                "no-conflicting-metadata": {
+                  "allOf": [
+                    {
+                      "description": "Metadata properties whose value is set by a separate decorator should not be set via the \"@metadata()\" decorator. See https://aka.ms/bicep/linter/no-conflicting-metadata"
+                    },
+                    {
+                      "$ref": "#/definitions/rule-def-level-warning"
+                    }
+                  ]
+                },
                 "no-hardcoded-env-urls": {
                   "allOf": [
                     {

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -308,7 +308,7 @@
                 "no-conflicting-metadata": {
                   "allOf": [
                     {
-                      "description": "Metadata properties whose value is set by a separate decorator should not be set via the \"@metadata()\" decorator. See https://aka.ms/bicep/linter/no-conflicting-metadata"
+                      "description": "Metadata properties whose value is set by a separate decorator should not be set via the '@metadata()' decorator. See https://aka.ms/bicep/linter/no-conflicting-metadata"
                     },
                     {
                       "$ref": "#/definitions/rule-def-level-warning"


### PR DESCRIPTION
Resolves #11308 

This PR updates the TemplateWriter to apply type modifying decorators in a fixed order rather than one dependent on the order in which the decorators appear in the template's Bicep source. 

Because `@metadata()` and `@description()` may sometimes be in conflict with one another, TemplateWriter will now prefer whatever appears within the `@description()` decorator due to its higher specificity and to match the information shown in hovers/tooltips in such scenarios. A linter has been added that will warn template authors when `@metadata()` and `@description()` are in conflict.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11380&drop=dogfoodAlpha