### PR TITLE
Perform deep validation on assigned parameter values in `.bicepparam` files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5272,4 +5272,30 @@ resource foo3 'Microsoft.Storage/storageAccounts@2022-09-01' = {
             ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"rg\" is not valid."),
         });
     }
+
+    // https://github.com/Azure/bicep/issues/11981
+    [TestMethod]
+    public void Test_Issue11981()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("main.bicep", """
+                @sealed()
+                param foo {
+                  bar: string
+                }
+                """),
+            ("parameters.bicepparam", """
+                using 'main.bicep'
+
+                param foo = {
+                  bar: 'bar'
+                  baz: 'baz'
+                }
+                """));
+
+        result.Should().HaveDiagnostics(new[]
+        {
+            ("BCP037", DiagnosticLevel.Error, "The property \"baz\" is not allowed on objects of type \"{ bar: string }\". No other properties are allowed."),
+        });
+    }
 }

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Expressions/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Expressions/parameters.diagnostics.bicepparam
@@ -2,42 +2,42 @@ using 'main.bicep'
 
 param testAny = any('foo')
 param testArray = array({})
-//@[00:27) [BCP260 (Error)] The parameter "testArray" expects a value of type "object" but the provided value is of type "array". (CodeDescription: none) |param testArray = array({})|
+//@[18:27) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "array". (CodeDescription: none) |array({})|
 param testBase64ToString = base64ToString(concat(base64('abc'), '@'))
-//@[00:69) [BCP260 (Error)] The parameter "testBase64ToString" expects a value of type "object" but the provided value is of type "string". (CodeDescription: none) |param testBase64ToString = base64ToString(concat(base64('abc'), '@'))|
+//@[27:69) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |base64ToString(concat(base64('abc'), '@'))|
 //@[27:69) [BCP338 (Error)] Failed to evaluate parameter "testBase64ToString": The template language function 'base64ToString' was invoked with a parameter that is not valid. The value cannot be decoded from base64 representation. (CodeDescription: none) |base64ToString(concat(base64('abc'), '@'))|
 //@[42:68) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (CodeDescription: bicep core(https://aka.ms/bicep/linter/prefer-interpolation)) |concat(base64('abc'), '@')|
 param testBase64ToJson = base64ToJson(base64('{"hi": "there"')).hi
 param testBool = bool('sdf')
-//@[00:28) [BCP260 (Error)] The parameter "testBool" expects a value of type "object" but the provided value is of type "bool". (CodeDescription: none) |param testBool = bool('sdf')|
+//@[17:28) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "bool". (CodeDescription: none) |bool('sdf')|
 //@[17:28) [BCP338 (Error)] Failed to evaluate parameter "testBool": The template language function 'bool' was invoked with a parameter that is not valid. The value cannot be converted to the target type. (CodeDescription: none) |bool('sdf')|
 param testConcat = concat(['abc'], {foo: 'bar'})
 //@[35:47) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "array". (CodeDescription: none) |{foo: 'bar'}|
 param testContains = contains('foo/bar', {})
 //@[41:43) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "string". (CodeDescription: none) |{}|
 param testDataUriToString = dataUriToString(concat(dataUri('abc'), '@'))
-//@[00:72) [BCP260 (Error)] The parameter "testDataUriToString" expects a value of type "object" but the provided value is of type "string". (CodeDescription: none) |param testDataUriToString = dataUriToString(concat(dataUri('abc'), '@'))|
+//@[28:72) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |dataUriToString(concat(dataUri('abc'), '@'))|
 //@[28:72) [BCP338 (Error)] Failed to evaluate parameter "testDataUriToString": The template language function 'dataUriToString' was invoked with a parameter that is not valid. The value cannot be converted to the target type. (CodeDescription: none) |dataUriToString(concat(dataUri('abc'), '@'))|
 //@[44:71) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (CodeDescription: bicep core(https://aka.ms/bicep/linter/prefer-interpolation)) |concat(dataUri('abc'), '@')|
 param testDateTimeAdd = dateTimeAdd(dateTimeFromEpoch(1680224438), 'PTASDIONS1D')  
-//@[00:81) [BCP260 (Error)] The parameter "testDateTimeAdd" expects a value of type "object" but the provided value is of type "string". (CodeDescription: none) |param testDateTimeAdd = dateTimeAdd(dateTimeFromEpoch(1680224438), 'PTASDIONS1D')|
+//@[24:81) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |dateTimeAdd(dateTimeFromEpoch(1680224438), 'PTASDIONS1D')|
 //@[24:81) [BCP338 (Error)] Failed to evaluate parameter "testDateTimeAdd": The template function 'dateTimeAdd' has an invalid parameter. The second parameter 'PTASDIONS1D' is not a valid ISO8601 Duration string. Please see https://aka.ms/arm-syntax-functions . (CodeDescription: none) |dateTimeAdd(dateTimeFromEpoch(1680224438), 'PTASDIONS1D')|
 param testDateTimeToEpoch = dateTimeToEpoch(dateTimeFromEpoch('adfasdf'))
 //@[62:71) [BCP070 (Error)] Argument of type "'adfasdf'" is not assignable to parameter of type "int". (CodeDescription: none) |'adfasdf'|
 param testEmpty = empty([])
-//@[00:27) [BCP260 (Error)] The parameter "testEmpty" expects a value of type "object" but the provided value is of type "true". (CodeDescription: none) |param testEmpty = empty([])|
+//@[18:27) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "true". (CodeDescription: none) |empty([])|
 param testEndsWith = endsWith('foo', [])
 //@[37:39) [BCP070 (Error)] Argument of type "<empty array>" is not assignable to parameter of type "string". (CodeDescription: none) |[]|
 param testFilter = filter([1, 2], i => i < 'foo')
-//@[00:49) [BCP260 (Error)] The parameter "testFilter" expects a value of type "object" but the provided value is of type "(1 | 2)[]". (CodeDescription: none) |param testFilter = filter([1, 2], i => i < 'foo')|
+//@[19:49) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "(1 | 2)[]". (CodeDescription: none) |filter([1, 2], i => i < 'foo')|
 //@[19:49) [BCP338 (Error)] Failed to evaluate parameter "testFilter": The template language function 'less' expects two parameters of matching types. The function was invoked with values of type 'Integer' and 'String' that do not match. (CodeDescription: none) |filter([1, 2], i => i < 'foo')|
 //@[39:48) [BCP045 (Error)] Cannot apply operator "<" to operands of type "1 | 2" and "'foo'". (CodeDescription: none) |i < 'foo'|
 param testFirst = first('asdfds')
-//@[00:33) [BCP260 (Error)] The parameter "testFirst" expects a value of type "object" but the provided value is of type "'a'". (CodeDescription: none) |param testFirst = first('asdfds')|
+//@[18:33) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'a'". (CodeDescription: none) |first('asdfds')|
 param testFlatten = flatten({foo: 'bar'})
 //@[28:40) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "array[]". (CodeDescription: none) |{foo: 'bar'}|
 param testFormat = format('->{123}<-', 123)
-//@[00:43) [BCP260 (Error)] The parameter "testFormat" expects a value of type "object" but the provided value is of type "string". (CodeDescription: none) |param testFormat = format('->{123}<-', 123)|
+//@[19:43) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |format('->{123}<-', 123)|
 //@[19:43) [BCP338 (Error)] Failed to evaluate parameter "testFormat": Unable to evaluate language function 'format': the format is invalid: 'Index (zero based) must be greater than or equal to zero and less than the size of the argument list.'. Please see https://aka.ms/arm-function-format for usage details. (CodeDescription: none) |format('->{123}<-', 123)|
 //@[26:42) [BCP234 (Warning)] The ARM function "format" failed when invoked on the value [->{123}<-, 123]: Unable to evaluate language function 'format': the format is invalid: 'Index (zero based) must be greater than or equal to zero and less than the size of the argument list.'. Please see https://aka.ms/arm-function-format for usage details. (CodeDescription: none) |'->{123}<-', 123|
 param testGuid = guid({})
@@ -45,7 +45,7 @@ param testGuid = guid({})
 param testIndexOf = indexOf('abc', {})
 //@[35:37) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "string". (CodeDescription: none) |{}|
 param testInt = int('asdf')
-//@[00:27) [BCP260 (Error)] The parameter "testInt" expects a value of type "object" but the provided value is of type "int". (CodeDescription: none) |param testInt = int('asdf')|
+//@[16:27) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "int". (CodeDescription: none) |int('asdf')|
 //@[16:27) [BCP338 (Error)] Failed to evaluate parameter "testInt": The template language function 'int' cannot convert provided value 'asdf' to integer value. Please see https://aka.ms/arm-function-int for usage details. (CodeDescription: none) |int('asdf')|
 param testIntersection = intersection([1, 2, 3], 'foo')
 //@[49:54) [BCP070 (Error)] Argument of type "'foo'" is not assignable to parameter of type "array". (CodeDescription: none) |'foo'|
@@ -54,19 +54,19 @@ param testItems = items('asdfas')
 param testJoin = join(['abc', 'def', 'ghi'], {})
 //@[45:47) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "string". (CodeDescription: none) |{}|
 param testLast = last('asdf')
-//@[00:29) [BCP260 (Error)] The parameter "testLast" expects a value of type "object" but the provided value is of type "'f'". (CodeDescription: none) |param testLast = last('asdf')|
+//@[17:29) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'f'". (CodeDescription: none) |last('asdf')|
 param testLastIndexOf = lastIndexOf('abcba', {})
 //@[45:47) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "string". (CodeDescription: none) |{}|
 param testLength = length({})
-//@[00:29) [BCP260 (Error)] The parameter "testLength" expects a value of type "object" but the provided value is of type "0". (CodeDescription: none) |param testLength = length({})|
+//@[19:29) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "0". (CodeDescription: none) |length({})|
 param testLoadFileAsBase64 = loadFileAsBase64('test.txt')
-//@[00:57) [BCP260 (Error)] The parameter "testLoadFileAsBase64" expects a value of type "object" but the provided value is of type "test.txt". (CodeDescription: none) |param testLoadFileAsBase64 = loadFileAsBase64('test.txt')|
+//@[29:57) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "test.txt". (CodeDescription: none) |loadFileAsBase64('test.txt')|
 param testLoadJsonContent = loadJsonContent('test.json').adsfsd
 //@[57:63) [BCP053 (Error)] The type "object" does not contain property "adsfsd". Available properties include "hello from". (CodeDescription: none) |adsfsd|
 param testLoadTextContent = loadTextContent('test.txt')
-//@[00:55) [BCP260 (Error)] The parameter "testLoadTextContent" expects a value of type "object" but the provided value is of type "'Hello from text file'". (CodeDescription: none) |param testLoadTextContent = loadTextContent('test.txt')|
+//@[28:55) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'Hello from text file'". (CodeDescription: none) |loadTextContent('test.txt')|
 param testMap = map(range(0, 3), i => dataUriToString('Hi ${i}!'))
-//@[00:66) [BCP260 (Error)] The parameter "testMap" expects a value of type "object" but the provided value is of type "string[]". (CodeDescription: none) |param testMap = map(range(0, 3), i => dataUriToString('Hi ${i}!'))|
+//@[16:66) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string[]". (CodeDescription: none) |map(range(0, 3), i => dataUriToString('Hi ${i}!'))|
 //@[16:66) [BCP338 (Error)] Failed to evaluate parameter "testMap": The template language function 'dataUriToString' expects its parameter to be formatted as a valid data URI. The provided value 'Hi 0!' was not formatted correctly. Please see https://aka.ms/arm-functions#dataUriToString for usage details. (CodeDescription: none) |map(range(0, 3), i => dataUriToString('Hi ${i}!'))|
 param testMax = max(1, 2, '3')
 //@[26:29) [BCP070 (Error)] Argument of type "'3'" is not assignable to parameter of type "int". (CodeDescription: none) |'3'|
@@ -84,7 +84,7 @@ param testReplace = replace('abc', 'b', {})
 param testSkip = skip([1, 2, 3], '1')
 //@[33:36) [BCP070 (Error)] Argument of type "'1'" is not assignable to parameter of type "int". (CodeDescription: none) |'1'|
 param testSort = sort(['c', 'd', 'a'], (a, b) => a + b)
-//@[00:55) [BCP260 (Error)] The parameter "testSort" expects a value of type "object" but the provided value is of type "('a' | 'c' | 'd')[]". (CodeDescription: none) |param testSort = sort(['c', 'd', 'a'], (a, b) => a + b)|
+//@[17:55) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "('a' | 'c' | 'd')[]". (CodeDescription: none) |sort(['c', 'd', 'a'], (a, b) => a + b)|
 //@[17:55) [BCP338 (Error)] Failed to evaluate parameter "testSort": Unhandled exception during evaluating template language function 'sort' is not handled. (CodeDescription: none) |sort(['c', 'd', 'a'], (a, b) => a + b)|
 //@[49:54) [BCP045 (Error)] Cannot apply operator "+" to operands of type "'a' | 'c' | 'd'" and "'a' | 'c' | 'd'". Use string interpolation instead. (CodeDescription: none) |a + b|
 param testSplit = split('a/b/c', 1 + 2)
@@ -92,7 +92,7 @@ param testSplit = split('a/b/c', 1 + 2)
 param testStartsWith = startsWith('abc', {})
 //@[41:43) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "string". (CodeDescription: none) |{}|
 param testString = string({})
-//@[00:29) [BCP260 (Error)] The parameter "testString" expects a value of type "object" but the provided value is of type "string". (CodeDescription: none) |param testString = string({})|
+//@[19:29) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |string({})|
 param testSubstring = substring('asdfasf', '3')
 //@[43:46) [BCP070 (Error)] Argument of type "'3'" is not assignable to parameter of type "int". (CodeDescription: none) |'3'|
 param testTake = take([1, 2, 3], '2')
@@ -108,9 +108,9 @@ param testTrim = trim(123)
 param testUnion = union({ abc: 'def' }, [123])
 //@[40:45) [BCP070 (Error)] Argument of type "[123]" is not assignable to parameter of type "object". (CodeDescription: none) |[123]|
 param testUniqueString = uniqueString('asd', 'asdf', 'asdf')
-//@[00:60) [BCP260 (Error)] The parameter "testUniqueString" expects a value of type "object" but the provided value is of type "'iizpqit7ih3cc'". (CodeDescription: none) |param testUniqueString = uniqueString('asd', 'asdf', 'asdf')|
+//@[25:60) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'iizpqit7ih3cc'". (CodeDescription: none) |uniqueString('asd', 'asdf', 'asdf')|
 param testUri = uri('github.com', 'Azure/bicep')
-//@[00:48) [BCP260 (Error)] The parameter "testUri" expects a value of type "object" but the provided value is of type "string". (CodeDescription: none) |param testUri = uri('github.com', 'Azure/bicep')|
+//@[16:48) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "string". (CodeDescription: none) |uri('github.com', 'Azure/bicep')|
 //@[16:48) [BCP338 (Error)] Failed to evaluate parameter "testUri": The template language function 'uri' expects its first argument to be a uri string. The provided value is 'github.com'. Please see https://aka.ms/arm-function-datauri for usage details. (CodeDescription: none) |uri('github.com', 'Azure/bicep')|
 //@[20:47) [BCP234 (Warning)] The ARM function "uri" failed when invoked on the value [github.com, Azure/bicep]: The template language function 'uri' expects its first argument to be a uri string. The provided value is 'github.com'. Please see https://aka.ms/arm-function-datauri for usage details. (CodeDescription: none) |'github.com', 'Azure/bicep'|
 param testUriComponent = uriComponent(123)

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_MismatchedTypes/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_MismatchedTypes/parameters.diagnostics.bicepparam
@@ -1,22 +1,22 @@
 using './main.bicep'
 
 param string = 123
-//@[0:18) [BCP260 (Error)] The parameter "string" expects a value of type "string" but the provided value is of type "123". (CodeDescription: none) |param string = 123|
+//@[15:18) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "123". (CodeDescription: none) |123|
 
 param bool = 'hello'
-//@[0:20) [BCP260 (Error)] The parameter "bool" expects a value of type "bool" but the provided value is of type "'hello'". (CodeDescription: none) |param bool = 'hello'|
+//@[13:20) [BCP033 (Error)] Expected a value of type "bool" but the provided value is of type "'hello'". (CodeDescription: none) |'hello'|
 
 param int = false
-//@[0:17) [BCP260 (Error)] The parameter "int" expects a value of type "int" but the provided value is of type "false". (CodeDescription: none) |param int = false|
+//@[12:17) [BCP033 (Error)] Expected a value of type "int" but the provided value is of type "false". (CodeDescription: none) |false|
 
 param object = ['abc', 'def']
-//@[0:29) [BCP260 (Error)] The parameter "object" expects a value of type "object" but the provided value is of type "['abc', 'def']". (CodeDescription: none) |param object = ['abc', 'def']|
+//@[15:29) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "['abc', 'def']". (CodeDescription: none) |['abc', 'def']|
 
 param array = {
-//@[0:38) [BCP260 (Error)] The parameter "array" expects a value of type "array" but the provided value is of type "object". (CodeDescription: none) |param array = {\n  isThis: 'correct?'\n}|
+//@[14:38) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "object". (CodeDescription: none) |{\n  isThis: 'correct?'\n}|
   isThis: 'correct?'
 }
 
 param stringAllowed = 'notTheAllowedValue'
-//@[0:42) [BCP260 (Error)] The parameter "stringAllowed" expects a value of type "'bar' | 'foo'" but the provided value is of type "'notTheAllowedValue'". (CodeDescription: none) |param stringAllowed = 'notTheAllowedValue'|
+//@[22:42) [BCP033 (Error)] Expected a value of type "'bar' | 'foo'" but the provided value is of type "'notTheAllowedValue'". (CodeDescription: none) |'notTheAllowedValue'|
 

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -552,10 +552,14 @@ namespace Bicep.Core.Semantics
             {
                 if (assignmentSymbol.Type is not ErrorType &&
                     assignmentSymbol.Type is not NullType && // `param x = null` is equivalent to skipping the assignment altogether
-                    TypeManager.GetDeclaredType(assignmentSymbol.DeclaringSyntax) is { } declaredType &&
-                    !TypeValidator.AreTypesAssignable(assignmentSymbol.Type, declaredType))
+                    TypeManager.GetDeclaredType(assignmentSymbol.DeclaringSyntax) is { } declaredType)
                 {
-                    yield return DiagnosticBuilder.ForPosition(assignmentSymbol.DeclaringSyntax).ParameterTypeMismatch(assignmentSymbol.Name, declaredType, assignmentSymbol.Type);
+                    var diagnostics = ToListDiagnosticWriter.Create();
+                    TypeValidator.NarrowTypeAndCollectDiagnostics(TypeManager, Binder, ParsingErrorLookup, diagnostics, assignmentSymbol.DeclaringParameterAssignment.Value, declaredType);
+                    foreach (var diagnostic in diagnostics.GetDiagnostics())
+                    {
+                        yield return diagnostic;
+                    }
                 }
             }
         }

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDeploymentStartCommandHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         {
             var bicepFileContents = @"
 param foo string
-param bar int            
+param bar int
             ";
 
             var bicepparamFileContents = @"
@@ -63,7 +63,7 @@ param foo = 'something'
 param bar = 1
             ";
 
-            var expectedParamJson = 
+            var expectedParamJson =
 @"{
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
   ""contentVersion"": ""1.0.0.0"",
@@ -99,7 +99,7 @@ param bar = 1
         {
             var bicepFileContents = @"
 param foo string
-param bar int            
+param bar int
             ";
 
             var bicepparamFileContents = @"
@@ -109,7 +109,7 @@ param foo = 'something'
 param bar = '1'
             ";
 
-            var expectedError = @"Error BCP260: The parameter ""bar"" expects a value of type ""int"" but the provided value is of type ""'1'""";
+            var expectedError = @"Error BCP033: Expected a value of type ""int"" but the provided value is of type ""'1'""";
 
             string bicepFilePath = FileHelper.SaveResultFile(TestContext, "main.bicep", bicepFileContents);
             var dir = Path.GetDirectoryName(bicepFilePath);
@@ -131,7 +131,7 @@ param bar = '1'
         [TestMethod]
         public void ExtractParametersObject_WithValidJsonReturns_ParametersPropertyValue()
         {
-            var paramJson = 
+            var paramJson =
 @"{
   ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
   ""contentVersion"": ""1.0.0.0"",


### PR DESCRIPTION
Resolves #11981 

Type analysis in `.bicepparam` files is currently only performing an assignability (shallow type affinity) check. This PR updates that analysis to use the `TypeValidator`'s deep validation method to match how parameter default values and resource bodies are checked.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/11985)