### PR TITLE
Refactor AzureContainerRegistryManager

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -125,7 +125,7 @@ namespace Bicep.Cli.IntegrationTests
 
             if (dataSet.HasExternalModules)
             {
-                settings.FeatureOverrides.Should().HaveValidModules();
+                settings.FeatureOverrides.Should().HaveValidCachedModules();
             }
 
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -5,6 +5,7 @@ using Azure;
 using Azure.Containers.ContainerRegistry;
 using Bicep.Core.Configuration;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
@@ -249,7 +250,7 @@ namespace Bicep.Cli.IntegrationTests
             var outputDirectory = dataSet.SaveFilesToTestDirectory(TestContext);
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
 
-            var client = StrictMock.Of<ContainerRegistryContentClient>();
+            var client = StrictMock.Of<IOciRegistryContentClient>();
             client
                 .Setup(m => m.UploadBlobAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new RequestFailedException("Mock registry request failure."));
@@ -281,7 +282,7 @@ namespace Bicep.Cli.IntegrationTests
             var outputDirectory = dataSet.SaveFilesToTestDirectory(TestContext);
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
 
-            var client = StrictMock.Of<ContainerRegistryContentClient>();
+            var client = StrictMock.Of<IOciRegistryContentClient>();
             client
                 .Setup(m => m.UploadBlobAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new AggregateException(new RequestFailedException("Mock registry request failure 1."), new RequestFailedException("Mock registry request failure 2.")));
@@ -372,7 +373,7 @@ namespace Bicep.Cli.IntegrationTests
 
             await DataSetsExtensions.PublishModuleToRegistryAsync(clientFactory.Object, "modulename", $"br:example.com/test/{moduleName}:v1", bicepModuleContents, documentationUri);
 
-            var manifest = Encoding.Default.GetString(blobClient.Manifests.Single().Value.ToBuilder().ToArray());
+            var manifest = blobClient.Manifests.Single().Value.Text;
 
             if (expectedDescription is null)
             {

--- a/src/Bicep.Core.UnitTests/Assertions/FeatureProviderAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/FeatureProviderAssertions.cs
@@ -23,7 +23,7 @@ namespace Bicep.Core.UnitTests.Assertions
 
         protected override string Identifier => "FeatureProvider";
 
-        public AndConstraint<FeatureProviderAssertions> HaveValidModules()
+        public AndConstraint<FeatureProviderAssertions> HaveValidCachedModules()
         {
             // ensure something got restored
             var cacheDir = new DirectoryInfo(this.Subject.CacheRootDirectory!);

--- a/src/Bicep.Core.UnitTests/Registry/MockRegistryBlobClient.cs
+++ b/src/Bicep.Core.UnitTests/Registry/MockRegistryBlobClient.cs
@@ -3,38 +3,46 @@
 
 using Azure;
 using Azure.Containers.ContainerRegistry;
+using Bicep.Core.Json;
 using Bicep.Core.Registry.Oci;
 using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using Moq;
+using SharpYaml.Tokens;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using static Bicep.Core.Emit.ParameterAssignmentEvaluator;
 
 namespace Bicep.Core.UnitTests.Registry
 {
     /// <summary>
     /// Mock OCI registry blob client. This client is intended to represent a single repository within a specific registry Uri.
     /// </summary>
-    public class MockRegistryBlobClient : ContainerRegistryContentClient
+    public class MockRegistryBlobClient : IOciRegistryContentClient
     {
-        public MockRegistryBlobClient() : base()
-        {
-            // ensure we call the base parameterless constructor to prevent outgoing calls
-        }
-
         // maps digest to blob bytes
-        public ConcurrentDictionary<string, ImmutableArray<byte>> Blobs { get; } = new();
+        public ConcurrentDictionary<string, TextBytes> Blobs { get; } = new();
 
         // maps digest to manifest bytes
-        public ConcurrentDictionary<string, ImmutableArray<byte>> Manifests { get; } = new();
+        public ConcurrentDictionary<string, TextBytes> Manifests { get; } = new();
 
         // maps tag to manifest digest
         public ConcurrentDictionary<string, string> ManifestTags { get; } = new();
 
-        public override async Task<Response<DownloadRegistryBlobResult>> DownloadBlobContentAsync(string digest, CancellationToken cancellationToken = default)
+        public IDictionary<string, OciManifest> ManifestObjects =>
+            Manifests.ToDictionary(kvp => kvp.Key, kvp => OciSerialization.Deserialize<OciManifest>(kvp.Value.ToStream()));
+
+        public async Task<Response<DownloadRegistryBlobResult>> DownloadBlobContentAsync(string digest, CancellationToken cancellationToken = default)
         {
             await Task.Yield();
 
@@ -43,10 +51,10 @@ namespace Bicep.Core.UnitTests.Registry
                 throw new RequestFailedException(404, "Mock blob does not exist.");
             }
 
-            return CreateResult(ContainerRegistryModelFactory.DownloadRegistryBlobResult(digest, BinaryData.FromStream(WriteStream(bytes))));
+            return CreateResult(ContainerRegistryModelFactory.DownloadRegistryBlobResult(digest, BinaryData.FromBytes(bytes.ToArray())));
         }
 
-        public override async Task<Response<GetManifestResult>> GetManifestAsync(string tagOrDigest, CancellationToken cancellationToken = default)
+        public async Task<Response<GetManifestResult>> GetManifestAsync(string tagOrDigest, CancellationToken cancellationToken = default)
         {
             await Task.Yield();
 
@@ -69,25 +77,25 @@ namespace Bicep.Core.UnitTests.Registry
             return CreateResult(ContainerRegistryModelFactory.GetManifestResult(
                 digest: digest,
                 mediaType: ManifestMediaType.OciImageManifest.ToString(),
-                manifest: BinaryData.FromStream(WriteStream(bytes))));
+                manifest: BinaryData.FromBytes(bytes.ToArray())));
         }
 
-        public override async Task<Response<UploadRegistryBlobResult>> UploadBlobAsync(Stream stream, CancellationToken cancellationToken = default)
+        public async Task<Response<UploadRegistryBlobResult>> UploadBlobAsync(Stream stream, CancellationToken cancellationToken = default)
         {
             await Task.Yield();
 
             var (copy, digest) = ReadStream(stream);
-            Blobs.TryAdd(digest, copy);
+            Blobs.TryAdd(digest, new TextBytes(copy));
 
             return CreateResult(ContainerRegistryModelFactory.UploadRegistryBlobResult(digest, copy.Length));
         }
 
-        public override async Task<Response<SetManifestResult>> SetManifestAsync(BinaryData manifest, string? tag = default, ManifestMediaType? mediaType = default, CancellationToken cancellationToken = default)
+        public async Task<Response<SetManifestResult>> SetManifestAsync(BinaryData manifest, string? tag = default, ManifestMediaType? mediaType = default, CancellationToken cancellationToken = default)
         {
             await Task.Yield();
 
             var (copy, digest) = ReadStream(manifest.ToStream());
-            Manifests.TryAdd(digest, copy);
+            Manifests.TryAdd(digest, new TextBytes(copy));
 
             if (tag is not null)
             {
@@ -112,17 +120,6 @@ namespace Bicep.Core.UnitTests.Registry
             var bytes = reader.ReadBytes((int)stream.Length).ToImmutableArray();
 
             return (bytes, digest);
-        }
-
-        public static Stream WriteStream(ImmutableArray<byte> bytes)
-        {
-            var stream = new MemoryStream(bytes.Length);
-            var writer = new BinaryWriter(stream, new UTF8Encoding(false), true);
-
-            writer.Write(bytes.AsSpan());
-            stream.Position = 0;
-
-            return stream;
         }
 
         private static Response<T> CreateResult<T>(T value)

--- a/src/Bicep.Core.UnitTests/Utils/TextBytes.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TextBytes.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Bicep.Core.UnitTests.Utils;
+
+/// <summary>
+/// Contains a byte array that represents a UTF-8 encoded string. Makes it easier to view the encoded
+/// string value while debugging.
+/// </summary>
+public class TextBytes
+{
+    private readonly ImmutableArray<byte> _bytes;
+
+    public TextBytes(string text) => _bytes = Encoding.UTF8.GetBytes(text).ToImmutableArray();
+
+    public TextBytes(byte[] bytes) => _bytes = bytes.ToImmutableArray();
+
+    public TextBytes(ImmutableArray<byte> bytes) => _bytes = bytes;
+
+    public ImmutableArray<byte> Bytes => _bytes;
+
+    public byte[] ToArray() => _bytes.ToArray();
+
+    // Left as property to make it easier to use in the debugger
+    public string Text => Encoding.UTF8.GetString(_bytes.ToArray());
+
+    public Stream ToStream()
+    {
+        return new MemoryStream(Bytes.ToArray());
+    }
+
+    public static Stream TextToStream(string text)
+    {
+        return new MemoryStream(Encoding.UTF8.GetBytes(text));
+    }
+
+    public static string StreamToText(Stream stream)
+    {
+        int capacity;
+        checked
+        {
+            capacity = ((int)stream.Length);
+        }
+        var ms = new MemoryStream(capacity);
+
+        stream.Position = 0;
+        stream.CopyTo(ms);
+        ms.Position = 0;
+        stream.Position = 0;
+
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+}

--- a/src/Bicep.Core/Emit/ParametersEmitter.cs
+++ b/src/Bicep.Core/Emit/ParametersEmitter.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 
 namespace Bicep.Core.Emit;
 
+ // Emits bicepparams files
 public class ParametersEmitter
 {
     private readonly SemanticModel model;

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -116,6 +116,8 @@ namespace Bicep.Core
         public const string ListFunctionPrefix = "list";
 
         public const string McrRepositoryPrefix = "bicep/";
+
+        // See https://github.com/opencontainers/image-spec/blob/main/annotations.md
         public const string OciOpenContainerImageDocumentationAnnotation = "org.opencontainers.image.documentation";
         public const string OciOpenContainerImageDescriptionAnnotation = "org.opencontainers.image.description";
 

--- a/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
+++ b/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
@@ -4,6 +4,7 @@
 using Azure.Containers.ContainerRegistry;
 using Bicep.Core.Configuration;
 using Bicep.Core.Registry.Auth;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.Tracing;
 using System;
 
@@ -18,7 +19,7 @@ namespace Bicep.Core.Registry
             this.credentialFactory = credentialFactory;
         }
 
-        public ContainerRegistryContentClient CreateAuthenticatedBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
+        public IOciRegistryContentClient CreateAuthenticatedBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
         {
             var options = new ContainerRegistryClientOptions();
             options.Diagnostics.ApplySharedContainerRegistrySettings();
@@ -26,16 +27,16 @@ namespace Bicep.Core.Registry
 
             var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.ActiveDirectoryAuthorityUri);
 
-            return new(registryUri, repository, credential, options);
+            return new OciRegistryContentClient(registryUri, repository, credential, options);
         }
 
-        public ContainerRegistryContentClient CreateAnonymousBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
+        public IOciRegistryContentClient CreateAnonymousBlobClient(RootConfiguration configuration, Uri registryUri, string repository)
         {
             var options = new ContainerRegistryClientOptions();
             options.Diagnostics.ApplySharedContainerRegistrySettings();
             options.Audience = new ContainerRegistryAudience(configuration.Cloud.ResourceManagerAudience);
 
-            return new(registryUri, repository, options);
+            return new OciRegistryContentClient(registryUri, repository, options);
         }
     }
 }

--- a/src/Bicep.Core/Registry/ExternalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/ExternalModuleRegistry.cs
@@ -30,13 +30,14 @@ namespace Bicep.Core.Registry
 
         protected IFileResolver FileResolver { get; }
 
-        protected abstract void WriteModuleContent(TModuleReference reference, TModuleEntity entity);
+        // Writes the contents of the downloaded module into the local cache folder
+        protected abstract void WriteModuleContentToCache(TModuleReference reference, TModuleEntity entity);
 
         protected abstract string GetModuleDirectoryPath(TModuleReference reference);
 
         protected abstract Uri GetModuleLockFileUri(TModuleReference reference);
 
-        protected async Task TryWriteModuleContentAsync(TModuleReference reference, TModuleEntity entity)
+        protected async Task TryWriteModuleContentToCacheAsync(TModuleReference reference, TModuleEntity entity)
         {
             // this has to be after downloading the module content so we don't create directories for non-existent modules
             var moduleDirectoryPath = this.GetModuleDirectoryPath(reference);
@@ -71,7 +72,7 @@ namespace Bicep.Core.Registry
                         }
 
                         // write the contents to disk
-                        this.WriteModuleContent(reference, entity);
+                        this.WriteModuleContentToCache(reference, entity);
                         return;
                     }
                 }

--- a/src/Bicep.Core/Registry/IContainerRegistryClientFactory.cs
+++ b/src/Bicep.Core/Registry/IContainerRegistryClientFactory.cs
@@ -3,6 +3,7 @@
 
 using Azure.Containers.ContainerRegistry;
 using Bicep.Core.Configuration;
+using Bicep.Core.Registry.Oci;
 using System;
 
 namespace Bicep.Core.Registry
@@ -13,8 +14,8 @@ namespace Bicep.Core.Registry
     /// <remarks>This exists because we need to inject mock clients in integration tests and because the real client constructor requires parameters.</remarks>
     public interface IContainerRegistryClientFactory
     {
-        ContainerRegistryContentClient CreateAuthenticatedBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
+        IOciRegistryContentClient CreateAuthenticatedBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
 
-        ContainerRegistryContentClient CreateAnonymousBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
+        IOciRegistryContentClient CreateAnonymousBlobClient(RootConfiguration configuration, Uri registryUri, string repository);
     }
 }

--- a/src/Bicep.Core/Registry/Oci/DescriptorFactory.cs
+++ b/src/Bicep.Core/Registry/Oci/DescriptorFactory.cs
@@ -22,6 +22,8 @@ namespace Bicep.Core.Registry.Oci
 
         public static string ComputeDigest(string algorithmIdentifier, Stream stream)
         {
+            stream.Seek(0, SeekOrigin.Begin);
+
             using var algorithm = CreateHashAlgorithm(algorithmIdentifier);
             var hashValue = algorithm.ComputeHash(stream);
 
@@ -33,6 +35,8 @@ namespace Bicep.Core.Registry.Oci
             {
                 buffer.Append(@byte.ToString("x2"));
             }
+
+            stream.Seek(0, SeekOrigin.Begin);
 
             return buffer.ToString();
         }

--- a/src/Bicep.Core/Registry/Oci/IOciRegistryContentClient.cs
+++ b/src/Bicep.Core/Registry/Oci/IOciRegistryContentClient.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure;
+using Azure.Containers.ContainerRegistry;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Registry.Oci;
+
+/// <summary>
+/// Client for interacting with OCI registry content. Makes it possible to mock other functionality that might be addede here.
+/// </summary>
+public interface IOciRegistryContentClient
+{
+    Task<Response<SetManifestResult>> SetManifestAsync(BinaryData manifest, string? tag = default, ManifestMediaType? mediaType = default, CancellationToken cancellationToken = default);
+    Task<Response<UploadRegistryBlobResult>> UploadBlobAsync(Stream content, CancellationToken cancellationToken = default);
+    Task<Response<DownloadRegistryBlobResult>> DownloadBlobContentAsync(string digest, CancellationToken cancellationToken = default);
+    Task<Response<GetManifestResult>> GetManifestAsync(string tagOrDigest, CancellationToken cancellationToken = default);
+}

--- a/src/Bicep.Core/Registry/Oci/OciManifest.cs
+++ b/src/Bicep.Core/Registry/Oci/OciManifest.cs
@@ -4,30 +4,37 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
-namespace Bicep.Core.Registry.Oci
+namespace Bicep.Core.Registry.Oci;
+
+public class OciManifest
 {
-    public class OciManifest
+    public OciManifest(int schemaVersion, string? mediaType, string? artifactType, OciDescriptor config, IEnumerable<OciDescriptor> layers, OciDescriptor? subject = null, IDictionary<string, string>? annotations = null)
     {
-        public OciManifest(int schemaVersion, string? artifactType, OciDescriptor config, IEnumerable<OciDescriptor> layers, IDictionary<string, string>? annotations = null)
-        {
-            this.Annotations = annotations?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
-            this.SchemaVersion = schemaVersion;
-            this.ArtifactType = artifactType;
-            this.Config = config;
-            this.Layers = layers.ToImmutableArray();
-        }
-
-        public int SchemaVersion { get; }
-
-        public string? ArtifactType { get; }
-
-        public OciDescriptor Config { get; }
-
-        public ImmutableArray<OciDescriptor> Layers { get; }
-
-        /// <summary>
-        /// Additional information provided through arbitrary metadata.
-        /// </summary>
-        public ImmutableDictionary<string, string> Annotations { get; }
+        this.Annotations = (annotations?.Count > 0) ? annotations.ToImmutableDictionary() : null;
+        this.SchemaVersion = schemaVersion;
+        this.MediaType = mediaType;
+        this.ArtifactType = artifactType;
+        this.Config = config;
+        this.Subject = subject;
+        this.Layers = layers.ToImmutableArray();
     }
+
+    public int SchemaVersion { get; }
+
+    public string? MediaType { get; }
+    public string? ArtifactType { get; }
+
+    public OciDescriptor Config { get; }
+
+    public ImmutableArray<OciDescriptor> Layers { get; }
+
+    /// <summary>
+    /// Reference to a separate manfest that this manifest is being attached to
+    /// </summary>
+    public OciDescriptor? Subject { get; }
+
+    /// <summary>
+    /// Additional information provided through arbitrary metadata.
+    /// </summary>
+    public ImmutableDictionary<string, string>? Annotations { get; }
 }

--- a/src/Bicep.Core/Registry/Oci/OciRegistryContentClient.cs
+++ b/src/Bicep.Core/Registry/Oci/OciRegistryContentClient.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure;
+using Azure.Containers.ContainerRegistry;
+using Azure.Core;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Registry.Oci;
+
+public class OciRegistryContentClient : IOciRegistryContentClient
+{
+    private readonly ContainerRegistryContentClient client;
+
+    public OciRegistryContentClient(Uri endpoint, string repositoryName, ContainerRegistryClientOptions options)
+    {
+        client = new ContainerRegistryContentClient(endpoint, repositoryName, options);
+    }
+
+    public OciRegistryContentClient(Uri endpoint, string repositoryName, TokenCredential credential, ContainerRegistryClientOptions options)
+    {
+        client = new ContainerRegistryContentClient(endpoint, repositoryName, credential, options);
+    }
+
+    public Task<Response<SetManifestResult>> SetManifestAsync(OciImageManifest manifest, string? tag = default, ManifestMediaType? mediaType = default, CancellationToken cancellationToken = default)
+        => client.SetManifestAsync(manifest, tag, mediaType, cancellationToken);
+
+    public Task<Response<SetManifestResult>> SetManifestAsync(BinaryData manifest, string? tag = default, ManifestMediaType? mediaType = default, CancellationToken cancellationToken = default)
+        => client.SetManifestAsync(manifest, tag, mediaType, cancellationToken);
+
+    public Task<Response<UploadRegistryBlobResult>> UploadBlobAsync(Stream content, CancellationToken cancellationToken = default)
+        => client.UploadBlobAsync(content, cancellationToken);
+
+    public Task<Response<DownloadRegistryBlobResult>> DownloadBlobContentAsync(string digest, CancellationToken cancellationToken = default)
+        => client.DownloadBlobContentAsync(digest, cancellationToken);
+
+    public Task<Response<GetManifestResult>> GetManifestAsync(string tagOrDigest, CancellationToken cancellationToken = default)
+        => client.GetManifestAsync(tagOrDigest, cancellationToken);
+}

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -81,7 +81,7 @@ namespace Bicep.Core.Registry
                     var repository = this.repositoryFactory.CreateRepository(configuration, reference.SubscriptionId);
                     var templateSpecEntity = await repository.FindTemplateSpecByIdAsync(reference.TemplateSpecResourceId);
 
-                    await this.TryWriteModuleContentAsync(reference, templateSpecEntity);
+                    await this.TryWriteModuleContentToCacheAsync(reference, templateSpecEntity);
                 }
                 catch (ExternalModuleException templateSpecException)
                 {
@@ -106,7 +106,7 @@ namespace Bicep.Core.Registry
             return statuses;
         }
 
-        protected override void WriteModuleContent(TemplateSpecModuleReference reference, TemplateSpecEntity entity) =>
+        protected override void WriteModuleContentToCache(TemplateSpecModuleReference reference, TemplateSpecEntity entity) =>
             File.WriteAllText(this.GetModuleEntryPointPath(reference), entity.Content);
 
         protected override string GetModuleDirectoryPath(TemplateSpecModuleReference reference) => Path.Combine(

--- a/src/Bicep.LangServer/Providers/AzureContainerRegistriesProvider.cs
+++ b/src/Bicep.LangServer/Providers/AzureContainerRegistriesProvider.cs
@@ -20,7 +20,8 @@ using Newtonsoft.Json.Linq;
 namespace Bicep.LanguageServer.Providers
 {
     /// <summary>
-    /// This provider fetches all the Azure Container Registries (ACR) names that the user has access to via Azure
+    /// This provider fetches all the Azure Container Registries (ACR) names that the user has access to via Azure. It does
+    /// so by downloading a list 
     /// </summary>
     public class AzureContainerRegistriesProvider : IAzureContainerRegistriesProvider
     {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/MockFactories/MockFileSystemFactory.cs
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/MockFactories/MockFileSystemFactory.cs
@@ -9,7 +9,7 @@ namespace Bicep.RegistryModuleTool.TestFixtures.MockFactories
 {
     public static class MockFileSystemFactory
     {
-        private const string CurrentDirectory = "/modules/test/testmodule";
+        private const string CurrentDirectory = "/modules/test/test module";
 
         public static MockFileSystem CreateFileSystemWithEmptyFolder() => CreateFileSystem(Enumerable.Empty<(string, string)>());
 

--- a/src/vscode-bicep/src/language/client.ts
+++ b/src/vscode-bicep/src/language/client.ts
@@ -89,7 +89,7 @@ export async function createLanguageService(
   const clientOptions: lsp.LanguageClientOptions = {
     documentSelector: [{ language: bicepLanguageId }],
     initializationOptions: {
-      // this tells the server that this client can handle additional DocumentUri schemes
+      // this tells the server that this client can handle additional DocumentUri schemes (e.g. bicep-cache://)
       enableRegistryContent: true,
     },
     progressOnInitialization: true,


### PR DESCRIPTION
Broken out from #11454, refactors the methods in AzureContainerRegistryManager into functions that are Bicep-specific (mostly those that contain "Module in the name) and those that are more generic, with the intention that they will be split into two classes afterwards.

NOTE: Also adds a layer of abstraction (IOciRegistryContentClient) over the Azure SDK's ContainerRegistryContentClient class.  The intention here was to allow a way to mock the OCI referrer's API (https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers/) implementation, but that portion doesn't carry over into this changelist since it's not currently needed.  @asilverman I think the addition in this PR still makes sense, but it could go either way.  If it makes your job harder, I'm fine with removing it for now.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/Azure/bicep/pull/11481&drop=dogfoodAlpha