### PR TITLE
Add check for Powershell Core to baseline script

### DIFF
--- a/scripts/SetBaseline.ps1
+++ b/scripts/SetBaseline.ps1
@@ -1,2 +1,7 @@
-# Use this script if you are using Windows PowerShell
-dotnet test --filter "TestCategory=Baseline" -- 'TestRunParameters.Parameter(name=\"SetBaseLine\", value=\"true\")'
+if (($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')) {
+    # PowerShell Core
+    dotnet test --filter "TestCategory=Baseline" -- 'TestRunParameters.Parameter(name="SetBaseLine", value="true")'
+} else {
+    # PowerShell Desktop
+    dotnet test --filter "TestCategory=Baseline" -- 'TestRunParameters.Parameter(name=\"SetBaseLine\", value=\"true\")'
+}

--- a/scripts/SetBaselineCore.ps1
+++ b/scripts/SetBaselineCore.ps1
@@ -1,2 +1,0 @@
-# Use this script if you are using PowerShell 7+
-dotnet test --filter "TestCategory=Baseline" -- 'TestRunParameters.Parameter(name="SetBaseLine", value="true")'


### PR DESCRIPTION
This change adds a PS edition check to `SetBaseline.ps1`, so that we can just have a single script that'll work on both Core & Desktop editions.

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11426&drop=dogfoodAlpha