### PR TITLE
Refactor regex declarations to use source gen to improve performance

### DIFF
--- a/src/Bicep.Core/Registry/Oci/OciArtifactReferenceFacts.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReferenceFacts.cs
@@ -13,7 +13,7 @@ namespace Bicep.Core.Registry.Oci
 
         public const int MaxRegistryLength = 255;
 
-        // must be kept in sync with the tag name regex
+        // must be kept in sync with TagNameRegex
         public const int MaxTagLength = 128;
 
         public const int MaxRepositoryLength = 255;
@@ -30,19 +30,19 @@ namespace Bicep.Core.Registry.Oci
         // digests are case sensitive
         public static readonly IEqualityComparer<string?> DigestComparer = StringComparer.Ordinal;
 
-        // must be kept in sync with the tag max length
-        private static readonly Regex TagRegex = new(@$"^[a-zA-Z0-9_][a-zA-Z0-9._-]{{0,{MaxTagLength - 1}}}$", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant);
-
-        public static bool IsOciTag(string value) => TagRegex.IsMatch(value);
-
         public static bool IsOciNamespaceSegment(string value) => OciNamespaceSegmentRegex().IsMatch(value);
 
         public static bool IsOciDigest(string value) => DigestRegex().IsMatch(value);
 
+        public static bool IsOciTag(string value) => TagNameRegex().IsMatch(value);
+
         // obtained from https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull
-        [GeneratedRegex("^[a-z0-9]+([._-][a-z0-9]+)*$", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant)]
-        public static partial Regex OciNamespaceSegmentRegex();
-        [GeneratedRegex("^sha256:[a-f0-9]{64}$", RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.CultureInvariant)]
-        public static partial Regex DigestRegex();
+        [GeneratedRegex("^[a-z0-9]+([._-][a-z0-9]+)*$", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
+        private static partial Regex OciNamespaceSegmentRegex();
+        [GeneratedRegex("^sha256:[a-f0-9]{64}$", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
+        private static partial Regex DigestRegex();
+
+        [GeneratedRegex("^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
+        private static partial Regex TagNameRegex();
     }
 }


### PR DESCRIPTION
## Description

Quick refactor to move `TagRegex` to source generation pattern
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11563)