### PR TITLE
Decompile: avoid direct dependencies on the filesystem

### DIFF
--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -31,6 +31,7 @@ namespace Bicep.Cli.Services
         private readonly IModuleDispatcher moduleDispatcher;
         private readonly IConfigurationManager configurationManager;
         private readonly IFeatureProviderFactory featureProviderFactory;
+        private readonly IFileResolver fileResolver;
         private readonly Workspace workspace;
 
         public CompilationService(
@@ -40,7 +41,8 @@ namespace Bicep.Cli.Services
             IDiagnosticLogger diagnosticLogger,
             IModuleDispatcher moduleDispatcher,
             IConfigurationManager configurationManager,
-            IFeatureProviderFactory featureProviderFactory)
+            IFeatureProviderFactory featureProviderFactory,
+            IFileResolver fileResolver)
         {
             this.bicepCompiler = bicepCompiler;
             this.decompiler = decompiler;
@@ -50,6 +52,7 @@ namespace Bicep.Cli.Services
             this.configurationManager = configurationManager;
             this.workspace = new Workspace();
             this.featureProviderFactory = featureProviderFactory;
+            this.fileResolver = fileResolver;
         }
 
         public async Task RestoreAsync(string inputPath, bool forceModulesRestore)
@@ -107,8 +110,12 @@ namespace Bicep.Cli.Services
             inputPath = PathHelper.ResolvePath(inputPath);
             Uri inputUri = PathHelper.FilePathToFileUrl(inputPath);
             Uri outputUri = PathHelper.FilePathToFileUrl(outputPath);
+            if (!fileResolver.TryRead(inputUri).IsSuccess(out var jsonContents, out _))
+            {
+                throw new InvalidOperationException($"Failed to read {inputUri}");
+            }
 
-            var decompilation = await decompiler.Decompile(inputUri, outputUri);
+            var decompilation = await decompiler.Decompile(outputUri, jsonContents);
 
             foreach (var (fileUri, bicepOutput) in decompilation.FilesToSave)
             {

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -110,7 +110,7 @@ namespace Bicep.Cli.Services
             inputPath = PathHelper.ResolvePath(inputPath);
             Uri inputUri = PathHelper.FilePathToFileUrl(inputPath);
             Uri outputUri = PathHelper.FilePathToFileUrl(outputPath);
-            if (!fileResolver.TryRead(inputUri).IsSuccess(out var jsonContents, out _))
+            if (!fileResolver.TryRead(inputUri).IsSuccess(out var jsonContents))
             {
                 throw new InvalidOperationException($"Failed to read {inputUri}");
             }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/conditional/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/conditional/main.bicep
@@ -70,7 +70,7 @@ resource baz 'Foo.Rp/bar@2019-06-01' = if (something == foo) {
   ]
 }
 
-module module1Deploy 'nested/module1.bicep' = if ((1 + 2) == 3) {
+module module1Deploy 'nested/module1.json' = if ((1 + 2) == 3) {
   name: 'module1Deploy'
   params: {
 //@[02:08) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "bar", "baz", "foo". (CodeDescription: none) |params|
@@ -83,7 +83,7 @@ module module1Deploy 'nested/module1.bicep' = if ((1 + 2) == 3) {
   }
 }
 
-module module2Deploy 'nested/module2.bicep' = if ((1 + 2) == 3) {
+module module2Deploy 'nested/module2.json' = if ((1 + 2) == 3) {
   name: 'module2Deploy'
   params: {
 //@[02:08) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "stringParam". (CodeDescription: none) |params|

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.bicep
@@ -1,5 +1,5 @@
-module foo 'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2' = {
-//@[11:93) [BCP190 (Error)] The module with reference "ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2" has not been restored. (CodeDescription: none) |'ts:28cbf98f-381d-4425-9ac4-cf342dab9753/StacksTestRG34xu72emdafmq/ABetterSpec:V2'|
+module foo 'ts:fc88314c-e5cf-4a0b-aee1-743b09254997/StacksTestRG34xu72emdafmq/ABetterSpec:V2' = {
+//@[11:93) [BCP190 (Error)] The module with reference "ts:fc88314c-e5cf-4a0b-aee1-743b09254997/StacksTestRG34xu72emdafmq/ABetterSpec:V2" has not been restored. (CodeDescription: none) |'ts:fc88314c-e5cf-4a0b-aee1-743b09254997/StacksTestRG34xu72emdafmq/ABetterSpec:V2'|
   name: 'foo'
   params: {}
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/issue3246/main.json
@@ -10,7 +10,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "id": "/subscriptions/28cbf98f-381d-4425-9ac4-cf342dab9753/resourceGroups/StacksTestRG34xu72emdafmq/providers/Microsoft.Resources/templateSpecs/ABetterSpec/versions/V2"
+                    "id": "/subscriptions/fc88314c-e5cf-4a0b-aee1-743b09254997/resourceGroups/StacksTestRG34xu72emdafmq/providers/Microsoft.Resources/templateSpecs/ABetterSpec/versions/V2"
                 }
             }
         }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/modules/main.bicep
@@ -15,7 +15,7 @@ var arrayVar = [
   location
 ]
 
-module module1Deploy 'nested/module1.bicep' = {
+module module1Deploy 'nested/module1.json' = {
   name: 'module1Deploy'
   params: {
     location: location
@@ -24,7 +24,7 @@ module module1Deploy 'nested/module1.bicep' = {
   }
 }
 
-module module2Deploy 'nested/module2.bicep' = {
+module module2Deploy 'nested/module2.jsonc' = {
   name: 'module2Deploy'
   params: {
     location: location
@@ -43,21 +43,21 @@ module moduleWithDodgyUri '?' /*TODO: replace with correct path to [concat(param
   }
 }
 
-module moduleWithRg 'nested/module1.bicep' = {
+module moduleWithRg 'nested/module1.json' = {
   name: 'moduleWithRg'
   scope: resourceGroup('test${module1Url}')
   params: {}
 //@[02:08) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "location", "objectParam". (CodeDescription: none) |params|
 }
 
-module moduleWithRgAndSub 'nested/module1.bicep' = {
+module moduleWithRgAndSub 'nested/module1.json' = {
   name: 'moduleWithRgAndSub'
   scope: resourceGroup('${module1Url}test', 'test${module1Url}')
   params: {}
 //@[02:08) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "location", "objectParam". (CodeDescription: none) |params|
 }
 
-module moduleWithSub 'nested/module1.bicep' = {
+module moduleWithSub 'nested/module1.json' = {
   name: 'moduleWithSub'
   scope: subscription('${module1Url}test')
 //@[09:42) [BCP134 (Error)] Scope "subscription" is not valid for this module. Permitted scopes: "resourceGroup". (CodeDescription: none) |subscription('${module1Url}test')|

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -26,80 +26,40 @@ namespace Bicep.Decompiler;
 public class BicepDecompiler
 {
     private readonly BicepCompiler bicepCompiler;
-    private readonly IFileResolver fileResolver;
 
     public static string DecompilerDisclaimerMessage => DecompilerResources.DecompilerDisclaimerMessage;
 
-    public BicepDecompiler(BicepCompiler bicepCompiler, IFileResolver fileResolver)
+    public BicepDecompiler(BicepCompiler bicepCompiler)
     {
         this.bicepCompiler = bicepCompiler;
-        this.fileResolver = fileResolver;
     }
 
-    public async Task<DecompileResult> Decompile(Uri entryJsonUri, Uri entryBicepUri, DecompileOptions? options = null)
+    public async Task<DecompileResult> Decompile(Uri bicepUri, string jsonContent, DecompileOptions? options = null)
     {
         var workspace = new Workspace();
         var decompileQueue = new Queue<(Uri, Uri)>();
         options ??= new DecompileOptions();
 
-        decompileQueue.Enqueue((entryJsonUri, entryBicepUri));
+        var (program, jsonTemplateUrisByModule) = TemplateConverter.DecompileTemplate(workspace, bicepUri, jsonContent, options);
+        var bicepFile = SourceFileFactory.CreateBicepFile(bicepUri, program.ToText());
+        workspace.UpsertSourceFile(bicepFile);
 
-        while (decompileQueue.Count > 0)
-        {
-            var (jsonUri, bicepUri) = decompileQueue.Dequeue();
-
-            if (PathHelper.HasBicepExtension(jsonUri))
-            {
-                throw new InvalidOperationException($"Cannot decompile the file with .bicep extension: {jsonUri}.");
-            }
-
-            if (workspace.TryGetSourceFile(bicepUri, out _))
-            {
-                continue;
-            }
-
-            if (!fileResolver.TryRead(jsonUri).IsSuccess(out var jsonInput))
-            {
-                throw new InvalidOperationException($"Failed to read {jsonUri}");
-            }
-
-            var (program, jsonTemplateUrisByModule) = TemplateConverter.DecompileTemplate(workspace, fileResolver, bicepUri, jsonInput, options);
-            var bicepFile = SourceFileFactory.CreateBicepFile(bicepUri, program.ToText());
-            workspace.UpsertSourceFile(bicepFile);
-
-            foreach (var module in program.Children.OfType<ModuleDeclarationSyntax>())
-            {
-                if (!SyntaxHelper.TryGetForeignTemplatePath(module).IsSuccess(out var moduleRelativePath) ||
-                    !LocalModuleReference.Validate(moduleRelativePath, out _) ||
-                    !Uri.TryCreate(bicepUri, moduleRelativePath, out var moduleUri))
-                {
-                    // Do our best, but keep going if we fail to resolve a module file
-                    continue;
-                }
-
-                if (!workspace.TryGetSourceFile(moduleUri, out _) && jsonTemplateUrisByModule.TryGetValue(module, out var linkedTemplateUri))
-                {
-                    decompileQueue.Enqueue((linkedTemplateUri, moduleUri));
-                }
-            }
-        }
-
-        await RewriteSyntax(workspace, entryBicepUri, semanticModel => new ParentChildResourceNameRewriter(semanticModel));
-        await RewriteSyntax(workspace, entryBicepUri, semanticModel => new DependsOnRemovalRewriter(semanticModel));
-        await RewriteSyntax(workspace, entryBicepUri, semanticModel => new ForExpressionSimplifierRewriter(semanticModel));
+        await RewriteSyntax(workspace, bicepUri, semanticModel => new ParentChildResourceNameRewriter(semanticModel));
+        await RewriteSyntax(workspace, bicepUri, semanticModel => new DependsOnRemovalRewriter(semanticModel));
+        await RewriteSyntax(workspace, bicepUri, semanticModel => new ForExpressionSimplifierRewriter(semanticModel));
         for (var i = 0; i < 5; i++)
         {
             // This is a little weird. If there are casing issues nested inside casing issues (e.g. in an object), then the inner casing issue will have no type information
             // available, as the compilation will not have associated a type with it (since there was no match on the outer object). So we need to correct the outer issue first,
             // and then move to the inner one. We need to recompute the entire compilation to do this. It feels simpler to just do this in passes over the file, rather than on demand.
-            if (!await RewriteSyntax(workspace, entryBicepUri, semanticModel => new TypeCasingFixerRewriter(semanticModel)))
+            if (!await RewriteSyntax(workspace, bicepUri, semanticModel => new TypeCasingFixerRewriter(semanticModel)))
             {
                 break;
             }
         }
 
         return new DecompileResult(
-            entryBicepUri,
+            bicepUri,
             PrintFiles(workspace));
     }
 
@@ -111,7 +71,7 @@ public class BicepDecompiler
         var bicepUri = new Uri("file://jsonInput.json", UriKind.Absolute);
         try
         {
-            var syntax = TemplateConverter.DecompileJsonValue(workspace, fileResolver, bicepUri, jsonInput, options);
+            var syntax = TemplateConverter.DecompileJsonValue(workspace, bicepUri, jsonInput, options);
             return syntax is null ? null : PrintSyntax(syntax);
         }
         catch (Exception)

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -37,16 +37,14 @@ namespace Bicep.Decompiler
 
         private INamingResolver nameResolver;
         private readonly Workspace workspace;
-        private readonly IFileResolver fileResolver;
         private readonly Uri bicepFileUri;
         private readonly JObject template;
         private readonly Dictionary<ModuleDeclarationSyntax, Uri> jsonTemplateUrisByModule;
         private readonly DecompileOptions options;
 
-        private TemplateConverter(Workspace workspace, IFileResolver fileResolver, Uri bicepFileUri, JObject template, Dictionary<ModuleDeclarationSyntax, Uri> jsonTemplateUrisByModule, DecompileOptions options)
+        private TemplateConverter(Workspace workspace, Uri bicepFileUri, JObject template, Dictionary<ModuleDeclarationSyntax, Uri> jsonTemplateUrisByModule, DecompileOptions options)
         {
             this.workspace = workspace;
-            this.fileResolver = fileResolver;
             this.bicepFileUri = bicepFileUri;
             this.template = template;
             this.nameResolver = new UniqueNamingResolver();
@@ -56,7 +54,6 @@ namespace Bicep.Decompiler
 
         public static (ProgramSyntax programSyntax, IReadOnlyDictionary<ModuleDeclarationSyntax, Uri> jsonTemplateUrisByModule) DecompileTemplate(
             Workspace workspace,
-            IFileResolver fileResolver,
             Uri bicepFileUri,
             string content,
             DecompileOptions options)
@@ -65,7 +62,6 @@ namespace Bicep.Decompiler
 
             var instance = new TemplateConverter(
                 workspace,
-                fileResolver,
                 bicepFileUri,
                 templateObject,
                 new(),
@@ -76,7 +72,6 @@ namespace Bicep.Decompiler
 
         public static SyntaxBase? DecompileJsonValue(
             Workspace workspace,
-            IFileResolver fileResolver,
             Uri bicepFileUri,
             string jsonInput,
             DecompileOptions options)
@@ -85,7 +80,6 @@ namespace Bicep.Decompiler
 
             var instance = new TemplateConverter(
                 workspace,
-                fileResolver,
                 bicepFileUri,
                 new JObject(),
                 new(),
@@ -977,26 +971,13 @@ namespace Bicep.Decompiler
                 return (createFakeModulePath(templateLink), null);
             }
 
-            var nestedUri = fileResolver.TryResolveFilePath(bicepFileUri, nestedRelativePath);
-            if (nestedUri is null || !fileResolver.TryRead(nestedUri).IsSuccess())
+            if (!Uri.TryCreate(bicepFileUri, nestedRelativePath, out var nestedUri))
             {
                 // return the original expression so that the author can fix it up rather than failing
                 return (createFakeModulePath(templateLink), null);
             }
 
-            var existIdenticalUrisWithDifferentExtensions = jsonTemplateUrisByModule.Values.Any(uri =>
-                uri != nestedUri && PathHelper.RemoveExtension(uri) == PathHelper.RemoveExtension(nestedUri));
-
-            /*
-             * If there exist another nested template with the same path and filename but a different extension,
-             * append ".bicep" to path of the current nested template to avoid the generate bicep files overwrite each other.
-             * Otherwise, change the extenstion of the nested template to ".bicep".
-             */
-            var moduleFilePath = (existIdenticalUrisWithDifferentExtensions
-                ? nestedRelativePath + ".bicep"
-                : Path.ChangeExtension(nestedRelativePath, ".bicep")).Replace("\\", "/");
-
-            return (SyntaxFactory.CreateStringLiteral(moduleFilePath), nestedUri);
+            return (SyntaxFactory.CreateStringLiteral(nestedRelativePath), nestedUri);
         }
 
         /// <summary>
@@ -1362,14 +1343,18 @@ namespace Bicep.Decompiler
                 var nestedValue = ProcessCondition(resource, nestedBody);
 
                 var filePath = $"./nested_{identifier}.bicep";
-                var nestedModuleUri = fileResolver.TryResolveFilePath(bicepFileUri, filePath) ?? throw new ConversionFailedException($"Unable to module uri for {typeString} {nameString}", nestedTemplate);
+                if (!Uri.TryCreate(bicepFileUri, filePath, out var nestedModuleUri))
+                {
+                    throw new ConversionFailedException($"Failed to create module uri for {typeString} {nameString}", nestedTemplate);
+                }
+
                 if (workspace.TryGetSourceFile(nestedModuleUri, out _))
                 {
                     throw new ConversionFailedException($"Unable to generate duplicate module to path ${nestedModuleUri} for {typeString} {nameString}", nestedTemplate);
                 }
 
                 var nestedOptions = this.options with { AllowMissingParamsAndVars = this.options.AllowMissingParamsAndVarsInNestedTemplates };
-                var nestedConverter = new TemplateConverter(workspace, fileResolver, nestedModuleUri, nestedTemplateObject, this.jsonTemplateUrisByModule, nestedOptions);
+                var nestedConverter = new TemplateConverter(workspace, nestedModuleUri, nestedTemplateObject, this.jsonTemplateUrisByModule, nestedOptions);
                 var nestedBicepFile = SourceFileFactory.CreateBicepFile(nestedModuleUri, nestedConverter.Parse().ToText());
                 workspace.UpsertSourceFile(nestedBicepFile);
 

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDecompileCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDecompileCommandHandlerTests.cs
@@ -708,9 +708,8 @@ module nestedDeploymentInner2 './nested_nestedDeploymentInner2.bicep' = {
 
             output.Should().NotMatchRegex("Overwriting");
             output.Should().MatchRegex("Writing .*[\\\\/]main.bicep");
-            output.Should().MatchRegex("Writing .*[\\\\/]parent_child.bicep");
             output.Should().MatchRegex("Decompilation complete.");
-            saveResult.mainSavedBicepPath.Should().BeEquivalentToPath(Path.Join(testOutputPath, "abc", "def", "main_decompiled", "main.bicep"), "Should have displayed main file");
+            saveResult.mainSavedBicepPath.Should().BeEquivalentToPath(Path.Join(testOutputPath, "abc", "def", "main.bicep"), "Should have displayed main file");
         }
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDecompileForPasteCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDecompileForPasteCommandHandler.cs
@@ -223,11 +223,10 @@ namespace Bicep.LanguageServer.Handlers
                 // Decompile the full template
                 Debug.Assert(constructedJsonTemplate is not null);
                 Log(output, String.Format(LangServerResources.Decompile_DecompilationStartMsg, "clipboard text"));
-                var singleFileResolver = new SingleFileResolver(JsonDummyUri, constructedJsonTemplate);
 
-                var decompiler = new BicepDecompiler(this.bicepCompiler, singleFileResolver);
+                var decompiler = new BicepDecompiler(this.bicepCompiler);
                 var options = GetDecompileOptions(pasteType);
-                (_, filesToSave) = await decompiler.Decompile(JsonDummyUri, BicepDummyUri, options);
+                (_, filesToSave) = await decompiler.Decompile(BicepDummyUri, constructedJsonTemplate, options: options);
             }
             catch (Exception ex)
             {
@@ -296,10 +295,8 @@ namespace Bicep.LanguageServer.Handlers
 
         private ResultAndTelemetry? TryConvertFromJsonValue(StringBuilder output, string json, string decompileId, PasteContext pasteContext, bool queryCanPaste)
         {
-            var singleFileResolver = new SingleFileResolver(JsonDummyUri, json);
-
             // Is it valid JSON that we can convert into Bicep?
-            var decompiler = new BicepDecompiler(this.bicepCompiler, singleFileResolver);
+            var decompiler = new BicepDecompiler(this.bicepCompiler);
             var pasteType = PasteType_JsonValue;
             var options = GetDecompileOptions(pasteType);
             var bicep = decompiler.DecompileJsonValue(json, options);
@@ -499,85 +496,5 @@ namespace Bicep.LanguageServer.Handlers
 
         private static string? TryGetStringProperty(JObject obj, string name)
             => (TryGetProperty(obj, name)?.Value as JValue)?.Value as string;
-    }
-
-    /// <summary>
-    /// A simple IFileResolver implementation that provides just enough capability to provide content for a single file
-    /// </summary>
-    class SingleFileResolver : IFileResolver
-    {
-        public Uri Uri { get; }
-        public string contents { get; }
-
-        public SingleFileResolver(Uri uri, string contents)
-        {
-            this.Uri = uri;
-            this.contents = contents;
-        }
-
-        public bool DirExists(Uri fileUri)
-        {
-            throw new NotImplementedException();
-        }
-
-        public bool FileExists(Uri uri)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IEnumerable<Uri> GetDirectories(Uri fileUri, string pattern = "")
-        {
-            throw new NotImplementedException();
-        }
-
-        public IEnumerable<Uri> GetFiles(Uri fileUri, string pattern = "")
-        {
-            throw new NotImplementedException();
-        }
-
-        public string GetRelativePath(string relativeTo, string path)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IDisposable? TryAcquireFileLock(Uri fileUri)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ResultWithDiagnostic<string> TryRead(Uri fileUri)
-        {
-            if (fileUri.Equals(this.Uri))
-            {
-                return new(this.contents);
-            }
-
-            return new(x => x.UnableToLoadNonFileUri(fileUri));
-        }
-
-        public ResultWithDiagnostic<FileWithEncoding> TryRead(Uri fileUri, Encoding fileEncoding, int maxCharacters)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ResultWithDiagnostic<string> TryReadAtMostNCharacters(Uri fileUri, Encoding fileEncoding, int n)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ResultWithDiagnostic<string> TryReadAsBase64(Uri fileUri, int maxCharacters = -1)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Uri? TryResolveFilePath(Uri parentFileUri, string childFilePath)
-        {
-            return new Uri(Path.Combine(parentFileUri.LocalPath, childFilePath), UriKind.Absolute);
-        }
-
-        public void Write(Uri fileUri, Stream contents)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/Bicep.Wasm/Interop.cs
+++ b/src/Bicep.Wasm/Interop.cs
@@ -67,15 +67,10 @@ namespace Bicep.Wasm
         {
             using var serviceScope = serviceProvider.CreateScope();
             var decompiler = serviceScope.ServiceProvider.GetRequiredService<BicepDecompiler>();
-            var fileSystem = serviceScope.ServiceProvider.GetRequiredService<IFileSystem>();
-
-            var jsonUri = new Uri("file:///main.json");
-            await fileSystem.File.WriteAllTextAsync(jsonUri.LocalPath, jsonContent);
 
             try
             {
-                var bicepUri = PathHelper.ChangeToBicepExtension(jsonUri);
-                var (entrypointUri, filesToSave) = await decompiler.Decompile(jsonUri, bicepUri);
+                var (entrypointUri, filesToSave) = await decompiler.Decompile(new Uri("inmemory:///main.bicep"), jsonContent);
 
                 return new DecompileResult(filesToSave[entrypointUri], null);
             }


### PR DESCRIPTION
Now that we support JSON modules, we can avoid the attempted conversion from JSON -> Bicep for linked templates and instead reference them directly.

This simplifies the decompile API for the Bicep RP.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11979)