### PR TITLE
Bump Node version in CI from 16 -> 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
@@ -366,7 +366,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: npm ci
         if: matrix.runTests
@@ -439,7 +439,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: npm ci
         run: npm ci
@@ -476,7 +476,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: TextMate Grammar
         run: |
@@ -645,7 +645,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Download Bicep CLI
         uses: actions/download-artifact@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: npm ci
         run: npm ci

--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3


### PR DESCRIPTION
Node 16 is end-of-life on 9/11: https://nodejs.org/en/blog/announcements/nodejs16-eol
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11763)