### PR TITLE
Move call to jest.setTimeout in e2e test to unblock #11852

### DIFF
--- a/src/vscode-bicep/src/test/e2e/setup.ts
+++ b/src/vscode-bicep/src/test/e2e/setup.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+jest.setTimeout(20000);
+
 // Workaround for https://github.com/microsoft/vscode-test/issues/37.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 jest.mock("vscode", () => (global as any).vscode, { virtual: true });
-
-jest.setTimeout(20000);


### PR DESCRIPTION
A dependabot PR (#11852) to update the version of `eslint-plugin-jest` used in the VS Code extension's tests is failing because our setup script triggers an error from a new linting rule. This PR updates the setup script to avoid the linter error
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11880)