### PR TITLE
Create workflow to automate code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+dotnet_sort_system_directives_first = true
 
 [*.{ts,tsx,js}]
 indent_style = space

--- a/.github/policies/README.md
+++ b/.github/policies/README.md
@@ -1,3 +1,0 @@
-# GitHub Policies
-
-This folder contains declarative policies that will be run by the Microsoft GitHub Policy Service. A reference on the YML syntax of policy files and on the capabilities of the Policy Service can be found at https://microsoft.github.io/GitOps/policies/resource-management.html

--- a/.github/policies/README.md
+++ b/.github/policies/README.md
@@ -1,0 +1,3 @@
+# GitHub Policies
+
+This folder contains declarative policies that will be run by the Microsoft GitHub Policy Service. A reference on the YML syntax of policy files and on the capabilities of the Policy Service can be found at https://microsoft.github.io/GitOps/policies/resource-management.html

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -1,0 +1,50 @@
+id: prAutoApproval.formatter
+name: GitOps.PullRequestIssueManagement
+description: Automatically approves formatting PRs cut by automation
+owner:
+resource: repository
+disabled: true
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: Create PRs when code formatting is run
+      if:
+        - payloadType: Issue
+        - isOpen: true
+        - isAction:
+            action: Opened
+        - bodyContains:
+            pattern: formatted-refs/heads/main
+            isRegex: false
+        - hasLabel:
+            label: 'code-formatting-automation'
+        - isActivitySender:
+            user: github-actions[bot]
+            issueAuthor: True
+      then:
+        - createPullRequest:
+            head: formatted-refs/heads/main
+            base: main
+            title: "Reformat code"
+            body: "Resolves #${number}"
+    - description: Approve PRs submitted by microsoft-github-policy-service with the "code-formatting-automation" label
+      if:
+      - payloadType: Pull_Request
+      - hasLabel:
+          label: 'code-formatting-automation'
+      - not:
+          hasLabel:
+            label: auto-merge
+      - isActivitySender:
+          user: microsoft-github-policy-service[bot]
+          issueAuthor: False
+      then:
+      - approvePullRequest:
+          comment: ':shipit:'
+      - addLabel:
+          label: auto-merge
+      - enableAutoMerge:
+          mergeMethod: Squash
+onFailure:
+onSuccess:

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -15,7 +15,7 @@ configuration:
             action: Opened
         - bodyContains:
             pattern: formatted-refs/heads/main
-            isRegex: false
+            isRegex: False
         - hasLabel:
             label: 'code-formatting-automation'
         - isActivitySender:

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -11,7 +11,6 @@ configuration:
     - description: Create PRs when code formatting is run
       if:
         - payloadType: Issues
-        - isOpen: true
         - isAction:
             action: Opened
         - bodyContains:

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -10,7 +10,7 @@ configuration:
     eventResponderTasks:
     - description: Create PRs when code formatting is run
       if:
-        - payloadType: Issue
+        - payloadType: Issues
         - isOpen: true
         - isAction:
             action: Opened

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -3,7 +3,7 @@ name: GitOps.PullRequestIssueManagement
 description: Automatically approves formatting PRs cut by automation
 owner:
 resource: repository
-disabled: true
+disabled: False
 where:
 configuration:
   resourceManagementConfiguration:

--- a/.github/workflows/formatter_update.md
+++ b/.github/workflows/formatter_update.md
@@ -1,0 +1,8 @@
+---
+name: Format code
+about: Create a report to help us improve
+title: 'Reformat code'
+labels: 'code-formatting-automation'
+---
+
+There are new updates to pick up on the `{{ env.SOURCE_BRANCH }}` branch.

--- a/.github/workflows/run-formatter.yml
+++ b/.github/workflows/run-formatter.yml
@@ -1,0 +1,75 @@
+name: Run formatter
+# This action will be run weekly against main and can be run on-demand against main.
+# It will run an automated code formatter and commit and push the changes (if any). If the source branch is protected, then the workflow will create a new to commit and push the changes.
+
+on:
+  schedule:
+    - cron: '30 4 * * SUN'
+  workflow_dispatch:
+
+jobs:
+  main:
+    name: Reformat code
+    runs-on: ubuntu-latest
+
+    env:
+      # don't print dotnet logo
+      DOTNET_NOLOGO: true
+
+      # disable telemetry (reduces dotnet tool output in logs)
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+
+      - name: Format
+        run: dotnet format
+
+      - name: Commit and push formatting updates
+        if: (!github.ref_protected)
+        run: |
+          git config --global user.email "bicep@noreply.github.com"
+          git config --global user.name "Bicep Automation"
+
+          git add .
+
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "Run code formatter"
+            git push
+          fi
+
+      - name: Commit formatting updates to branch.
+        id: commit_for_pr
+        if: github.ref_protected
+        env:
+          BRANCH_ID: formatted-${{ github.ref }}
+        run: |
+          git checkout -b $BRANCH_ID
+
+          git config --global user.email "bicep@noreply.github.com"
+          git config --global user.name "Bicep Automation"
+
+          git add .
+
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "Run code formatter"
+            git push -fu origin $BRANCH_ID
+            echo "UPDATES_BRANCH=$BRANCH_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "UPDATES_BRANCH=nil" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue to merge updates
+        if: ${{ github.ref_protected && steps.commit_for_pr.outputs.UPDATES_BRANCH != 'nil' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_BRANCH: ${{ steps.commit_for_pr.outputs.UPDATES_BRANCH }}
+        with:
+          update_existing: true
+          filename: .github/workflows/formatter_update.md

--- a/.github/workflows/run-formatter.yml
+++ b/.github/workflows/run-formatter.yml
@@ -1,6 +1,6 @@
 name: Run formatter
 # This action will be run weekly against main and can be run on-demand against main.
-# It will run an automated code formatter and commit and push the changes (if any). If the source branch is protected, then the workflow will create a new to commit and push the changes.
+# It will run an automated code formatter and commit and push the changes (if any). If the source branch is protected, then the workflow will create a new branch to commit and push the changes.
 
 on:
   schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,12 @@ The Bicep solution is comprised of the following main components:
 * Running VS Code extension unit tests
   * From src\vscode-bicep:
     * `npm i`
-    * `npm run test:unit` or run launch vscode from src\vscode-bicep and run "Launch Tests: Unit Tests (dev)" 
+    * `npm run test:unit` or run launch vscode from src\vscode-bicep and run "Launch Tests: Unit Tests (dev)"
 * Running VS Code extension end-to-end tests
   * From repo root folder: `dotnet build`
   * From src\vscode-bicep:
     * `npm i`
-    * `npm run testlocal:e2e` or run launch vscode from src\vscode-bicep and run "Launch Tests: E2E (dev)" 
+    * `npm run testlocal:e2e` or run launch vscode from src\vscode-bicep and run "Launch Tests: E2E (dev)"
 
 ### Updating test baselines
 
@@ -94,7 +94,7 @@ If you have an active branch pushed to your GitHub fork, you can use the "Update
 ### Running the Bicep CLI
 
 * In the [VSCode Run View](https://code.visualstudio.com/Docs/editor/debugging), select the "Bicep CLI" task, and press the "Start" button. This will build and run the Bicep CLI and allow you to step through the code.
-* Note that usually you will want to pass your own custom arguments to the Bicep CLI. This can be done by modifying the `launch.json` configuration to add arguments to the "args" array for the "Bicep CLI" task. 
+* Note that usually you will want to pass your own custom arguments to the Bicep CLI. This can be done by modifying the `launch.json` configuration to add arguments to the "args" array for the "Bicep CLI" task.
 
 ### 3rd party Syntax Highlighting libraries
 See [Syntax Highlighting Libraries](./docs/highlighting.md) for information on the various 3rd party highlighting libraries that Bicep supports, where they are used, and how to contribute to them.
@@ -117,7 +117,7 @@ We are integrating the Bicep examples into the [Azure QuickStart Templates](http
 
 ### Snippets
 
-If you'd like to contribute to the collection of snippets:  
+If you'd like to contribute to the collection of snippets:
 
 * A snippet should either be a single, generic resource or follow [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type). Ensure your snippet meets this criteria.
 * Add a Bicep file to [`./src/Bicep.LangServer/Files/SnippetTemplates`](./src/Bicep.LangServer/Files/SnippetTemplates) using the naming convention res-RESOURCENAME.bicep
@@ -143,6 +143,12 @@ If you'd like to contribute to the collection of snippets:
 * See [Running the tests](#running-the-tests) if you'd like to test locally before submitting a PR.
 
 * Submit a PR for review
+
+### Repository management and automation
+
+Wherever possible, Bicep uses versioned files for repository management and automation. Bicep primarily relies on:
+* [GitHub actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) maintained in `.github/workflows`, and
+* [Microsoft GitHub Policy Service policies](https://microsoft.github.io/GitOps/policies/resource-management.html) maintained in `.github/policies`.
 
 ## Feature Suggestions
 


### PR DESCRIPTION
This PR adds a workflow to automate running `dotnet format` per the discussion in #11691. Since we can't create a PR from a GitHub action, the workflow is a bit of a Rube Goldberg machine:

1. There is a new GitHub action added that will run `dotnet format` and then either commit and push the results directly to the source branch (if the branch is not protected) or commit and push the results to a branch named `formatted-refs/heads/<branch name>` otherwise. This action can be run on demand for any branch and will be run weekly for the `main` branch.
2. If the push went to a `formatted-...` branch, the action will also create a new issue with the name of the branch in the body and a `code-formatting-automation` label.
3. There is a new policy that will scan for issues with the `code-formatting-automation` label and `formatting-refs/heads/main` in the body and create a PR to merge `formatting-refs/heads/main` into `main` with the `code-formatting-automation` label.
4. There is another policy that will approve and enable automerge for PRs with the `code-formatting-automation` label that were opened by the MS policy bot.

I was able to test steps 1 and 2 with both protected and unprotected branches. The policy yml (for steps 3 & 4) is untested since policies must be committed to the repository's default branch before they will run. 