### PR TITLE
Make post-test cleanup in vscode-bicep test:e2e task strictly best-effort

### DIFF
--- a/src/vscode-bicep/src/test/e2e/createBicepConfig.test.ts
+++ b/src/vscode-bicep/src/test/e2e/createBicepConfig.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {} from "fs";
-import fse from "fs-extra";
+import fs from "fs";
 import path from "path";
 import { TextEditor, Uri, window } from "vscode";
 import { createUniqueTempFolder } from "../utils/createUniqueTempFolder";
@@ -104,20 +103,24 @@ describe("bicep.createConfigFile", (): void => {
       );
       */
     } finally {
-      fse.rmdirSync(tempFolder, {
-        recursive: true,
-        maxRetries: 5,
-        retryDelay: 1000,
-      });
+      try {
+        fs.rmSync(tempFolder, {
+          recursive: true,
+          maxRetries: 5,
+          retryDelay: 1000,
+        });
+      } catch {
+        // post-test cleanup is strictly best-effort only
+      }
     }
   });
 
   function fileExists(path: string): boolean {
-    return fse.existsSync(path);
+    return fs.existsSync(path);
   }
 
   function fileContains(path: string, pattern: RegExp | string): boolean {
-    const contents: string = fse.readFileSync(path).toString();
+    const contents: string = fs.readFileSync(path).toString();
     return !!contents.match(pattern);
   }
 });

--- a/src/vscode-bicep/src/test/e2e/decompile.test.ts
+++ b/src/vscode-bicep/src/test/e2e/decompile.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import fs from "fs";
-import fse from "fs-extra";
 import path from "path";
 import vscode from "vscode";
 import { createUniqueTempFolder } from "../utils/createUniqueTempFolder";
@@ -58,10 +57,14 @@ describe("decompile", (): void => {
     expect(fs.existsSync(outputPath2)).toBe(true);
 
     // Delete the folder
-    fse.rmdirSync(folder, {
-      recursive: true,
-      maxRetries: 5,
-      retryDelay: 1000,
-    });
+    try {
+      fs.rmSync(folder, {
+        recursive: true,
+        maxRetries: 5,
+        retryDelay: 1000,
+      });
+    } catch {
+      // post-test cleanup is strictly best-effort only
+    }
   });
 });

--- a/src/vscode-bicep/src/test/e2e/emptyConfigFileSnippets.test.ts
+++ b/src/vscode-bicep/src/test/e2e/emptyConfigFileSnippets.test.ts
@@ -10,7 +10,7 @@ import vscode, {
   workspace,
 } from "vscode";
 import path from "path";
-import fse from "fs-extra";
+import fs from "fs";
 import {
   executeCloseAllEditors,
   executeCompletionItemProvider,
@@ -30,7 +30,7 @@ describe("empty config file snippets", (): void => {
 
     const tempFolder = createUniqueTempFolder("emptyConfigSnippetsTest-");
     const configPath = path.join(tempFolder, "bicepconfig.json");
-    fse.writeFileSync(configPath, "\n");
+    fs.writeFileSync(configPath, "\n");
 
     try {
       const doc = await workspace.openTextDocument(configPath);
@@ -85,11 +85,15 @@ describe("empty config file snippets", (): void => {
       );
       */
     } finally {
-      fse.rmdirSync(tempFolder, {
-        recursive: true,
-        maxRetries: 5,
-        retryDelay: 1000,
-      });
+      try {
+        fs.rmSync(tempFolder, {
+          recursive: true,
+          maxRetries: 5,
+          retryDelay: 1000,
+        });
+      } catch {
+        // post-test cleanup is strictly best-effort only
+      }
     }
   });
 });


### PR DESCRIPTION
One of our required CI tasks, `Build / Build VSCode Extension`, has been failing all runs on Windows environments since some time yesterday due to an EBUSY error raised during post-test cleanup. According to some comments on [StackOverflow](https://stackoverflow.com/questions/55212864/error-ebusy-resource-busy-or-locked-rmdir), this *may* be caused by MS Defender holding a lock on one or more test artifact files in order to perform an anti-malware scan.

This PR allows the test to pass if the post-test cleanup fails. The files that are generated as part of the test are written to a temp dir, so any files that post-test cleanup fails to delete will eventually be taken care of when the OS reclaims disk space from stale temp files. The CI task runners are ephemeral environments and will just blink out of existence once the task is complete, so there's no reason we need to record a failure if test files are not properly cleaned up.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11762)