### PR TITLE
Update staging branch name in code formatting automation

### DIFF
--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -14,7 +14,7 @@ configuration:
         - isAction:
             action: Opened
         - bodyContains:
-            pattern: formatted-main
+            pattern: chores/format/main
             isRegex: False
         - hasLabel:
             label: 'code-formatting-automation'
@@ -23,7 +23,7 @@ configuration:
             issueAuthor: True
       then:
         - createPullRequest:
-            head: formatted-main
+            head: chores/format/main
             base: main
             title: "Reformat code"
             body: "Resolves #${number}"

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -14,7 +14,7 @@ configuration:
         - isAction:
             action: Opened
         - bodyContains:
-            pattern: formatted-refs/heads/main
+            pattern: formatted-main
             isRegex: False
         - hasLabel:
             label: 'code-formatting-automation'
@@ -23,7 +23,7 @@ configuration:
             issueAuthor: True
       then:
         - createPullRequest:
-            head: formatted-refs/heads/main
+            head: formatted-main
             base: main
             title: "Reformat code"
             body: "Resolves #${number}"

--- a/.github/workflows/run-formatter.yml
+++ b/.github/workflows/run-formatter.yml
@@ -47,7 +47,7 @@ jobs:
         id: commit_for_pr
         if: github.ref_protected
         env:
-          BRANCH_ID: formatted-${{ github.ref_name }}
+          BRANCH_ID: chores/format/${{ github.ref_name }}
         run: |
           git checkout -b $BRANCH_ID
 

--- a/.github/workflows/run-formatter.yml
+++ b/.github/workflows/run-formatter.yml
@@ -47,7 +47,7 @@ jobs:
         id: commit_for_pr
         if: github.ref_protected
         env:
-          BRANCH_ID: formatted-${{ github.ref }}
+          BRANCH_ID: formatted-${{ github.ref_name }}
         run: |
           git checkout -b $BRANCH_ID
 


### PR DESCRIPTION
Use `github.ref_name` instead of `github.ref` to trim out `refs/heads/` prefix

Addresses https://github.com/Azure/bicep/issues/11987#issuecomment-1743095584

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12021)