### PR TITLE
Use languageVersion 2.0 if any types are imported

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -1047,4 +1047,39 @@ public class CompileTimeImportTests
             ("BCP355", DiagnosticLevel.Error, "Expected the name of an exported symbol at this location."),
         });
     }
+
+    [TestMethod]
+    public void Importing_type_results_in_ARM_language_version_2()
+    {
+        var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImports,
+            ("main.bicep", """
+                import {foo} from 'mod.bicep'
+                """),
+            ("mod.bicep", """
+                @export()
+                type foo = string
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
+    }
+
+    [TestMethod]
+    public void Importing_variables_only_does_not_result_in_elevated_ARM_language_version()
+    {
+        var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImports,
+            ("main.bicep", """
+                import {bar} from 'mod.bicep'
+                """),
+            ("mod.bicep", """
+                @export()
+                type foo = string
+
+                @export()
+                var bar = 'bar'
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().NotHaveValueAtPath("languageVersion");
+    }
 }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -23,6 +23,8 @@ namespace Bicep.Core.Emit
                 model.Features.SymbolicNameCodegenEnabled ||
                 // there are any user-defined type declarations
                 model.Root.TypeDeclarations.Any() ||
+                // there are any user-defined types imported
+                model.Root.ImportedSymbols.Where(imported => imported.Kind == SymbolKind.TypeAlias).Any() ||
                 // any user-defined type declaration syntax is used (e.g., in a `param` or `output` statement)
                 SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
                     seed: false,


### PR DESCRIPTION
Resolves #11881 

Bicep will use languageVersion: 2.0 in compiled templates if the source template contains any `type` statements or uses type expressions that will result in ARM syntax only supported in language version 2.0. The compiler needs to also check if there were any `import` statements that pull in user-defined types, as that will also result in a template with syntax requiring language version 2.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11886)