### PR TITLE
CodeFix: Remove relative path prefix from types loading 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,10 +32,10 @@
                 "build",
                 "${file}"
             ],
-            "env": {
-                "BICEP_TRACING_ENABLED": "true",
-                // "BICEP_REGISTRY_FQDN": "your-registry-here.azurecr.io"
-            },
+          "env": {
+            "BICEP_TRACING_ENABLED": "true"
+            // "__EXPERIMENTAL_BICEP_REGISTRY_FQDN": "your-registry-here.azurecr.io"
+          },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",
             "stopAtEntry": false
@@ -51,7 +51,8 @@
                 "${file}"
             ],
             "env": {
-                "BICEP_TRACING_ENABLED": "true"
+                "BICEP_TRACING_ENABLED": "true",
+                "__EXPERIMENTAL_BICEP_REGISTRY_FQDN": "localhost:5000"
             },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,6 @@
             ],
           "env": {
             "BICEP_TRACING_ENABLED": "true"
-            // "__EXPERIMENTAL_BICEP_REGISTRY_FQDN": "your-registry-here.azurecr.io"
           },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",
@@ -52,7 +51,6 @@
             ],
             "env": {
                 "BICEP_TRACING_ENABLED": "true",
-                "__EXPERIMENTAL_BICEP_REGISTRY_FQDN": "localhost:5000"
             },
             "cwd": "${workspaceFolder}/src/Bicep.Cli",
             "console": "internalConsole",

--- a/src/Bicep.Core/TypeSystem/Az/OciAzTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Az/OciAzTypeLoader.cs
@@ -53,7 +53,7 @@ namespace Bicep.Core.TypeSystem.Az
 
         protected override Stream GetContentStreamAtPath(string path)
         {
-            if (this.typesCache.TryGetValue($"./{path}", out var bytes))
+            if (this.typesCache.TryGetValue($"{path}", out var bytes))
             {
                 return new MemoryStream(bytes);
             }


### PR DESCRIPTION
## Description

The current implementation makes the wrong assumption that the key names indexed in the types cache have a prefix `./`. This was the case when I was using a dev artifact since the publishing logic wasn't ready.

Now that we have a publishing logic for the types package we can fix the code so that it doesn't assume the `./` prefix is found in the files as proven by https://github.com/Azure/bicep-types-az/actions/runs/6398352791/job/17368317634.

This PR should be merged before https://github.com/Azure/bicep-types-az/pull/1553, and https://github.com/Azure/bicep-types-az/pull/1553 should be updated to download the latest build from the `main` branch.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12026)