### PR TITLE
Decompile Bicepparams: Use consistent URI -> FS conversion

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/DecompileParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/DecompileParamsCommandTests.cs
@@ -104,8 +104,9 @@ param fourth = {
 param foo = 'bar'";
 
             var (jsonPath, bicepparamPath) = Setup(TestContext, paramFile);
+            var bicepPath = PathHelper.ResolvePath("./dir/main.bicep", Path.GetDirectoryName(jsonPath));
 
-            var (output, error, result) = await Bicep("decompile-params", jsonPath, "--bicep-file", "./dir/main.bicep");
+            var (output, error, result) = await Bicep("decompile-params", jsonPath, "--bicep-file", bicepPath);
 
             using (new AssertionScope())
             {

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -144,7 +144,7 @@ Usage:
       --outfile <file>  Saves the output as the specified file path.
       --stdout          Prints the output to stdout.
       --force           Allows overwriting the output file if it exists (applies only to 'bicep decompile' or 'bicep decompile-params').
-      --bicep-file      Path to the bicep template file (relative to the .bicepparam file) that will be referenced in the using declaration
+      --bicep-file      Path to the bicep template file that will be referenced in the using declaration
 
     Examples:
       bicep decompile-params file.json

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -124,10 +124,11 @@ namespace Bicep.Cli.Services
         public DecompileResult DecompileParams(string inputPath, string outputPath, string? bicepPath)
         {
             inputPath = PathHelper.ResolvePath(inputPath);
-            Uri inputUri = PathHelper.FilePathToFileUrl(inputPath);
-            Uri outputUri = PathHelper.FilePathToFileUrl(outputPath);
+            var inputUri = PathHelper.FilePathToFileUrl(inputPath);
+            var outputUri = PathHelper.FilePathToFileUrl(outputPath);
+            var bicepUri = bicepPath is {} ? PathHelper.FilePathToFileUrl(bicepPath) : null;
 
-            var decompilation =  paramDecompiler.Decompile(inputUri, outputUri, bicepPath);
+            var decompilation =  paramDecompiler.Decompile(inputUri, outputUri, bicepUri);
 
             foreach (var (fileUri, bicepOutput) in decompilation.FilesToSave)
             {

--- a/src/Bicep.Core.UnitTests/FileSystem/PathHelperTests.cs
+++ b/src/Bicep.Core.UnitTests/FileSystem/PathHelperTests.cs
@@ -96,6 +96,23 @@ namespace Bicep.Core.UnitTests.FileSystem
             PathHelper.GetDefaultDecompileOutputPath(path).Should().Be(expectedPath);
         }
 
+        [DataRow("file:///path/to/source.txt", "file:///path/to/target.exe", "./target.exe")]
+        [DataRow("file:///path/to/source.txt", "file:///path/target.exe", "../target.exe")]
+        [DataRow("file:///path/source.txt", "file:///path/to/target.exe", "./to/target.exe")]
+        [DataRow("inmemory:///path/source.txt", "inmemory:///path/to/target.exe", "./to/target.exe")]
+        [TestMethod]
+        public void GetRelativePath_should_return_expected_output(string source, string target, string expected)
+        {
+            PathHelper.GetRelativePath(new Uri(source), new Uri(target)).Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void GetRelativePath_should_fail_for_unexpected_input()
+        {
+            FluentActions.Invoking(() => PathHelper.GetRelativePath(new Uri("file:///foo.txt"), new Uri("inmemory:///bar.txt")))
+                .Should().Throw<InvalidOperationException>().WithMessage("Source scheme 'file' does not match target scheme 'inmemory'");
+        }
+
         public static string GetDisplayName(MethodInfo info, object[] row)
         {
             row.Should().HaveCount(2);

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -220,7 +220,7 @@ namespace Bicep.Core.FileSystem
                 relativePath = $"./{relativePath}";
             }
 
-            return relativePath.StartsWith(".") ? relativePath : $"./{relativePath}";
+            return relativePath;
         }
     }
 }

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -206,5 +206,21 @@ namespace Bicep.Core.FileSystem
 
             return child.AbsolutePath.StartsWith(parentPath);
         }
+
+        public static string GetRelativePath(Uri source, Uri target)
+        {
+            if (source.Scheme != target.Scheme)
+            {
+                throw new InvalidOperationException($"Source scheme '{source.Scheme}' does not match target scheme '{target.Scheme}'");
+            }
+
+            var relativePath = source.MakeRelativeUri(target).OriginalString;
+            if (!relativePath.StartsWith(".")) {
+                // follow the convention of './main.bicep' rather than 'main.bicep'
+                relativePath = $"./{relativePath}";
+            }
+
+            return relativePath.StartsWith(".") ? relativePath : $"./{relativePath}";
+        }
     }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/ParamsDecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/ParamsDecompilationTests.cs
@@ -119,8 +119,7 @@ param second = 1
 param third = true";
 
             var paramFileUri = new Uri("file:///path/to/main.json");
-
-            var bicepFilePath = "./dir/main.bicep";
+            var bicepFileUri = new Uri("file:///path/to/dir/main.bicep");
 
             var fileResolver = new InMemoryFileResolver(new Dictionary<Uri, string>
             {
@@ -132,7 +131,7 @@ param third = true";
             var (entryPointUri, filesToSave) = bicepparamDecompiler.Decompile(
               paramFileUri, 
               PathHelper.ChangeExtension(paramFileUri, LanguageConstants.ParamsFileExtension), 
-              bicepFilePath);
+              bicepFileUri);
 
             filesToSave[entryPointUri].Should().Be(expectedBicepparamFile);         
         }

--- a/src/Bicep.Decompiler/BicepparamDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepparamDecompiler.cs
@@ -38,7 +38,7 @@ public class BicepparamDecompiler
         this.fileResolver = fileResolver;
     }
 
-    public DecompileResult Decompile(Uri entryJsonUri, Uri entryBicepparamUri, string? bicepFilePath)
+    public DecompileResult Decompile(Uri entryJsonUri, Uri entryBicepparamUri, Uri? bicepFileUri)
     {
         var workspace = new Workspace();
 
@@ -47,7 +47,7 @@ public class BicepparamDecompiler
             throw new InvalidOperationException($"Failed to read {entryJsonUri}");
         }
 
-        var program = DecompileParamFile(jsonInput, entryBicepparamUri, bicepFilePath);
+        var program = DecompileParamFile(jsonInput, entryBicepparamUri, bicepFileUri);
 
         var bicepparamFile = SourceFileFactory.CreateBicepParamFile(entryBicepparamUri, program.ToText());
 
@@ -56,16 +56,17 @@ public class BicepparamDecompiler
         return new DecompileResult(entryBicepparamUri, PrintFiles(workspace));
     }
 
-    private ProgramSyntax DecompileParamFile(string jsonInput, Uri entryBicepparamUri, string? bicepFilePath)
+    private ProgramSyntax DecompileParamFile(string jsonInput, Uri entryBicepparamUri, Uri? bicepFileUri)
     {
         var statements = new List<SyntaxBase>();
 
         var jsonObject = JTokenHelpers.LoadJson(jsonInput, JObject.Load, ignoreTrailingContent: false);
+        var bicepPath = bicepFileUri is {} ? PathHelper.GetRelativePath(entryBicepparamUri, bicepFileUri) : null;
 
         statements.Add(new UsingDeclarationSyntax(
             SyntaxFactory.CreateIdentifierToken("using"), 
-            bicepFilePath is { } ?
-            SyntaxFactory.CreateStringLiteral(bicepFilePath): 
+            bicepPath is { } ?
+            SyntaxFactory.CreateStringLiteral(bicepPath): 
             SyntaxFactory.CreateStringLiteralWithComment("", "TODO: Provide a path to a bicep template")));        
 
             statements.Add(SyntaxFactory.DoubleNewlineToken);

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDecompileParamsCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDecompileParamsCommandHandlerTests.cs
@@ -54,13 +54,14 @@ namespace Bicep.LangServer.UnitTests.Handlers
   }
 }";
             var expectedOutput =
-@"using '/main.bicep'
+@"using './main.bicep'
 
 param foo = 'bar'";
 
             var paramFilePath = FileHelper.SaveResultFile(TestContext, "param.json", paramFile);
+            var bicepPath = PathHelper.ResolvePath("./main.bicep", Path.GetDirectoryName(paramFilePath));
 
-            var requestParams = new BicepDecompileParamsCommandParams(DocumentUri.File(paramFilePath), "/main.bicep");
+            var requestParams = new BicepDecompileParamsCommandParams(DocumentUri.File(paramFilePath), DocumentUri.File(bicepPath));
 
             var decompileParamsCommandHandler = CreateHandler();
 

--- a/src/vscode-bicep/src/commands/decompileParams.ts
+++ b/src/vscode-bicep/src/commands/decompileParams.ts
@@ -57,13 +57,13 @@ export class DecompileParamsCommand implements Command {
       );
     }
 
-    const bicepFileUri = await DecompileParamsCommand.selectBicepFile(
-      context,
-    );
+    const bicepFileUri = await DecompileParamsCommand.selectBicepFile(context);
 
     const decompileParamsCommandParams: DecompileParamsCommandParams = {
       jsonUri: documentUri.path,
-      bicepUri: bicepFileUri ? this.client.code2ProtocolConverter.asUri(bicepFileUri) : undefined,
+      bicepUri: bicepFileUri
+        ? this.client.code2ProtocolConverter.asUri(bicepFileUri)
+        : undefined,
     };
 
     this.outputChannelManager.appendToOutputChannel(
@@ -81,20 +81,19 @@ export class DecompileParamsCommand implements Command {
     }
 
     assert(decompileParamsResult.decompiledBicepparamFile !== undefined);
-    let bicepparamPath = this.client.protocol2CodeConverter.asUri(decompileParamsResult.decompiledBicepparamFile.uri).fsPath;
+    let bicepparamPath = this.client.protocol2CodeConverter.asUri(
+      decompileParamsResult.decompiledBicepparamFile.uri,
+    ).fsPath;
 
-    if (
-      await fse.pathExists(bicepparamPath)
-    ) {
+    if (await fse.pathExists(bicepparamPath)) {
       const fileSaveOption = await DecompileParamsCommand.getFileSaveOption(
         context,
       );
 
       if (fileSaveOption === "Copy") {
-        bicepparamPath =
-          await DecompileParamsCommand.getUniquePath(
-            bicepparamPath,
-          );
+        bicepparamPath = await DecompileParamsCommand.getUniquePath(
+          bicepparamPath,
+        );
         this.outputChannelManager.appendToOutputChannel(
           `Saving Decompiled file (copy): ${bicepparamPath}`,
         );

--- a/src/vscode-bicep/src/commands/decompileParams.ts
+++ b/src/vscode-bicep/src/commands/decompileParams.ts
@@ -15,17 +15,17 @@ import assert from "assert";
 
 interface DecompileParamsCommandParams {
   jsonUri: DocumentUri;
-  bicepPath: string | undefined;
+  bicepUri?: DocumentUri;
 }
 
 interface DecompiledBicepparamFile {
   contents: string;
-  absolutePath: string;
+  uri: DocumentUri;
 }
 
 interface DecompileParamsCommandResult {
-  decompiledBicepparamFile: DecompiledBicepparamFile | undefined;
-  errorMessage: string | undefined;
+  decompiledBicepparamFile?: DecompiledBicepparamFile;
+  errorMessage?: string;
 }
 
 export class DecompileParamsCommand implements Command {
@@ -57,14 +57,13 @@ export class DecompileParamsCommand implements Command {
       );
     }
 
-    const bicepFileRelativePath = await DecompileParamsCommand.selectBicepFile(
+    const bicepFileUri = await DecompileParamsCommand.selectBicepFile(
       context,
-      path.dirname(documentUri.fsPath),
     );
 
     const decompileParamsCommandParams: DecompileParamsCommandParams = {
       jsonUri: documentUri.path,
-      bicepPath: bicepFileRelativePath,
+      bicepUri: bicepFileUri ? this.client.code2ProtocolConverter.asUri(bicepFileUri) : undefined,
     };
 
     this.outputChannelManager.appendToOutputChannel(
@@ -82,39 +81,38 @@ export class DecompileParamsCommand implements Command {
     }
 
     assert(decompileParamsResult.decompiledBicepparamFile !== undefined);
+    let bicepparamPath = this.client.protocol2CodeConverter.asUri(decompileParamsResult.decompiledBicepparamFile.uri).fsPath;
 
     if (
-      await fse.pathExists(
-        decompileParamsResult.decompiledBicepparamFile.absolutePath.toString(),
-      )
+      await fse.pathExists(bicepparamPath)
     ) {
       const fileSaveOption = await DecompileParamsCommand.getFileSaveOption(
         context,
       );
 
       if (fileSaveOption === "Copy") {
-        decompileParamsResult.decompiledBicepparamFile.absolutePath =
+        bicepparamPath =
           await DecompileParamsCommand.getUniquePath(
-            decompileParamsResult.decompiledBicepparamFile.absolutePath,
+            bicepparamPath,
           );
         this.outputChannelManager.appendToOutputChannel(
-          `Saving Decompiled file (copy): ${decompileParamsResult.decompiledBicepparamFile.absolutePath}`,
+          `Saving Decompiled file (copy): ${bicepparamPath}`,
         );
       }
 
       if (fileSaveOption === "Overwrite") {
         this.outputChannelManager.appendToOutputChannel(
-          `Overwriting Decompiled file: ${decompileParamsResult.decompiledBicepparamFile.absolutePath}`,
+          `Overwriting Decompiled file: ${bicepparamPath}`,
         );
       }
     } else {
       this.outputChannelManager.appendToOutputChannel(
-        `Saving Decompiled file: ${decompileParamsResult.decompiledBicepparamFile.absolutePath}`,
+        `Saving Decompiled file: ${bicepparamPath}`,
       );
     }
 
     await fse.writeFile(
-      decompileParamsResult.decompiledBicepparamFile.absolutePath,
+      bicepparamPath,
       decompileParamsResult.decompiledBicepparamFile.contents,
     );
   }
@@ -136,8 +134,7 @@ export class DecompileParamsCommand implements Command {
 
   private static async selectBicepFile(
     context: IActionContext,
-    inputDirPath: string,
-  ): Promise<string | undefined> {
+  ): Promise<Uri | undefined> {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       const quickPickItems: IAzureQuickPickItem<string>[] = [
@@ -154,7 +151,7 @@ export class DecompileParamsCommand implements Command {
       const result: IAzureQuickPickItem<string> =
         await context.ui.showQuickPick(quickPickItems, {
           canPickMany: false,
-          placeHolder: `Select a parameter file`,
+          placeHolder: `Link to a Bicep file?`,
         });
 
       if (result.label === "None") {
@@ -165,17 +162,14 @@ export class DecompileParamsCommand implements Command {
         const bicepPaths: Uri[] | undefined =
           await vscode.window.showOpenDialog({
             canSelectMany: false,
-            openLabel: "Select Path File",
+            openLabel: "Select Bicep File",
             filters: {
-              "Bicp Files": ["bicep"],
+              "Bicep Files": ["bicep"],
             },
           });
         if (bicepPaths) {
           assert(bicepPaths.length === 1, "Expected bicepPaths.length === 1");
-          const bicepFileAbsolutePath = bicepPaths[0].fsPath;
-          return path
-            .relative(inputDirPath, bicepFileAbsolutePath)
-            .replaceAll("\\", "/");
+          return bicepPaths[0];
         }
       }
     }


### PR DESCRIPTION
I noticed we're inconsistent in usage of URI vs file system paths in the language server - this PR fixes that.

This **might** address #11615, but I'm not confident we have enough information about it to confirm or deny that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11834)