### PR TITLE
Added Bicep AvailableItemName to MSBuild props

### DIFF
--- a/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.props
+++ b/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.props
@@ -4,5 +4,14 @@
     <BicepDefaultOutputFileExtension Condition=" $(BicepDefaultOutputFileExtension) == '' ">.json</BicepDefaultOutputFileExtension>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- 
+      This has the following effect in Visual Studio:
+      - Makes project up-to-date checks aware of Bicep items
+      - Makes "Bicep" one of the Build Actions available for a file.
+    -->
+    <AvailableItemName Include="Bicep" />
+  </ItemGroup>
+
   <UsingTask TaskName="Bicep" AssemblyFile="$(TaskAssembly)" />
 </Project>


### PR DESCRIPTION
Updated our MSBuild props file to declare an `AvailableItemName` called "Bicep". This tells Visual Studio the following:
* "Bicep" is a build action for a file in a project. 
* `Bicep` items to appear in solution explorer.
* Project up-to-date checks now consider `Bicep` items during analysis. This prevents VS from skipping builds on projects where only a .bicep file was modified.

Unfortunately, this change is not really testable in CI as we're not currently set up for end-to-end MSBuild tests in VS.

This fixes #11847.

Screenshot from VS:
<img width="385" alt="image" src="https://github.com/Azure/bicep/assets/22460039/7b910827-e757-43b5-8926-88797760622e">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11915)