### PR TITLE
Build workflow improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -625,14 +625,14 @@ jobs:
               <summary>VSCode (Mac/Linux)</summary>
               
               ```sh
-              bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh) --run-id ${{ github.run_id }}
+              bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --run-id ${{ github.run_id }}
               ```
             </details>
             <details>
               <summary>Azure CLI (Mac/Linux)</summary>
               
               ```sh
-              bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) --run-id ${{ github.run_id }}
+              bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --run-id ${{ github.run_id }}
               ```
             </details>
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,8 @@ jobs:
           path: out/*
           if-no-files-found: error
 
-  build-langserver:
-    name: Build Language Server
+  build-vscode-ext:
+    name: "Build: VSCode Extension"
     runs-on: ubuntu-latest
 
     steps:
@@ -99,30 +99,45 @@ jobs:
           fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
           submodules: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
 
       - name: Publish Language Server
-        run: dotnet publish --configuration release ./src/Bicep.LangServer/Bicep.LangServer.csproj
+        run: |
+          dotnet publish --configuration release ./src/Bicep.LangServer/Bicep.LangServer.csproj
+          cp -R src/Bicep.LangServer/bin/release/net7.0/publish ./src/vscode-bicep/bicepLanguageServer
 
-      - name: Upload Language Server
+      - name: npm ci
+        run: npm ci
+        working-directory: ./src/vscode-bicep
+
+      - name: Generate VSIX notice
+        run: |
+          mkdir -p ./src/vscode-bicep-notice/inputs
+          npm --prefix ./src/vscode-bicep list -a --json > ./src/vscode-bicep-notice/inputs/npm-list.json
+          cp ./src/Bicep.LangServer/obj/project.assets.json ./src/vscode-bicep-notice/inputs/project.assets.json
+          dotnet build --configuration Release ./src/vscode-bicep-notice/vscode-bicep-notice.proj
+
+      - name: Create VSIX
+        run: npm run package
+        working-directory: ./src/vscode-bicep
+
+      - name: Upload VSIX
         uses: actions/upload-artifact@v3
         with:
-          name: Bicep.LangServer
-          path: ./src/Bicep.LangServer/bin/release/net7.0/publish/*
+          name: vscode-bicep.vsix
+          path: ./src/vscode-bicep/vscode-bicep.vsix
           if-no-files-found: error
 
-      # needed to generate notice file
-      - name: Upload Language Server project assets file
-        uses: actions/upload-artifact@v3
-        with:
-          name: Bicep.LangServer.ProjAssets
-          path: ./src/Bicep.LangServer/obj/project.assets.json
-
-  build-vscode-ext:
-    name: Build VSCode Extension
+  test-vscode-ext:
+    name: "Test: VSCode Extension"
     runs-on: ${{ matrix.os }}
-    needs: build-langserver
+    needs: build-vscode-ext
     strategy:
       fail-fast: false
       matrix:
@@ -145,9 +160,21 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
 
+      - name: Publish Language Server
+        run: |
+          dotnet publish --configuration release ./src/Bicep.LangServer/Bicep.LangServer.csproj
+          cp -R src/Bicep.LangServer/bin/release/net7.0/publish ./src/vscode-bicep/bicepLanguageServer
+
       - name: npm ci
         run: npm ci
         working-directory: ./src/vscode-bicep
+
+      - name: Generate VSIX notice
+        run: |
+          mkdir -p ./src/vscode-bicep-notice/inputs
+          npm --prefix ./src/vscode-bicep list -a --json > ./src/vscode-bicep-notice/inputs/npm-list.json
+          cp ./src/Bicep.LangServer/obj/project.assets.json ./src/vscode-bicep-notice/inputs/project.assets.json
+          dotnet build --configuration Release ./src/vscode-bicep-notice/vscode-bicep-notice.proj
 
       - name: Run lint
         run: npm run lint
@@ -160,28 +187,6 @@ jobs:
       - name: Run snapshot tests
         run: npm run test:snapshot
         working-directory: ./src/vscode-bicep
-
-      - name: Download Language Server
-        uses: actions/download-artifact@v3
-        with:
-          name: Bicep.LangServer
-          path: ./src/vscode-bicep/bicepLanguageServer
-
-      - name: Download Language Server project assets file
-        if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
-        with:
-          name: Bicep.LangServer.ProjAssets
-          path: ./src/vscode-bicep-notice/inputs
-
-      - name: npm list -a --json
-        if: runner.os == 'Linux'
-        run: npm list -a --json > ../vscode-bicep-notice/inputs/npm-list.json
-        working-directory: ./src/vscode-bicep
-
-      - name: Generate VSIX notice
-        if: runner.os == 'Linux'
-        run: dotnet build --configuration Release ./src/vscode-bicep-notice/vscode-bicep-notice.proj
 
       - name: Build prod
         run: npm run build:prod
@@ -212,19 +217,6 @@ jobs:
         with:
           flags: typescript
           directory: ./src/vscode-bicep/coverage
-
-      - name: Create VSIX
-        run: npm run package
-        if: runner.os == 'Linux'
-        working-directory: ./src/vscode-bicep
-
-      - name: Upload VSIX
-        uses: actions/upload-artifact@v3
-        if: runner.os == 'Linux'
-        with:
-          name: vscode-bicep.vsix
-          path: ./src/vscode-bicep/vscode-bicep.vsix
-          if-no-files-found: error
 
   build-vs-ext:
     name: Build Visual Studio Extension
@@ -535,14 +527,14 @@ jobs:
         uses: actions/setup-dotnet@v3
 
       - name: Run Tests
-        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --settings ./.github/workflows/codecov.runsettings --results-directory ./TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.runtime.rid }}
+        run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --settings ./.github/workflows/codecov.runsettings --results-directory ./TestResults
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: Bicep.TestResults.${{ matrix.runtime.rid }}
-          path: ./TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.runtime.rid }}/**/*.trx
+          path: ./TestResults/*.trx
           if-no-files-found: error
 
       - name: Download Bicep CLI
@@ -576,36 +568,74 @@ jobs:
         with:
           flags: dotnet
 
-  publish-test-results:
-    name: "Publish Tests Results (${{ matrix.rid }})"
+  comment-test-summary:
+    name: "PR Comment: Tests Summary"
     needs: test-bicep
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      # only needed unless run with comment_mode: off
       pull-requests: write
-    strategy:
-      fail-fast: false
-      matrix:
-        rid: ["win-x64", "linux-x64", "linux-musl-x64", "osx-x64"]
     if: always()
 
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: Bicep.TestResults.${{ matrix.rid }}
-          path: TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.rid }}
+          name: Bicep.TestResults.win-x64
+          path: TestResults/win-x64
 
-      - name: List downloaded artifacts
-        run: ls -R TestResults/
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Bicep.TestResults.linux-x64
+          path: TestResults/linux-x64
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Bicep.TestResults.linux-musl-x64
+          path: TestResults/linux-musl-x64
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Bicep.TestResults.osx-x64
+          path: TestResults/osx-x64
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: "Test Results (${{ matrix.rid }})"
-          files: "TestResults/${{ github.run_id }}/${{ github.run_attempt}}/${{ matrix.rid }}/**/*.trx"
+          check_name: Test Results
+          files: "TestResults/**/*.trx"
   
+  comment-preview-links:
+    name: "PR Comment: Preview Links"
+    needs: [build-vscode-ext, build-cli]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: always()
+
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Test this change out locally with the following install scripts (Action run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}))
+            <details>
+              <summary>VSCode (Mac/Linux)</summary>
+              
+              ```sh
+              bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh) --run-id ${{ github.run_id }}
+              ```
+            </details>
+            <details>
+              <summary>Azure CLI (Mac/Linux)</summary>
+              
+              ```sh
+              bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) --run-id ${{ github.run_id }}
+              ```
+            </details>
+
   can-run-live-tests:
     name: Check secret access
     runs-on: ubuntu-latest

--- a/docs/installing-nightly.md
+++ b/docs/installing-nightly.md
@@ -8,14 +8,14 @@ These steps only work on Linux or Mac platforms
 ### VSCode Extension
 1. Run the following:
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh)
+   bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh)
    ```
 1. Reload your VSCode window.
 
 ### Azure CLI
 1. Run the following:
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh)
+   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh)
    ```
 1. Your Azure CLI install should now be referencing the latest nightly Bicep CLI release.
 
@@ -23,19 +23,19 @@ These steps only work on Linux or Mac platforms
 The following optional arguments are also supported in the nightly install scripts:
 - Installing from a GitHub branch (VSCode extension):
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh) --branch jeskew/variable-imports
+   bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --branch jeskew/variable-imports
    ```
 - Installing from a GitHub branch (CLI):
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) --branch jeskew/variable-imports
+   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --branch jeskew/variable-imports
    ```
 - Installing from a GitHub Action run (VSCode extension):
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_vsix_nightly.sh) --run-id 6146657618
+   bash <(curl -Ls https://aka.ms/bicep/nightly-vsix.sh) --run-id 6146657618
    ```
 - Installing from a GitHub Action run (CLI):
    ```sh
-   bash <(curl -s https://raw.githubusercontent.com/Azure/bicep/main/scripts/install_cli_nightly.sh) --run-id 6146657618
+   bash <(curl -Ls https://aka.ms/bicep/nightly-cli.sh) --run-id 6146657618
    ```
 
 ## Manual


### PR DESCRIPTION
- Add action to log preview install scripts
    <img width="649" alt="image" src="https://github.com/Azure/bicep/assets/38542602/910d3ded-6ab0-41c2-839b-4f4d8112e00b">
- Summarize dotnet test results into single comment rather than 4 separate comments
    <img width="646" alt="image" src="https://github.com/Azure/bicep/assets/38542602/5553e192-d26a-4009-99d8-5cd23779226b">
- Split VSCode into build & test jobs. This means you get a working VSCode package even if there are lint or test failures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11829)