### PR TITLE
Nightly install script improvements

### DIFF
--- a/docs/installing-nightly.md
+++ b/docs/installing-nightly.md
@@ -6,11 +6,17 @@
 These steps only work on Linux or Mac platforms
 
 ### VSCode Extension
-1. Run `bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh)`.
+1. Run the following:
+   ```sh
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh)
+   ```
 1. Reload your VSCode window.
 
 ### Azure CLI
-1. Run `bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) <platform> <arch>`
+1. Run the following:
+   ```sh
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) <platform> <arch>
+   ```
    - `<platform>` should either be `linux` or `osx`
    - `<arch>` should either be `x64` or `arm64`
 1. Your Azure CLI install should now be referencing the latest nightly Bicep CLI release.

--- a/docs/installing-nightly.md
+++ b/docs/installing-nightly.md
@@ -15,10 +15,8 @@ These steps only work on Linux or Mac platforms
 ### Azure CLI
 1. Run the following:
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) <platform> <arch>
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh)
    ```
-   - `<platform>` should either be `linux` or `osx`
-   - `<arch>` should either be `x64` or `arm64`
 1. Your Azure CLI install should now be referencing the latest nightly Bicep CLI release.
 
 ## Manual

--- a/docs/installing-nightly.md
+++ b/docs/installing-nightly.md
@@ -19,6 +19,25 @@ These steps only work on Linux or Mac platforms
    ```
 1. Your Azure CLI install should now be referencing the latest nightly Bicep CLI release.
 
+### Targeting a particular build or branch
+The following optional arguments are also supported in the nightly install scripts:
+- Installing from a GitHub branch (VSCode extension):
+   ```sh
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh) --branch jeskew/variable-imports
+   ```
+- Installing from a GitHub branch (CLI):
+   ```sh
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) --branch jeskew/variable-imports
+   ```
+- Installing from a GitHub Action run (VSCode extension):
+   ```sh
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh) --run-id 6146657618
+   ```
+- Installing from a GitHub Action run (CLI):
+   ```sh
+   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) --run-id 6146657618
+   ```
+
 ## Manual
 We are not currently publishing "nightly" releases, but you can grab the latest bits by viewing the latest Action workflows for the `main` branch (or any other branch).
 

--- a/scripts/install_cli_nightly.sh
+++ b/scripts/install_cli_nightly.sh
@@ -18,14 +18,14 @@ gh run download -R $REPO $lastRunId -n "bicep-release-$platform-$arch" --dir $tm
 
 # Install
 AZCLI_BIN_DIR="$HOME/.azure/bin"
+if [[ $platform == "osx" ]]; then
+  # Ad-hoc sign the binary
+  codesign -s - "$tmpDir/bicep"
+fi
+
 mkdir -p $AZCLI_BIN_DIR
 mv "$tmpDir/bicep" "$AZCLI_BIN_DIR/bicep"
 chmod +x "$AZCLI_BIN_DIR/bicep"
-if [[ $platform == "osx" ]]
-then
-  # Nightly binaries aren't signed, so OSX requires a gatekeeper exception
-  sudo -p "Enter your password to allow the Bicep binary to run: " spctl --add "$AZCLI_BIN_DIR/bicep"
-fi
 
 # Cleanup
 rm -Rf $tmpDir

--- a/scripts/install_cli_nightly.sh
+++ b/scripts/install_cli_nightly.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --run-id)   runId="${2}"; shift;;
+    --branch)   branch="${2}"; shift;;
+    *)          echo "Unrecognized argument \"${1}\"."; exit 1;;
+  esac
+  shift
+done
+
 if ! command -v gh > /dev/null; then
   echo "Please install the GitHub CLI: https://cli.github.com/"; exit 1;
 fi
@@ -20,9 +29,14 @@ esac
 
 # Fetch
 REPO="Azure/bicep"
-lastRunId=$(gh run list -R $REPO --branch main --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+if [ -z "$branch" ]; then
+  branch=main
+fi
+if [ -z "$runId" ]; then
+  runId=$(gh run list -R $REPO --branch $branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+fi
 tmpDir=$(mktemp -d)
-gh run download -R $REPO $lastRunId -n "bicep-release-$platform-$arch" --dir $tmpDir
+gh run download -R $REPO $runId -n "bicep-release-$platform-$arch" --dir $tmpDir
 
 # Install
 if [[ $platform == "osx" ]]; then
@@ -35,7 +49,8 @@ mkdir -p $AZCLI_BIN_DIR
 mv "$tmpDir/bicep" "$AZCLI_BIN_DIR/bicep"
 chmod +x "$AZCLI_BIN_DIR/bicep"
 
-echo "Installed Bicep from https://github.com/Azure/bicep/actions/runs/$lastRunId to $AZCLI_BIN_DIR/bicep"
+version=$("$AZCLI_BIN_DIR/bicep" --version | sed 's/^.* \([0-9]*\.[0-9]*\.[0-9]*\) .*/\1/')
+echo "Installed Bicep $version from https://github.com/Azure/bicep/actions/runs/$runId to $AZCLI_BIN_DIR/bicep"
 
 # Cleanup
 rm -Rf $tmpDir

--- a/scripts/install_vsix_nightly.sh
+++ b/scripts/install_vsix_nightly.sh
@@ -2,8 +2,7 @@
 set -e
 
 if ! command -v gh > /dev/null; then
-  echo "Please install the GitHub CLI: https://cli.github.com/"
-  exit 1
+  echo "Please install the GitHub CLI: https://cli.github.com/"; exit 1;
 fi
 
 # Fetch
@@ -13,7 +12,9 @@ tmpDir=$(mktemp -d)
 gh run download -R $REPO $lastRunId -n vscode-bicep.vsix --dir $tmpDir
 
 # Install
-code --install-extension "$tmpDir/vscode-bicep.vsix" --force
+code --install-extension "$tmpDir/vscode-bicep.vsix" --force > /dev/null
+
+echo "Installed Bicep VSCode extension from https://github.com/Azure/bicep/actions/runs/$lastRunId"
 
 # Cleanup
 rm -Rf $tmpDir

--- a/scripts/install_vsix_nightly.sh
+++ b/scripts/install_vsix_nightly.sh
@@ -1,20 +1,34 @@
 #!/bin/bash
 set -e
 
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --run-id)   runId="${2}"; shift;;
+    --branch)   branch="${2}"; shift;;
+    *)          echo "Unrecognized argument \"${1}\"."; exit 1;;
+  esac
+  shift
+done
+
 if ! command -v gh > /dev/null; then
   echo "Please install the GitHub CLI: https://cli.github.com/"; exit 1;
 fi
 
 # Fetch
 REPO="Azure/bicep"
-lastRunId=$(gh run list -R $REPO --branch main --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+if [ -z "$branch" ]; then
+  branch=main
+fi
+if [ -z "$runId" ]; then
+  runId=$(gh run list -R $REPO --branch $branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+fi
 tmpDir=$(mktemp -d)
-gh run download -R $REPO $lastRunId -n vscode-bicep.vsix --dir $tmpDir
+gh run download -R $REPO $runId -n vscode-bicep.vsix --dir $tmpDir
 
 # Install
-code --install-extension "$tmpDir/vscode-bicep.vsix" --force > /dev/null
+code --install-extension "$tmpDir/vscode-bicep.vsix" --force
 
-echo "Installed Bicep VSCode extension from https://github.com/Azure/bicep/actions/runs/$lastRunId"
+echo "Installed Bicep VSCode extension from https://github.com/Azure/bicep/actions/runs/$runId"
 
 # Cleanup
 rm -Rf $tmpDir


### PR DESCRIPTION
- Use ad-hoc signing instead of requiring root on Mac (following https://github.com/dotnet/sdk/issues/34917). Signing is a requirement on an M1 Mac, regardless of Gatekeeper.
- Add platform & architecture detection to simplify installing the CLI.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11824)