### PR TITLE
Allow configuration of (harcoded) registry FQD using Env Variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,7 @@
             ],
             "env": {
                 "BICEP_TRACING_ENABLED": "true",
-                "BICEP_REGISTRY_FQDN": "asilvermantestbr.azurecr.io"
+                // "BICEP_REGISTRY_FQDN": "your-registry-here.azurecr.io"
             },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,8 @@
                 "${file}"
             ],
             "env": {
-                "BICEP_TRACING_ENABLED": "true"
+                "BICEP_TRACING_ENABLED": "true",
+                "BICEP_REGISTRY_FQDN": "asilvermantestbr.azurecr.io"
             },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -40,14 +40,17 @@ namespace Bicep.Core.Features
 
         public static bool TracingEnabled => ReadBooleanEnvVar("BICEP_TRACING_ENABLED", defaultValue: false);
 
-        public static TraceVerbosity TracingVerbosity => ReadEnumEnvvar("BICEP_TRACING_VERBOSITY", TraceVerbosity.Basic);
+        public static TraceVerbosity TracingVerbosity => ReadEnumEnvVar("BICEP_TRACING_VERBOSITY", TraceVerbosity.Basic);
 
         public bool DynamicTypeLoadingEnabled => configuration.ExperimentalFeaturesEnabled.DynamicTypeLoading;
 
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)
             => bool.TryParse(Environment.GetEnvironmentVariable(envVar), out var value) ? value : defaultValue;
 
-        private static T ReadEnumEnvvar<T>(string envVar, T defaultValue) where T : struct
+        public static string ReadEnvVar(string envVar, string defaultValue)
+            => Environment.GetEnvironmentVariable(envVar) ?? defaultValue;
+
+        private static T ReadEnumEnvVar<T>(string envVar, T defaultValue) where T : struct
         {
             var str = Environment.GetEnvironmentVariable(envVar);
             return Enum.TryParse<T>(str, true, out var value) ? value : defaultValue;

--- a/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
+++ b/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
@@ -140,6 +140,7 @@ namespace Bicep.Core.Registry
             catch (RequestFailedException exception) when (exception.Status == 404)
             {
                 // manifest does not exist
+                Trace.WriteLine($"Manifest for module {artifactReference.FullyQualifiedReference} could not be found in the registry.");
                 throw new OciModuleRegistryException("The artifact does not exist in the registry.", exception);
             }
 

--- a/src/Bicep.Core/Syntax/ProviderDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProviderDeclarationSyntax.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Features;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Registry.Oci;
@@ -41,13 +42,13 @@ namespace Bicep.Core.Syntax
 
         public IdentifierSyntax? Alias => (this.AsClause as AliasAsClauseSyntax)?.Alias;
 
-        private StringSyntax ProviderPath => SyntaxFactory.CreateStringLiteral($@"{OciArtifactReferenceFacts.Scheme}:{LanguageConstants.BicepPublicMcrRegistry}/bicep/providers/{this.Specification.Name}:{this.Specification.Version}");
-
         public override TextSpan Span => TextSpan.Between(this.Keyword, TextSpan.LastNonNull(this.SpecificationString, this.WithClause, this.AsClause));
 
         SyntaxBase IForeignArtifactReference.ReferenceSourceSyntax => ProviderPath;
 
         public override void Accept(ISyntaxVisitor visitor) => visitor.VisitProviderDeclarationSyntax(this);
+
+        private StringSyntax ProviderPath => SyntaxFactory.CreateStringLiteral($@"{OciArtifactReferenceFacts.Scheme}:{FeatureProvider.ReadEnvVar("BICEP_REGISTRY_FQDN", LanguageConstants.BicepPublicMcrRegistry)}/bicep/providers/{this.Specification.Name}:{this.Specification.Version}");
 
         public StringSyntax? TryGetPath() => ProviderPath;
     }

--- a/src/Bicep.Core/Syntax/ProviderDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProviderDeclarationSyntax.cs
@@ -48,7 +48,7 @@ namespace Bicep.Core.Syntax
 
         public override void Accept(ISyntaxVisitor visitor) => visitor.VisitProviderDeclarationSyntax(this);
 
-        private StringSyntax ProviderPath => SyntaxFactory.CreateStringLiteral($@"{OciArtifactReferenceFacts.Scheme}:{FeatureProvider.ReadEnvVar("BICEP_REGISTRY_FQDN", LanguageConstants.BicepPublicMcrRegistry)}/bicep/providers/{this.Specification.Name}:{this.Specification.Version}");
+        private StringSyntax ProviderPath => SyntaxFactory.CreateStringLiteral($@"{OciArtifactReferenceFacts.Scheme}:{FeatureProvider.ReadEnvVar("__EXPERIMENTAL_BICEP_REGISTRY_FQDN", LanguageConstants.BicepPublicMcrRegistry)}/bicep/providers/{this.Specification.Name}:{this.Specification.Version}");
 
         public StringSyntax? TryGetPath() => ProviderPath;
     }


### PR DESCRIPTION
## Description

This PR adds a temp capability to configure the FQDN of the registry from which resource type provider OCI artifacts are pulled from. As of now the value is hardcoded to MCR temporarily and future PRs will relax this constraint. However, we need to configure it for the purpose of demonstrating the functionality to allow fetching OCI artifacts from a test registry.

Setting `BICEP_REGISTRY_FQDN` in the execution context of the process will allow us to do so. 

PS this is only relevant when `bicepconfig.json` is set with:
```jsonx
{
//...
    "experimentalFeaturesEnabled": {
        "extensibility": true,
        "dynamicTypeLoading": true
    },
//...
}
```

Usage Example

```
BICEP_REGISTRY_FQDN=awesomeregistry.com bicep build main.bicep
```


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11547)