### PR TITLE
Fix nested type property decorator completions

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecorators.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecorators.json
@@ -42,27 +42,6 @@
     }
   },
   {
-    "label": "discriminator",
-    "kind": "function",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\ndiscriminator(value: string): any\n\n```\n\n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_discriminator",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminator($0)"
-    },
-    "command": {
-      "title": "signature help",
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "maxValue",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/intParameterDecoratorsPlusNamespace.json
@@ -42,27 +42,6 @@
     }
   },
   {
-    "label": "discriminator",
-    "kind": "function",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\ndiscriminator(value: string): any\n\n```\n\n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_discriminator",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminator($0)"
-    },
-    "command": {
-      "title": "signature help",
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "maxValue",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecorators.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecorators.json
@@ -42,27 +42,6 @@
     }
   },
   {
-    "label": "discriminator",
-    "kind": "function",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\ndiscriminator(value: string): any\n\n```\n\n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_discriminator",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminator($0)"
-    },
-    "command": {
-      "title": "signature help",
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "maxLength",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/stringParameterDecoratorsPlusNamespace.json
@@ -42,27 +42,6 @@
     }
   },
   {
-    "label": "discriminator",
-    "kind": "function",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\ndiscriminator(value: string): any\n\n```\n\n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "3_discriminator",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "discriminator($0)"
-    },
-    "command": {
-      "title": "signature help",
-      "command": "editor.action.triggerParameterHints"
-    }
-  },
-  {
     "label": "maxLength",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
@@ -237,16 +237,19 @@ type discriminatorInnerSelfCycle2 = typeA | discriminatorInnerSelfCycle2Helper
 
 @discriminator('type')
 //@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
+//@[00:022) [BCP124 (Error)] The decorator "discriminator" can only be attached to targets of type "object", but the target has type "[typeA, typeB]". (CodeDescription: none) |@discriminator('type')|
 type discriminatorTupleBadType1 = [typeA, typeB]
 
 @discriminator('type')
 //@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
+//@[00:022) [BCP124 (Error)] The decorator "discriminator" can only be attached to targets of type "object", but the target has type "[typeA | typeB]". (CodeDescription: none) |@discriminator('type')|
 type discriminatorTupleBadType2 = [typeA | typeB]
 //@[35:040) [BCP293 (Error)] All members of a union type declaration must be literal values. (CodeDescription: none) |typeA|
 //@[43:048) [BCP293 (Error)] All members of a union type declaration must be literal values. (CodeDescription: none) |typeB|
 
 @discriminator('type')
 //@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
+//@[00:022) [BCP124 (Error)] The decorator "discriminator" can only be attached to targets of type "object", but the target has type "[typeA | typeB, typeC | typeD]". (CodeDescription: none) |@discriminator('type')|
 type discriminatorTupleBadType3 = [typeA | typeB, typeC | typeD]
 //@[35:040) [BCP293 (Error)] All members of a union type declaration must be literal values. (CodeDescription: none) |typeA|
 //@[43:048) [BCP293 (Error)] All members of a union type declaration must be literal values. (CodeDescription: none) |typeB|
@@ -268,6 +271,7 @@ type discriminatorInlineAdditionalPropsBadType2 = {
 type discriminatorInlineAdditionalPropsBadType3 = {
   @discriminator('type')
 //@[02:024) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
+//@[02:024) [BCP124 (Error)] The decorator "discriminator" can only be attached to targets of type "object", but the target has type "string". (CodeDescription: none) |@discriminator('type')|
   *: string
 }
 

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1676,6 +1676,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("value", LanguageConstants.String, "The discriminator property name.")
                 .WithFlags(FunctionFlags.ParameterOutputOrTypeDecorator)
                 .WithValidator(ValidateTypeDiscriminator)
+                .WithAttachableType(LanguageConstants.Object)
                 .Build();
         }
 

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -2014,6 +2014,29 @@ output stringOutput |
         }
 
         [TestMethod]
+        public async Task TypePropertyDecoratorsShouldAlignWithPropertyType()
+        {
+            var fileWithCursors = """
+                type obj = {
+                  @|
+                  intProp: int
+                }
+                """;
+            var (text, cursor) = ParserHelper.GetFileWithSingleCursor(fileWithCursors, '|');
+            var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(text);
+            var completions = await file.RequestCompletion(cursor);
+
+            completions.Should().Contain(x => x.Label == "description");
+            completions.Should().Contain(x => x.Label == "metadata");
+            completions.Should().Contain(x => x.Label == "minValue");
+            completions.Should().Contain(x => x.Label == "maxValue");
+
+            completions.Should().NotContain(x => x.Label == "sealed");
+            completions.Should().NotContain(x => x.Label == "secure");
+            completions.Should().NotContain(x => x.Label == "discriminator");
+        }
+
+        [TestMethod]
         public async Task ModuleCompletionsShouldNotBeUrlEscaped()
         {
             var fileWithCursors = @"


### PR DESCRIPTION
Resolves #11970 

The LS is currently looking at the type of the top-level statement in which a cursor is located when proposing decorator completions. This means that for a scenario like the following:

```bicep
type obj = {
  @|
  prop: int
}
```

the LS will propose completions for decorators that can be used on objects (the type of the full `type obj = {...}` statement) rather than decorators that can be used on integers (the type of the decorator's target). Consequently, the LS is proposing completions that will raise an error diagnostic (like `@sealed()` or `@discriminator()`) and not proposing completions that would be valid (like `@minValue()`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11972)