### PR TITLE
Raise an error-level diagnostic when two symbols of a given type are differentiated only by casing

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4906,4 +4906,72 @@ param foo = 'asdf'
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
+
+    // https://github.com/Azure/bicep/issues/502
+    [TestMethod]
+    public void Test_Issue502()
+    {
+        var result = CompilationHelper.Compile("""
+            var foo = 1
+            var FoO = 2
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP353", DiagnosticLevel.Error, "The variables \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The variables \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+        });
+
+        result = CompilationHelper.Compile("""
+            param foo int = 1
+            param FoO int = 2
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP353", DiagnosticLevel.Error, "The parameters \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The parameters \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+        });
+
+        result = CompilationHelper.Compile("""
+            output foo int = 1
+            output FoO int = 2
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP353", DiagnosticLevel.Error, "The outputs \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The outputs \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+        });
+
+        result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), """
+            type foo = string
+            type FoO = int
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP353", DiagnosticLevel.Error, "The types \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The types \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+        });
+
+        result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(AssertsEnabled: true)), """
+            assert foo = true
+            assert FoO = true
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP353", DiagnosticLevel.Error, "The asserts \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The asserts \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+        });
+
+        // if the two symbols are of different types, ARM will be able to distinguish between them
+        result = CompilationHelper.Compile("""
+            param foo int = 1
+            var FoO = 2
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
 }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -4918,8 +4918,8 @@ param foo = 'asdf'
 
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
         {
-            ("BCP353", DiagnosticLevel.Error, "The variables \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
-            ("BCP353", DiagnosticLevel.Error, "The variables \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The variables \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The variables \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
         });
 
         result = CompilationHelper.Compile("""
@@ -4929,8 +4929,8 @@ param foo = 'asdf'
 
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
         {
-            ("BCP353", DiagnosticLevel.Error, "The parameters \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
-            ("BCP353", DiagnosticLevel.Error, "The parameters \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The parameters \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The parameters \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
         });
 
         result = CompilationHelper.Compile("""
@@ -4940,8 +4940,8 @@ param foo = 'asdf'
 
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
         {
-            ("BCP353", DiagnosticLevel.Error, "The outputs \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
-            ("BCP353", DiagnosticLevel.Error, "The outputs \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The outputs \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The outputs \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
         });
 
         result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(UserDefinedTypesEnabled: true)), """
@@ -4951,8 +4951,8 @@ param foo = 'asdf'
 
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
         {
-            ("BCP353", DiagnosticLevel.Error, "The types \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
-            ("BCP353", DiagnosticLevel.Error, "The types \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The types \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The types \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
         });
 
         result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(AssertsEnabled: true)), """
@@ -4962,8 +4962,8 @@ param foo = 'asdf'
 
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
         {
-            ("BCP353", DiagnosticLevel.Error, "The asserts \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
-            ("BCP353", DiagnosticLevel.Error, "The asserts \"foo\" and \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The asserts \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
+            ("BCP353", DiagnosticLevel.Error, "The asserts \"foo\", \"FoO\" differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them."),
         });
 
         // if the two symbols are of different types, ARM will be able to distinguish between them

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1981,10 +1981,10 @@ namespace Bicep.Core.Diagnostics
                 "BCP352",
                 $"Failed to evaluate variable \"{name}\": {message}");
 
-            public ErrorDiagnostic SymbolsMustBeCaseInsensitivelyUnique(string symbolTypePluralName, string[] symbolNames) => new(
+            public ErrorDiagnostic SymbolsMustBeCaseInsensitivelyUnique(string symbolTypePluralName, IEnumerable<string> symbolNames) => new(
                 TextSpan,
                 "BCP353",
-                $"The {symbolTypePluralName} {SentenceJoin(symbolNames, quoteChar: '"')} differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them.");
+                $"The {symbolTypePluralName} {ToQuotedString(symbolNames)} differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)
@@ -1995,33 +1995,5 @@ namespace Bicep.Core.Diagnostics
 
         public static DiagnosticBuilderInternal ForDocumentStart()
             => new(TextSpan.TextDocumentStart);
-
-        /// <summary>
-        /// Joins zero or more strings together into a list suitable for use in an English sentence, with an option to quote each item.
-        /// </summary>
-        /// <remarks>
-        /// This method follows Strunk and White rules: no Oxford comma is used, and separating commas will appear within the quotation marks.
-        /// </remarks>
-        private static string SentenceJoin(string[] toJoin, char? quoteChar = null)
-        {
-            StringBuilder builder = new();
-            string quote = quoteChar?.ToString() ?? string.Empty;
-
-            for (int i = 0; i < toJoin.Length; i++)
-            {
-                builder.Append(quoteChar).Append(toJoin[i]);
-                if (i < toJoin.Length - 2)
-                {
-                    builder.Append(',');
-                }
-                builder.Append(quoteChar);
-                if (i == toJoin.Length - 2)
-                {
-                    builder.Append(" and ");
-                }
-            }
-
-            return builder.ToString();
-        }
     }
 }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1980,6 +1980,11 @@ namespace Bicep.Core.Diagnostics
                 TextSpan,
                 "BCP352",
                 $"Failed to evaluate variable \"{name}\": {message}");
+
+            public ErrorDiagnostic SymbolsMustBeCaseInsensitivelyUnique(string symbolTypePluralName, string[] symbolNames) => new(
+                TextSpan,
+                "BCP353",
+                $"The {symbolTypePluralName} {SentenceJoin(symbolNames, quoteChar: '"')} differ only in casing. The ARM deployments engine is not case sensitive and will not be able to distinguish between them.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)
@@ -1990,5 +1995,33 @@ namespace Bicep.Core.Diagnostics
 
         public static DiagnosticBuilderInternal ForDocumentStart()
             => new(TextSpan.TextDocumentStart);
+
+        /// <summary>
+        /// Joins zero or more strings together into a list suitable for use in an English sentence, with an option to quote each item.
+        /// </summary>
+        /// <remarks>
+        /// This method follows Strunk and White rules: no Oxford comma is used, and separating commas will appear within the quotation marks.
+        /// </remarks>
+        private static string SentenceJoin(string[] toJoin, char? quoteChar = null)
+        {
+            StringBuilder builder = new();
+            string quote = quoteChar?.ToString() ?? string.Empty;
+
+            for (int i = 0; i < toJoin.Length; i++)
+            {
+                builder.Append(quoteChar).Append(toJoin[i]);
+                if (i < toJoin.Length - 2)
+                {
+                    builder.Append(',');
+                }
+                builder.Append(quoteChar);
+                if (i == toJoin.Length - 2)
+                {
+                    builder.Append(" and ");
+                }
+            }
+
+            return builder.ToString();
+        }
     }
 }

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -52,6 +52,7 @@ namespace Bicep.Core.Emit
             BlockTestFrameworkWithoutExperimentalFeaure(model, diagnostics);
             BlockUserDefinedTypesWithUserDefinedFunctions(model, diagnostics);
             BlockAssertsWithoutExperimentalFeatures(model, diagnostics);
+            BlockNamesDistinguishedOnlyByCase(model, diagnostics);
             var paramAssignments = CalculateParameterAssignments(model, diagnostics);
 
             return new(diagnostics.GetDiagnostics(), moduleScopeData, resourceScopeData, paramAssignments);
@@ -588,6 +589,31 @@ namespace Bicep.Core.Emit
                 {
                     diagnostics.Write(value, x => x.AssertsUnsupported());
                 }
+            }
+        }
+
+        private static void BlockNamesDistinguishedOnlyByCase(SemanticModel model, IDiagnosticWriter diagnostics)
+        {
+            foreach (var (symbolTypePluralName, symbolsOfType) in new (string, IEnumerable<DeclaredSymbol>)[]
+            {
+                ("parameters", model.Root.ParameterDeclarations),
+                ("variables", model.Root.VariableDeclarations),
+                ("outputs", model.Root.OutputDeclarations),
+                ("types", model.Root.TypeDeclarations),
+                ("asserts", model.Root.AssertDeclarations),
+            })
+            {
+                BlockCaseInsensitiveNameClashes(symbolTypePluralName, symbolsOfType, diagnostics);
+            }
+        }
+
+        private static void BlockCaseInsensitiveNameClashes(string symbolTypePluralName, IEnumerable<DeclaredSymbol> symbolsOfType, IDiagnosticWriter diagnostics)
+        {
+            foreach (var grouping in symbolsOfType.ToLookup(s => s.Name, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1))
+            {
+                var clashingSymbols = grouping.Select(s => s.Name).ToArray();
+                diagnostics.WriteMultiple(grouping.Select(
+                    symbol => DiagnosticBuilder.ForPosition(symbol.NameSource).SymbolsMustBeCaseInsensitivelyUnique(symbolTypePluralName, clashingSymbols)));
             }
         }
     }

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -612,6 +612,13 @@ namespace Bicep.Core.Emit
             foreach (var grouping in symbolsOfType.ToLookup(s => s.Name, StringComparer.OrdinalIgnoreCase).Where(g => g.Count() > 1))
             {
                 var clashingSymbols = grouping.Select(s => s.Name).ToArray();
+
+                // if any symbols are exact matches, a different diagnostic about multiple declarations will have already been raised
+                if (clashingSymbols.Distinct().Count() != clashingSymbols.Length)
+                {
+                    continue;
+                }
+
                 diagnostics.WriteMultiple(grouping.Select(
                     symbol => DiagnosticBuilder.ForPosition(symbol.NameSource).SymbolsMustBeCaseInsensitivelyUnique(symbolTypePluralName, clashingSymbols)));
             }


### PR DESCRIPTION
Resolves #502

Because this change is accounting for an intermediate language limitation, templates that use symbols *of different types* whose names are differ only by casing are still permitted, since the ARM engine uses a separate namespace for each category of symbol.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11453&drop=dogfoodAlpha