### PR TITLE
Block calls to scope functions in `.biecpparam` files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5103,4 +5103,26 @@ resource foo3 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 
         result.Should().NotHaveAnyDiagnostics();
     }
+
+    // https://github.com/Azure/bicep/issues/11902
+    [TestMethod]
+    public void Test_Issue11902()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("main.bicep", """
+                param rgName string
+                """),
+            ("parameters.bicepparam", """
+                using 'main.bicep'
+
+                var rg = resourceGroup().name
+                param rgName = rg
+                """));
+
+        result.Should().HaveDiagnostics(new[]
+        {
+            ("BCP057", DiagnosticLevel.Error, "The name \"resourceGroup\" does not exist in the current context."),
+            ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"rg\" is not valid."),
+        });
+    }
 }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5125,4 +5125,38 @@ resource foo3 'Microsoft.Storage/storageAccounts@2022-09-01' = {
             ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"rg\" is not valid."),
         });
     }
+
+    // https://github.com/Azure/bicep/issues/11902
+    [TestMethod]
+    public void Array_access_into_for_expression_should_not_cause_stack_overflow()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("main.bicep", """
+                param rgName string
+                """),
+            ("parameters.bicepparam", """
+                using 'main.bicep'
+
+                var groups = [
+                  {
+                    name: 'foo'
+                    abrv: 'f'
+                  }
+                  {
+                    name: 'bar'
+                    abrv: 'b'
+                  }
+                ]
+
+                var rg = [for group in groups: group.name == resourceGroup().name ? group : []][0].abrv
+                param rgName = rg
+                """));
+
+        result.Should().HaveDiagnostics(new[]
+        {
+            ("BCP138", DiagnosticLevel.Error, "For-expressions are not supported in this context. For-expressions may be used as values of resource, module, variable, and output declarations, or values of resource and module properties."),
+            ("BCP057", DiagnosticLevel.Error, "The name \"resourceGroup\" does not exist in the current context."),
+            ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"rg\" is not valid."),
+        });
+    }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -290,17 +290,6 @@ namespace Bicep.Core.Semantics.Namespaces
 
         private static IEnumerable<FunctionOverload> GetAzOverloads(ResourceScope resourceScope, BicepSourceFileKind sourceFileKind)
         {
-            foreach (var (functionOverload, allowedScopes) in GetScopeFunctions())
-            {
-                // we only include it if it's valid at all of the scopes that the template is valid at
-                if (resourceScope == (resourceScope & allowedScopes))
-                {
-                    yield return functionOverload;
-                }
-
-                // TODO: add banned function to explain why a given function isn't available
-            }
-
             if (sourceFileKind == BicepSourceFileKind.ParamsFile)
             {
                 yield return new FunctionOverloadBuilder(GetSecretFunctionName)
@@ -348,6 +337,17 @@ namespace Bicep.Core.Semantics.Namespaces
             }
             else
             {
+                foreach (var (functionOverload, allowedScopes) in GetScopeFunctions())
+                {
+                    // we only include it if it's valid at all of the scopes that the template is valid at
+                    if (resourceScope == (resourceScope & allowedScopes))
+                    {
+                        yield return functionOverload;
+                    }
+
+                    // TODO: add banned function to explain why a given function isn't available
+                }
+
                 // TODO: Add schema for return type
                 yield return new FunctionOverloadBuilder("deployment")
                     .WithReturnType(GetDeploymentReturnType(resourceScope))

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -1134,7 +1134,7 @@ namespace Bicep.Core.TypeSystem
             Stack<AccessExpressionSyntax> chainedAccesses = syntax.ToAccessExpressionStack();
             var baseAssignment = chainedAccesses.Peek() switch
             {
-                PropertyAccessSyntax access when access.BaseExpression is ForSyntax
+                AccessExpressionSyntax access when access.BaseExpression is ForSyntax
                     // in certain parser recovery scenarios, the parser can produce a PropertyAccessSyntax operating on a ForSyntax
                     // this leads to a stack overflow which we don't really want, so let's short circuit here.
                     => null,


### PR DESCRIPTION
Resolves #11902 

The error message currently shown when a scope function is used in a .bicepparam file is unhelpful. These functions should only be defined in `.bicep` files so that template authors get actionable error messages if they try to use one.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11903)