### PR TITLE
Bump Bicep.Types to latest to clear deprecation warnings and ensure backwards compatibility

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2025,7 +2025,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -1851,7 +1851,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -62,10 +62,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -1789,7 +1789,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2025,7 +2025,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2025,7 +2025,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -102,10 +102,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2009,7 +2009,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Azure.Deployments.Core" Version="1.0.1040" />
     <PackageReference Include="Azure.Deployments.Templates" Version="1.0.1040" />
     <PackageReference Include="Azure.Deployments.Expression" Version="1.0.1040" />
-    <PackageReference Include="Azure.Bicep.Types" Version="0.3.181" />
+    <PackageReference Include="Azure.Bicep.Types" Version="0.4.1" />
     <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.552" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.504" />
     <PackageReference Include="System.IO.Abstractions" Version="19.2.29" />

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
@@ -102,9 +102,20 @@ namespace Bicep.Core.TypeSystem.Az
         {
             switch (typeBase)
             {
+                case Azure.Bicep.Types.Concrete.AnyType:
+                    return LanguageConstants.Any;
+                case Azure.Bicep.Types.Concrete.NullType:
+                    return LanguageConstants.Null;
+                case Azure.Bicep.Types.Concrete.BooleanType:
+                    return LanguageConstants.Bool;
+                case Azure.Bicep.Types.Concrete.IntegerType @int:
+                    return TypeFactory.CreateIntegerType(@int.MinValue, @int.MaxValue);
+                case Azure.Bicep.Types.Concrete.StringType @string:
+                    return TypeFactory.CreateStringType(@string.MinLength, @string.MaxLength);
                 case Azure.Bicep.Types.Concrete.BuiltInType builtInType:
                     return builtInType.Kind switch
                     {
+                        #pragma warning disable 618
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Any => LanguageConstants.Any,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Null => LanguageConstants.Null,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Bool => LanguageConstants.Bool,
@@ -113,6 +124,7 @@ namespace Bicep.Core.TypeSystem.Az
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Object => LanguageConstants.Object,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Array => LanguageConstants.Array,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.ResourceRef => LanguageConstants.ResourceRef,
+                        #pragma warning restore 618
                         _ => throw new ArgumentException(),
                     };
                 case Azure.Bicep.Types.Concrete.ObjectType objectType:

--- a/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/K8s/K8sResourceTypeFactory.cs
@@ -69,8 +69,20 @@ namespace Bicep.Core.TypeSystem.K8s
         {
             switch (typeBase)
             {
+                case Azure.Bicep.Types.Concrete.AnyType:
+                    return LanguageConstants.Any;
+                case Azure.Bicep.Types.Concrete.NullType:
+                    return LanguageConstants.Null;
+                case Azure.Bicep.Types.Concrete.BooleanType:
+                    return LanguageConstants.Bool;
+                case Azure.Bicep.Types.Concrete.IntegerType @int:
+                    return TypeFactory.CreateIntegerType(@int.MinValue, @int.MaxValue);
+                case Azure.Bicep.Types.Concrete.StringType @string:
+                    return TypeFactory.CreateStringType(@string.MinLength, @string.MaxLength);
                 case Azure.Bicep.Types.Concrete.BuiltInType builtInType:
-                    return builtInType.Kind switch {
+                    return builtInType.Kind switch
+                    {
+                        #pragma warning disable 618
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Any => LanguageConstants.Any,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Null => LanguageConstants.Null,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Bool => LanguageConstants.Bool,
@@ -79,6 +91,7 @@ namespace Bicep.Core.TypeSystem.K8s
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Object => LanguageConstants.Object,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Array => LanguageConstants.Array,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.ResourceRef => LanguageConstants.ResourceRef,
+                        #pragma warning restore 618
                         _ => throw new ArgumentException(),
                     };
                 case Azure.Bicep.Types.Concrete.ObjectType objectType:

--- a/src/Bicep.Core/TypeSystem/MicrosoftGraph/MicrosoftGraphResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/MicrosoftGraph/MicrosoftGraphResourceTypeFactory.cs
@@ -69,8 +69,20 @@ namespace Bicep.Core.TypeSystem.MicrosoftGraph
         {
             switch (typeBase)
             {
+                case Azure.Bicep.Types.Concrete.AnyType:
+                    return LanguageConstants.Any;
+                case Azure.Bicep.Types.Concrete.NullType:
+                    return LanguageConstants.Null;
+                case Azure.Bicep.Types.Concrete.BooleanType:
+                    return LanguageConstants.Bool;
+                case Azure.Bicep.Types.Concrete.IntegerType @int:
+                    return TypeFactory.CreateIntegerType(@int.MinValue, @int.MaxValue);
+                case Azure.Bicep.Types.Concrete.StringType @string:
+                    return TypeFactory.CreateStringType(@string.MinLength, @string.MaxLength);
                 case Azure.Bicep.Types.Concrete.BuiltInType builtInType:
-                    return builtInType.Kind switch {
+                    return builtInType.Kind switch
+                    {
+                        #pragma warning disable 618
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Any => LanguageConstants.Any,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Null => LanguageConstants.Null,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Bool => LanguageConstants.Bool,
@@ -79,6 +91,7 @@ namespace Bicep.Core.TypeSystem.MicrosoftGraph
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Object => LanguageConstants.Object,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Array => LanguageConstants.Array,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.ResourceRef => LanguageConstants.ResourceRef,
+                        #pragma warning restore 618
                         _ => throw new ArgumentException(),
                     };
                 case Azure.Bicep.Types.Concrete.ObjectType objectType:

--- a/src/Bicep.Core/TypeSystem/TypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/TypeFactory.cs
@@ -7,8 +7,12 @@ namespace Bicep.Core.TypeSystem;
 
 public static class TypeFactory
 {
-    public static BooleanType CreateBooleanType(TypeSymbolValidationFlags validationFlags = TypeSymbolValidationFlags.Default)
-        => new(validationFlags);
+    private static readonly BooleanType UnrefinedBool = new(default);
+    private static readonly IntegerType UnrefinedInt = new(default, default, default);
+    private static readonly StringType UnrefinedString = new(default, default, default);
+
+    public static TypeSymbol CreateBooleanType(TypeSymbolValidationFlags validationFlags = TypeSymbolValidationFlags.Default)
+        => validationFlags == UnrefinedBool.ValidationFlags ? UnrefinedBool : new BooleanType(validationFlags);
 
     public static BooleanLiteralType CreateBooleanLiteralType(bool value, TypeSymbolValidationFlags validationFlags = TypeSymbolValidationFlags.Default)
         => new(value, validationFlags);
@@ -20,7 +24,12 @@ public static class TypeFactory
             return CreateIntegerLiteralType(minValue.Value, validationFlags);
         }
 
-        return new IntegerType(minValue, maxValue, validationFlags);
+        if (minValue != UnrefinedInt.MinValue || maxValue != UnrefinedInt.MaxValue || validationFlags != UnrefinedInt.ValidationFlags)
+        {
+            return new IntegerType(minValue, maxValue, validationFlags);
+        }
+
+        return UnrefinedInt;
     }
 
     public static IntegerLiteralType CreateIntegerLiteralType(long value, TypeSymbolValidationFlags validationFlags = TypeSymbolValidationFlags.Default)
@@ -51,7 +60,12 @@ public static class TypeFactory
             return CreateStringLiteralType(string.Empty, validationFlags);
         }
 
-        return new StringType(minLength, maxLength, validationFlags);
+        if (minLength != UnrefinedString.MinLength || maxLength != UnrefinedString.MaxLength || validationFlags != UnrefinedString.ValidationFlags)
+        {
+            return new StringType(minLength, maxLength, validationFlags);
+        }
+
+        return UnrefinedString;
     }
 
     public static StringLiteralType CreateStringLiteralType(string value, TypeSymbolValidationFlags validationFlags = TypeSymbolValidationFlags.Default)

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "Azure.Bicep.Types": {
         "type": "Direct",
-        "requested": "[0.3.181, )",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "requested": "[0.4.1, )",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2005,7 +2005,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2005,7 +2005,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -38,10 +38,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -1738,7 +1738,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -103,10 +103,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2039,7 +2039,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -99,10 +99,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2047,7 +2047,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -73,10 +73,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -1899,7 +1899,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2108,7 +2108,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -68,10 +68,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2050,7 +2050,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -69,10 +69,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2108,7 +2108,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -169,10 +169,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2033,7 +2033,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -50,10 +50,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -2118,7 +2118,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -63,10 +63,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.3.181",
-        "contentHash": "Zbn4qhr79IXsrIRGyqKPkP5UTa2HO4TiGcryQvHv3xFtX5AKdgoQShMW5y0VlFNSBDgwT0rd509ITyt0uyvCsQ==",
+        "resolved": "0.4.1",
+        "contentHash": "IKmxyCwXkuIPcJhpjKkz2P9PNxlTvdtjGLlGEMduGaQTiYgE/glIirPeknwj3DAc9VhysZ9i/nGgpe0O2Vl1eg==",
         "dependencies": {
-          "System.Text.Json": "7.0.1"
+          "System.Text.Json": "7.0.3"
         }
       },
       "Azure.Bicep.Types.Az": {
@@ -1864,7 +1864,7 @@
       "Azure.Bicep.Core": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.3.181, )",
+          "Azure.Bicep.Types": "[0.4.1, )",
           "Azure.Bicep.Types.Az": "[0.2.552, )",
           "Azure.Bicep.Types.K8s": "[0.1.504, )",
           "Azure.Containers.ContainerRegistry": "[1.1.0, )",


### PR DESCRIPTION
Resolves #9572 

This PR updates updates The `Az`, `K8s`, and `MicrosoftGraph` type factories to recognize and process the new constraint-bearing primitive type definitions introduced in `Azure.Bicep.Types v0.4.1`. The Az type generation workflow has been updated to use these new definitions when resource properties are constrained in the service model, so the next release of Bicep will include warnings when, for example, a string is too short or too long to be accepted as a resource name.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11687)