### PR TITLE
Block the use of interpolated string when a compile-time constant is required

### DIFF
--- a/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CompileTimeConstantVisitor.cs
@@ -60,6 +60,15 @@ namespace Bicep.Core.TypeSystem
             this.AppendError(syntax);
         }
 
+        public override void VisitStringSyntax(StringSyntax syntax)
+        {
+            // Flag string interpolation since we don't support constant folding and constant propagation.
+            if (syntax.IsInterpolated())
+            {
+                this.AppendError(syntax);
+            }
+        }
+
         public override void VisitTernaryOperationSyntax(TernaryOperationSyntax syntax)
         {
             this.AppendError(syntax);

--- a/src/Bicep.LangServer/Extensions/DocumentUriExtensions.cs
+++ b/src/Bicep.LangServer/Extensions/DocumentUriExtensions.cs
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using OmniSharp.Extensions.LanguageServer.Protocol;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OmniSharp.Extensions.LanguageServer.Protocol
 {


### PR DESCRIPTION
Fixed https://github.com/Azure/bicep/issues/11292.