### PR TITLE
Refactor code to use `System.Text.Json` for deserialization of `OciManifest`

### DIFF
--- a/src/Bicep.Core.UnitTests/Registry/Oci/OciArtifactResult.cs
+++ b/src/Bicep.Core.UnitTests/Registry/Oci/OciArtifactResult.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using Bicep.Core.Registry.Oci;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.UnitTests.Registry.Oci
+{
+    /// <summary>
+    /// Tests related to deserialization of OciArtifactResult class
+    /// </summary>
+    [TestClass]
+    public class OciManifestTests
+    {
+        [TestMethod]
+        [Description("Verify that a valid OCI manifest can be deserialized from a valid JSON")]
+        public void FromBinaryData_ValidInput_DeserializesSuccessfully()
+        {
+            const string jsonManifest = """
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.ms.bicep.provider.artifact",
+  "config": {
+    "mediaType": "application/vnd.ms.bicep.provider.config.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.ms.bicep.provider.layer.v1.tar+gzip",
+      "digest": "sha256:f1f31b47972a60b1905f3252a4819dad964d505cf530a9cd3d67cee8a3c295f5",
+      "size": 9346232
+    }
+  ],
+  "annotations": {
+    "bicep.serialization.format": "v1",
+    "org.opencontainers.image.created": "2023-05-04T16:40:05Z"
+  }
+}
+""";
+            var binaryData = new BinaryData(Encoding.UTF8.GetBytes(jsonManifest));
+
+            var got = OciManifest.FromBinaryData(binaryData).Should().BeOfType<OciManifest>().Subject;
+
+            got.SchemaVersion.Should().Be(2);
+            got.ArtifactType.Should().Be(BicepMediaTypes.BicepProviderArtifactType);
+            got.Config.MediaType.Should().Be(BicepMediaTypes.BicepProviderConfigV1);
+            got.Config.Digest.Should().Be("sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a");
+            got.Config.Size.Should().Be(2);
+            got.Layers.Should().HaveCount(1);
+            got.Layers[0].MediaType.Should().Be(BicepMediaTypes.BicepProviderArtifactLayerV1TarGzip);
+            got.Annotations.Should().HaveCount(2);
+        }
+    }
+}

--- a/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
+++ b/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
@@ -106,7 +106,7 @@ namespace Bicep.Core.Registry
                 annotations[LanguageConstants.OciOpenContainerImageDescriptionAnnotation] = description;
             }
 
-            var manifest = new OciManifest(2, artifactType, configDescriptor, layerDescriptors, annotations);
+            var manifest = new OciManifest(2, artifactType, configDescriptor, layerDescriptors.ToImmutableArray(), annotations.ToImmutableDictionary());
 
             using var manifestStream = new MemoryStream();
             OciSerialization.Serialize(manifestStream, manifest);

--- a/src/Bicep.Core/Registry/Oci/OciDescriptor.cs
+++ b/src/Bicep.Core/Registry/Oci/OciDescriptor.cs
@@ -17,14 +17,6 @@ namespace Bicep.Core.Registry.Oci
             this.Size = size;
             this.Annotations = annotations ?? ImmutableDictionary<string, string>.Empty;
         }
-        public OciDescriptor(string mediaType, string digest, long size, IDictionary<string, string>? annotations)
-        {
-            this.MediaType = mediaType;
-            this.Digest = digest;
-            this.Size = size;
-            this.Annotations = annotations?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
-        }
-
         public string MediaType { get; }
 
         public string Digest { get; }

--- a/src/Bicep.Core/Registry/Oci/OciDescriptor.cs
+++ b/src/Bicep.Core/Registry/Oci/OciDescriptor.cs
@@ -9,6 +9,14 @@ namespace Bicep.Core.Registry.Oci
 {
     public class OciDescriptor
     {
+        [JsonConstructor]
+        public OciDescriptor(string mediaType, string digest, long size, ImmutableDictionary<string, string>? annotations)
+        {
+            this.MediaType = mediaType;
+            this.Digest = digest;
+            this.Size = size;
+            this.Annotations = annotations ?? ImmutableDictionary<string, string>.Empty;
+        }
         public OciDescriptor(string mediaType, string digest, long size, IDictionary<string, string>? annotations)
         {
             this.MediaType = mediaType;
@@ -16,17 +24,14 @@ namespace Bicep.Core.Registry.Oci
             this.Size = size;
             this.Annotations = annotations?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
         }
-        [JsonPropertyName("mediaType")]
+
         public string MediaType { get; }
 
-        [JsonPropertyName("digest")]
         public string Digest { get; }
 
-        [JsonPropertyName("size")]
         public long Size { get; }
 
         // TODO: Skip serialization for empty annotations
-        [JsonPropertyName("annotations")]
         public ImmutableDictionary<string, string> Annotations { get; }
     }
 }

--- a/src/Bicep.Core/Registry/Oci/OciManifest.cs
+++ b/src/Bicep.Core/Registry/Oci/OciManifest.cs
@@ -4,25 +4,34 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 
 namespace Bicep.Core.Registry.Oci
 {
+    [JsonSerializable(typeof(OciManifest))]
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    public partial class OciManifestSerializationContext : JsonSerializerContext { }
+
+    [JsonSerializable(typeof(OciManifest))]
     public class OciManifest
     {
+        [JsonConstructor]
         public OciManifest(
             int schemaVersion,
             string? artifactType,
             OciDescriptor config,
-            IEnumerable<OciDescriptor> layers,
-            IDictionary<string, string>? annotations = null)
+            ImmutableArray<OciDescriptor> layers,
+            ImmutableDictionary<string, string> annotations)
         {
-            this.Annotations = annotations?.ToImmutableDictionary() ?? ImmutableDictionary<string, string>.Empty;
+            this.Annotations = annotations;
             this.SchemaVersion = schemaVersion;
             this.ArtifactType = artifactType;
             this.Config = config;
-            this.Layers = layers.ToImmutableArray();
+            this.Layers = layers;
         }
 
         public int SchemaVersion { get; }
@@ -38,9 +47,7 @@ namespace Bicep.Core.Registry.Oci
         /// </summary>
         public ImmutableDictionary<string, string> Annotations { get; }
 
-        internal static OciManifest? FromBinaryData(BinaryData data)
-        {
-            return JsonConvert.DeserializeObject<OciManifest>(data.ToString());
-        }
+        public static OciManifest? FromBinaryData(BinaryData data)
+            => JsonSerializer.Deserialize(data, OciManifestSerializationContext.Default.OciManifest);
     }
 }


### PR DESCRIPTION
## Description

Addresses [PR comment](https://github.com/Azure/bicep/pull/11458#discussion_r1293937454) to use `System.Text.Json` instead of `Newtonsoft.Json` in the deserialization of `OciManifest` class

## Changes

* Adds biz logic to support deserialization with `System.Text.Json`
* Adds a unit test to verify proper deserialization of a valid JSON manifest 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11591)