### PR TITLE
Updated view documentation hover link to force bicep as deployment language

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -339,7 +339,7 @@ resource test|Output string = 'str'
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my module\n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my param\n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my var\n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my  \nmultiline  \nresource  \n[View Documentation](https://docs.microsoft.com/azure/templates/test.rp/discriminatortests?tabs=bicep)\n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my  \nmultiline  \nresource  \n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/discriminatortests?tabs=bicep&pivots=deployment-language-bicep)\n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```\nthis is my output  \n\n"));
         }
 
@@ -544,13 +544,13 @@ resource m|adeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01' = {}
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource foo 'Test.Rp/basicTests@2020-01-01'
 ```
-[View Documentation](https://docs.microsoft.com/azure/templates/test.rp/basictests?tabs=bicep)
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?tabs=bicep&pivots=deployment-language-bicep)
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource bar 'Test.Rp/basicTests@2020-01-01'
 ```
 This resource also has a description!  " + @"
-[View Documentation](https://docs.microsoft.com/azure/templates/test.rp/basictests?tabs=bicep)
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?tabs=bicep&pivots=deployment-language-bicep)
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -333,7 +333,7 @@ namespace Bicep.LanguageServer.Handlers
                 var provider = resourceType.TypeReference.TypeSegments.First().ToLowerInvariant();
                 var typePath = resourceType.TypeReference.TypeSegments.Skip(1).Select(x => x.ToLowerInvariant());
 
-                return $"https://docs.microsoft.com/azure/templates/{provider}/{string.Join('/', typePath)}?tabs=bicep";
+                return $"https://learn.microsoft.com/azure/templates/{provider}/{string.Join('/', typePath)}?tabs=bicep&pivots=deployment-language-bicep";
             }
 
             return null;

--- a/src/vscode-bicep/src/test/e2e/hover.test.ts
+++ b/src/vscode-bicep/src/test/e2e/hover.test.ts
@@ -73,7 +73,7 @@ describe("hover", (): void => {
       contents: [
         codeblockWithDescription(
           "resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01'",
-          "[View Documentation](https://docs.microsoft.com/azure/templates/microsoft.network/virtualnetworks?tabs=bicep)",
+          "[View Documentation](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks?tabs=bicep&pivots=deployment-language-bicep)",
         ),
       ],
     });


### PR DESCRIPTION
Fixes #11539.

- Updated `View documentation` hover link with query string `&pivots=deployment-language-bicep` to force Bicep as deployment language
- Updated the link from `docs.microsoft.com` to `learn.microsoft.com`
