### PR TITLE
Refactor: avoid global workspace & env vars

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -106,7 +106,6 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         public async Task Build_params_with_correct_overrides_succeeds_with_values_overridden()
         {
             var bicepparamsPath = FileHelper.SaveResultFile(
@@ -175,7 +174,6 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         public async Task Build_params_with_overrides_with_mismatch_type_fails_with_error()
         {
             var bicepparamsPath = FileHelper.SaveResultFile(

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -39,9 +39,18 @@ namespace Bicep.Cli.IntegrationTests
     [TestClass]
     public class BuildParamsCommandTests : TestBase
     {
-        
         [NotNull]
         public TestContext? TestContext { get; set; }
+
+        private InvocationSettings Settings
+            => CreateDefaultSettings() with { 
+                FeatureOverrides = new(testContext: TestContext),
+                Environment = TestEnvironment.Create(
+                    ("stringEnvVariableName", "test"),
+                    ("intEnvVariableName", "100"),
+                    ("boolEnvironmentVariable", "true")
+                )
+            };
 
         [TestMethod]
         public async Task Build_Params_With_Incorrect_Bicep_File_Extension_ShouldFail_WithExpectedErrorMessage()
@@ -52,7 +61,7 @@ namespace Bicep.Cli.IntegrationTests
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();
-            var(output, error, result) = await Bicep("build-params", bicepparamsPath,"--bicep-file", bicepPath, "--outfile", outputFilePath);
+            var(output, error, result) = await Bicep(Settings, "build-params", bicepparamsPath,"--bicep-file", bicepPath, "--outfile", outputFilePath);
 
             result.Should().Be(1);
             output.Should().BeEmpty();
@@ -67,11 +76,10 @@ namespace Bicep.Cli.IntegrationTests
 
             var otherBicepPath = FileHelper.SaveResultFile(TestContext, "otherMain.bicep", "", Path.GetDirectoryName(bicepparamsPath));
 
-            var settings = new InvocationSettings(new(TestContext), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();
-            var result = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile", outputFilePath);
+            var result = await Bicep(Settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile", outputFilePath);
 
             result.Should().Fail().And.HaveStderrMatch($"Bicep file {otherBicepPath} provided with --bicep-file option doesn't match the Bicep file {bicepPath} referenced by the \"using\" declaration in the parameters file.*");
         }
@@ -89,10 +97,9 @@ namespace Bicep.Cli.IntegrationTests
 
             var otherBicepPath = FileHelper.SaveResultFile(TestContext, "otherMain.bicep", "", Path.GetDirectoryName(bicepparamsPath));
 
-            var settings = new InvocationSettings(new(TestContext), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
-            var result = await Bicep(settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile", outputFilePath);
+            var result = await Bicep(Settings, "build-params", bicepparamsPath,"--bicep-file", otherBicepPath, "--outfile", outputFilePath);
 
             result.Should().Fail().And.HaveStderrMatch($"Bicep file {otherBicepPath} provided with --bicep-file option doesn't match the Bicep file {bicepPath} referenced by the \"using\" declaration in the parameters file.*");
             File.Exists(outputFilePath).Should().BeFalse();
@@ -139,14 +146,16 @@ namespace Bicep.Cli.IntegrationTests
                         otherProp: "otherValue"
                     }
                 }
-                """;    
+                """;
 
-            Environment.SetEnvironmentVariable("BICEP_PARAMETERS_OVERRIDES", paramsOverrides);
+            var settings = Settings with { Environment = TestEnvironment.Create(
+                ("BICEP_PARAMETERS_OVERRIDES", paramsOverrides)
+            ) };
 
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();            
-            var result = await Bicep("build-params", bicepparamsPath, "--stdout");
+            var result = await Bicep(settings, "build-params", bicepparamsPath, "--stdout");
 
             result.Should().Succeed();
             var parametersStdout = result.Stdout.FromJson<BuildParamsStdout>();
@@ -163,8 +172,6 @@ namespace Bicep.Cli.IntegrationTests
                 otherProp: "otherValue"
             }
             """));
-
-            Environment.SetEnvironmentVariable("BICEP_PARAMETERS_OVERRIDES", null);
         }
 
         [TestMethod]
@@ -191,18 +198,18 @@ namespace Bicep.Cli.IntegrationTests
                 {
                     "intParam" : "bar"
                 }
-                """;    
+                """;
 
-            Environment.SetEnvironmentVariable("BICEP_PARAMETERS_OVERRIDES", paramsOverrides);
+            var settings = Settings with { Environment = TestEnvironment.Create(
+                ("BICEP_PARAMETERS_OVERRIDES", paramsOverrides)
+            ) };
 
             var outputFilePath = FileHelper.GetResultFilePath(TestContext, "output.json");
 
             File.Exists(outputFilePath).Should().BeFalse();            
-            var result = await Bicep("build-params", bicepparamsPath, "--stdout");
+            var result = await Bicep(settings, "build-params", bicepparamsPath, "--stdout");
             result.Should().Fail().And.NotHaveStdout();
             result.Stderr.Should().Contain("Error BCP033: Expected a value of type \"int\" but the provided value is of type \"'bar'\".");
-        
-            Environment.SetEnvironmentVariable("BICEP_PARAMETERS_OVERRIDES", null);
         }
 
         [DataTestMethod]
@@ -212,8 +219,7 @@ namespace Bicep.Cli.IntegrationTests
         {
             var data = baselineData.GetData(TestContext);
             var features = new FeatureProviderOverrides(TestContext);
-            var settings = new InvocationSettings(features, BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
-            var (output, error, result) = await Bicep(settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath);
+            var (output, error, result) = await Bicep(Settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath);
 
             using (new AssertionScope())
             {
@@ -232,9 +238,7 @@ namespace Bicep.Cli.IntegrationTests
         {   
             var data = baselineData.GetData(TestContext);
 
-            var settings = new InvocationSettings(new (), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
-
-            var (output, error, result) = await Bicep(settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath, "--stdout");
+            var (output, error, result) = await Bicep(Settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath, "--stdout");
 
             using (new AssertionScope())
             {
@@ -255,10 +259,9 @@ namespace Bicep.Cli.IntegrationTests
         {
             var data = baselineData.GetData(TestContext);
 
-            var settings = new InvocationSettings(new(TestContext), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var diagnostics = await GetAllParamDiagnostics(data.Parameters.OutputFilePath);
 
-            var (output, error, result) = await Bicep(settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath);
+            var (output, error, result) = await Bicep(Settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath);
 
             using (new AssertionScope())
             {
@@ -349,14 +352,6 @@ namespace Bicep.Cli.IntegrationTests
             
             result.Should().Fail().And.NotHaveStdout();
             result.Stderr.Should().Contain("main.bicepparam(1,7) : Error BCP192: Unable to restore the module with reference \"br:mockregistry.io/parameters/basic:v1\": Mock registry request failure.");
-        }
-
-        [TestInitialize]
-        public void testInit()
-        {
-            System.Environment.SetEnvironmentVariable("stringEnvVariableName", "test");
-            System.Environment.SetEnvironmentVariable("intEnvVariableName", "100");
-            System.Environment.SetEnvironmentVariable("boolEnvironmentVariable", "true");
         }
     }
 }

--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Text;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,7 +33,11 @@ namespace Bicep.Cli.IntegrationTests
 
         protected static readonly MockRepository Repository = new(MockBehavior.Strict);
 
-        protected record InvocationSettings(FeatureProviderOverrides FeatureOverrides, IContainerRegistryClientFactory ClientFactory, ITemplateSpecRepositoryFactory TemplateSpecRepositoryFactory);
+        protected record InvocationSettings(
+            FeatureProviderOverrides FeatureOverrides,
+            IContainerRegistryClientFactory ClientFactory,
+            ITemplateSpecRepositoryFactory TemplateSpecRepositoryFactory,
+            IEnvironment? Environment = null);
 
         protected static Task<CliResult> Bicep(params string[] args) => Bicep(CreateDefaultSettings(), args);
 
@@ -47,6 +52,7 @@ namespace Bicep.Cli.IntegrationTests
                     => services
                         .WithEmptyAzResources()
                         .WithFeatureOverrides(settings.FeatureOverrides)
+                        .AddSingleton(settings.Environment ?? BicepTestConstants.EmptyEnvironment)
                         .AddSingleton(settings.ClientFactory)
                         .AddSingleton(settings.TemplateSpecRepositoryFactory))
                     .RunAsync(args));

--- a/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Utils;
 using Bicep.Decompiler;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO.Abstractions;
@@ -61,6 +62,7 @@ public static class ServiceCollectionExtensions
         .AddSingleton<IArtifactRegistryProvider, DefaultArtifactRegistryProvider>()
         .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
         .AddSingleton<IFileResolver, FileResolver>()
+        .AddSingleton<IEnvironment, Environment>()
         .AddSingleton<IFileSystem, IOFileSystem>()
         .AddSingleton<IConfigurationManager, ConfigurationManager>()
         .AddSingleton<IBicepAnalyzer, LinterAnalyzer>()

--- a/src/Bicep.Cli/Services/CompilationService.cs
+++ b/src/Bicep.Cli/Services/CompilationService.cs
@@ -32,8 +32,6 @@ namespace Bicep.Cli.Services
         private readonly IConfigurationManager configurationManager;
         private readonly IFeatureProviderFactory featureProviderFactory;
         private readonly IFileResolver fileResolver;
-        private readonly Workspace workspace;
-        public Workspace Workspace => workspace;
 
         public CompilationService(
             BicepCompiler bicepCompiler,
@@ -51,17 +49,17 @@ namespace Bicep.Cli.Services
             this.diagnosticLogger = diagnosticLogger;
             this.moduleDispatcher = moduleDispatcher;
             this.configurationManager = configurationManager;
-            this.workspace = new Workspace();
             this.featureProviderFactory = featureProviderFactory;
             this.fileResolver = fileResolver;
         }
 
         public async Task RestoreAsync(string inputPath, bool forceModulesRestore)
         {
+            var workspace = new Workspace();
             var inputUri = PathHelper.FilePathToFileUrl(inputPath);
             var configuration = this.configurationManager.GetConfiguration(inputUri);
 
-            var compilation = await bicepCompiler.CreateCompilation(inputUri, this.workspace, skipRestore: true, forceModulesRestore: forceModulesRestore);
+            var compilation = await bicepCompiler.CreateCompilation(inputUri, workspace, skipRestore: true, forceModulesRestore: forceModulesRestore);
             var originalModulesToRestore = compilation.SourceFileGrouping.GetModulesToRestore().ToImmutableHashSet();
 
             // RestoreModules() does a distinct but we'll do it also to prevent duplicates in processing and logging
@@ -73,16 +71,17 @@ namespace Bicep.Cli.Services
             await moduleDispatcher.RestoreModules(modulesToRestoreReferences, forceModulesRestore);
 
             // update the errors based on restore status
-            var sourceFileGrouping = SourceFileGroupingBuilder.Rebuild(featureProviderFactory, this.moduleDispatcher, this.workspace, compilation.SourceFileGrouping);
+            var sourceFileGrouping = SourceFileGroupingBuilder.Rebuild(featureProviderFactory, this.moduleDispatcher, workspace, compilation.SourceFileGrouping);
 
             LogDiagnostics(GetModuleRestoreDiagnosticsByBicepFile(sourceFileGrouping, originalModulesToRestore, forceModulesRestore));
         }
 
-        public async Task<Compilation> CompileAsync(string inputPath, bool skipRestore, Action<Compilation>? validateFunc = null)
+        public async Task<Compilation> CompileAsync(string inputPath, bool skipRestore, Workspace? workspace = null, Action<Compilation>? validateFunc = null)
         {
+            workspace ??= new Workspace();
             var inputUri = PathHelper.FilePathToFileUrl(inputPath);
 
-            var compilation = await bicepCompiler.CreateCompilation(inputUri, this.workspace, skipRestore, forceModulesRestore: false);
+            var compilation = await bicepCompiler.CreateCompilation(inputUri, workspace, skipRestore, forceModulesRestore: false);
 
             validateFunc?.Invoke(compilation);
 
@@ -93,9 +92,10 @@ namespace Bicep.Cli.Services
 
         public async Task<TestResults> TestAsync(string inputPath, bool skipRestore)
         {
+            var workspace = new Workspace();
             var inputUri = PathHelper.FilePathToFileUrl(inputPath);
 
-            var compilation = await bicepCompiler.CreateCompilation(inputUri, this.workspace, skipRestore, forceModulesRestore: false);
+            var compilation = await bicepCompiler.CreateCompilation(inputUri, workspace, skipRestore, forceModulesRestore: false);
             var semanticModel = compilation.GetEntrypointSemanticModel();
 
             var declarations = semanticModel.Root.TestDeclarations;
@@ -108,6 +108,7 @@ namespace Bicep.Cli.Services
 
         public async Task<DecompileResult> DecompileAsync(string inputPath, string outputPath)
         {
+            var workspace = new Workspace();
             inputPath = PathHelper.ResolvePath(inputPath);
             Uri inputUri = PathHelper.FilePathToFileUrl(inputPath);
             Uri outputUri = PathHelper.FilePathToFileUrl(outputPath);
@@ -124,7 +125,7 @@ namespace Bicep.Cli.Services
             }
 
             // to verify success we recompile and check for syntax errors.
-            await CompileAsync(decompilation.EntrypointUri.LocalPath, skipRestore: true);
+            await CompileAsync(decompilation.EntrypointUri.LocalPath, skipRestore: true, workspace: workspace);
 
             return decompilation;
         }
@@ -136,14 +137,7 @@ namespace Bicep.Cli.Services
             var outputUri = PathHelper.FilePathToFileUrl(outputPath);
             var bicepUri = bicepPath is {} ? PathHelper.FilePathToFileUrl(bicepPath) : null;
 
-            var decompilation =  paramDecompiler.Decompile(inputUri, outputUri, bicepUri);
-
-            foreach (var (fileUri, bicepOutput) in decompilation.FilesToSave)
-            {
-                workspace.UpsertSourceFile(SourceFileFactory.CreateBicepFile(fileUri, bicepOutput));
-            }
-
-            return decompilation;
+            return paramDecompiler.Decompile(inputUri, outputUri, bicepUri);
         }
 
         private static ImmutableDictionary<BicepSourceFile, ImmutableArray<IDiagnostic>> GetModuleRestoreDiagnosticsByBicepFile(SourceFileGrouping sourceFileGrouping, ImmutableHashSet<ArtifactResolutionInfo> originalModulesToRestore, bool forceModulesRestore)

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -30,7 +30,13 @@ namespace Bicep.Core.IntegrationTests.Emit
     [TestClass]
     public class TemplateEmitterTests
     {
-        private static ServiceBuilder Services => new ServiceBuilder().WithEmptyAzResources();
+        private static ServiceBuilder Services => new ServiceBuilder()
+            .WithEmptyAzResources()
+            .WithEnvironmentVariables(
+                ("stringEnvVariableName", "test"),
+                ("intEnvVariableName", "100"),
+                ("boolEnvironmentVariable", "true")
+            );
 
         [NotNull]
         public TestContext? TestContext { get; set; }
@@ -287,14 +293,6 @@ this
 
             // second write should succeed if stringWriter wasn't closed
             emitter.Emit(stringWriter);
-        }
-
-        [TestInitialize]
-        public void testInit()
-        {
-            System.Environment.SetEnvironmentVariable("stringEnvVariableName", "test");
-            System.Environment.SetEnvironmentVariable("intEnvVariableName", "100");
-            System.Environment.SetEnvironmentVariable("boolEnvironmentVariable", "true");
         }
 
         private EmitResult EmitTemplate(SourceFileGrouping sourceFileGrouping, FeatureProviderOverrides features, string filePath)

--- a/src/Bicep.Core.IntegrationTests/Semantics/ParamsSemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/ParamsSemanticModelTests.cs
@@ -17,7 +17,13 @@ namespace Bicep.Core.IntegrationTests.Semantics
     [TestClass]
     public class ParamsSemanticModelTests
     {
-        private static ServiceBuilder Services => new ServiceBuilder().WithEmptyAzResources();
+        private static ServiceBuilder Services => new ServiceBuilder()
+            .WithEmptyAzResources()
+            .WithEnvironmentVariables(
+                ("stringEnvVariableName", "test"),
+                ("intEnvVariableName", "100"),
+                ("boolEnvironmentVariable", "true")
+            );
 
         [NotNull]
         public TestContext? TestContext { get; set; }
@@ -77,13 +83,6 @@ namespace Bicep.Core.IntegrationTests.Semantics
 
             data.Symbols.WriteToOutputFolder(sourceTextWithDiags);
             data.Symbols.ShouldHaveExpectedValue();
-        }
-        [TestInitialize]
-        public void testInit()
-        {
-            System.Environment.SetEnvironmentVariable("stringEnvVariableName", "test");
-            System.Environment.SetEnvironmentVariable("intEnvVariableName", "100");
-            System.Environment.SetEnvironmentVariable("boolEnvironmentVariable", "true");
         }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/SemanticModelTests.cs
@@ -31,7 +31,12 @@ namespace Bicep.Core.IntegrationTests.Semantics
         [NotNull]
         public TestContext? TestContext { get; set; }
 
-        private static ServiceBuilder Services => new ServiceBuilder();
+        private static ServiceBuilder Services => new ServiceBuilder()
+            .WithEnvironmentVariables(
+                ("stringEnvVariableName", "test"),
+                ("intEnvVariableName", "100"),
+                ("boolEnvironmentVariable", "true")
+            );
 
         // NOTE: Uses the linter analyzers specified in BicepTestConstants.BuiltInConfigurationWithProblematicAnalyzersDisabled
         //   Problematic ones that should be disabled in this and most other tests by default can be added to BicepTestConstants.AnalyzerRulesToDisableInTests
@@ -343,14 +348,6 @@ param storageAccount string = 'testStorageAccount'";
                 dataSet.Ir ?? "",
                 expectedLocation: DataSet.GetBaselineUpdatePath(dataSet, DataSet.TestFileMainIr),
                 actualLocation: resultsFile);
-        }
-
-        [TestInitialize]
-        public void testInit()
-        {
-            System.Environment.SetEnvironmentVariable("stringEnvVariableName", "test");
-            System.Environment.SetEnvironmentVariable("intEnvVariableName", "100");
-            System.Environment.SetEnvironmentVariable("boolEnvironmentVariable", "true");
         }
 
         private static List<SyntaxBase> GetAllBoundSymbolReferences(ProgramSyntax program)

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using Azure.Core.Pipeline;
 using Bicep.Core.Analyzers.Linter;
 using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
@@ -15,6 +17,8 @@ using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Configuration;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Utils;
 using Bicep.LanguageServer.Registry;
 using Bicep.LanguageServer.Telemetry;
 using Moq;
@@ -69,6 +73,8 @@ namespace Bicep.Core.UnitTests
 
         // By default turns off only problematic analyzers
         public static readonly LinterAnalyzer LinterAnalyzer = new LinterAnalyzer();
+
+        public static IEnvironment EmptyEnvironment = new TestEnvironment(ImmutableDictionary<string, string?>.Empty);
 
         public static readonly IModuleRestoreScheduler ModuleRestoreScheduler = CreateMockModuleRestoreScheduler();
 

--- a/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO.Abstractions;
 using System.Linq;
 using Bicep.Core.Analyzers.Interfaces;
@@ -18,6 +19,7 @@ using Bicep.Core.UnitTests.Configuration;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using Bicep.Decompiler;
 using Bicep.LanguageServer.CompilationManager;
@@ -41,6 +43,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IArtifactRegistryProvider, DefaultArtifactRegistryProvider>()
         .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
         .AddSingleton<IFileResolver, FileResolver>()
+        .AddSingleton<IEnvironment, Core.Utils.Environment>()
         .AddSingleton<IFileSystem, IOFileSystem>()
         .AddSingleton<IConfigurationManager, ConfigurationManager>()
         .AddSingleton<IBicepAnalyzer, LinterAnalyzer>()
@@ -68,6 +71,9 @@ public static class IServiceCollectionExtensions
         => Register(services, overrides)
             .AddSingleton<FeatureProviderFactory>()
             .AddSingleton<IFeatureProviderFactory, OverriddenFeatureProviderFactory>();
+
+    public static IServiceCollection WithEnvironmentVariables(this IServiceCollection services, params (string key, string? value)[] variables)
+        => Register(services, TestEnvironment.Create(variables));
 
     public static IServiceCollection WithNamespaceProvider(this IServiceCollection services, INamespaceProvider namespaceProvider)
         => Register(services, namespaceProvider);

--- a/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
@@ -43,7 +43,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IArtifactRegistryProvider, DefaultArtifactRegistryProvider>()
         .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
         .AddSingleton<IFileResolver, FileResolver>()
-        .AddSingleton<IEnvironment, Core.Utils.Environment>()
+        .AddSingleton<IEnvironment>(TestEnvironment.Create())
         .AddSingleton<IFileSystem, IOFileSystem>()
         .AddSingleton<IConfigurationManager, ConfigurationManager>()
         .AddSingleton<IBicepAnalyzer, LinterAnalyzer>()

--- a/src/Bicep.Core.UnitTests/ServiceBuilder.cs
+++ b/src/Bicep.Core.UnitTests/ServiceBuilder.cs
@@ -9,6 +9,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using Bicep.Decompiler;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,7 @@ public static class IDependencyHelperExtensions
     public static Compilation BuildCompilation(this IDependencyHelper helper, SourceFileGrouping sourceFileGrouping, ImmutableDictionary<ISourceFile, ISemanticModel>? modelLookup = null)
         => new(
             helper.Construct<IFeatureProviderFactory>(),
+            helper.Construct<IEnvironment>(),
             helper.Construct<INamespaceProvider>(),
             sourceFileGrouping,
             helper.Construct<IConfigurationManager>(),

--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
             var mockDiagnosticWriter = Repository.Create<IDiagnosticWriter>();
             mockDiagnosticWriter.Setup(writer => writer.Write(It.Is<IDiagnostic>(diag => diag.Code == "BCP234")));
 
-            matches.Single().ResultBuilder(Repository.Create<IBinder>().Object, Repository.Create<IFileResolver>().Object, mockDiagnosticWriter.Object, functionCall, argumentTypes.ToImmutableArray()).Type.Should().Be(expectedReturnType);
+            matches.Single().ResultBuilder(Repository.Create<IBinder>().Object, BicepTestConstants.EmptyEnvironment, Repository.Create<IFileResolver>().Object, mockDiagnosticWriter.Object, functionCall, argumentTypes.ToImmutableArray()).Type.Should().Be(expectedReturnType);
         }
 
         [DataTestMethod]
@@ -55,7 +55,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
             var mockDiagnosticWriter = Repository.Create<IDiagnosticWriter>();
             mockDiagnosticWriter.Setup(writer => writer.Write(It.Is<IDiagnostic>(diag => diag.Code == "BCP234")));
 
-            matches.Select(m => m.ResultBuilder(Repository.Create<IBinder>().Object, Repository.Create<IFileResolver>().Object, mockDiagnosticWriter.Object, functionCall, Enumerable.Repeat(LanguageConstants.Any, numberOfArguments).ToImmutableArray()).Type).Should().BeEquivalentTo(expectedReturnTypes);
+            matches.Select(m => m.ResultBuilder(Repository.Create<IBinder>().Object, BicepTestConstants.EmptyEnvironment, Repository.Create<IFileResolver>().Object, mockDiagnosticWriter.Object, functionCall, Enumerable.Repeat(LanguageConstants.Any, numberOfArguments).ToImmutableArray()).Type).Should().BeEquivalentTo(expectedReturnTypes);
         }
 
         [DataTestMethod]
@@ -639,6 +639,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
 
             return matches.Single().ResultBuilder(
                 Repository.Create<IBinder>().Object,
+                BicepTestConstants.EmptyEnvironment,
                 Repository.Create<IFileResolver>().Object,
                 Repository.Create<IDiagnosticWriter>().Object,
                 SyntaxFactory.CreateFunctionCall(functionName, arguments),

--- a/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/TypeValidatorAssignabilityTests.cs
@@ -958,7 +958,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
 
             parsingErrorLookup ??= EmptyDiagnosticLookup.Instance;
 
-            var typeManager = new TypeManager(BicepTestConstants.Features, binderMock.Object, fileResolverMock.Object, parsingErrorLookup, StrictMock.Of<ISourceFileLookup>().Object, StrictMock.Of<ISemanticModelLookup>().Object, Core.Workspaces.BicepSourceFileKind.BicepFile);
+            var typeManager = new TypeManager(BicepTestConstants.Features, binderMock.Object, BicepTestConstants.EmptyEnvironment, fileResolverMock.Object, parsingErrorLookup, StrictMock.Of<ISourceFileLookup>().Object, StrictMock.Of<ISemanticModelLookup>().Object, Core.Workspaces.BicepSourceFileKind.BicepFile);
 
             var diagnosticWriter = ToListDiagnosticWriter.Create();
             var result = TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binderMock.Object, parsingErrorLookup, diagnosticWriter, expression, targetType);

--- a/src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Bicep.Core.Analyzers.Interfaces;
 using Bicep.Core.Configuration;
 using Bicep.Core.FileSystem;
@@ -48,6 +49,9 @@ public static class ServiceBuilderExtensions
 
     public static ServiceBuilder WithWorkspaceFiles(this ServiceBuilder serviceBuilder, IReadOnlyDictionary<Uri, string> fileContentsByUri)
         => serviceBuilder.WithRegistration(x => x.WithWorkspaceFiles(fileContentsByUri));
+
+    public static ServiceBuilder WithEnvironmentVariables(this ServiceBuilder serviceBuilder, params (string key, string? value)[] variables)
+        => serviceBuilder.WithRegistration(x => x.WithEnvironmentVariables(variables));
 
     public static Compilation BuildCompilation(this ServiceBuilder services, IReadOnlyDictionary<Uri, string> fileContentsByUri, Uri entryFileUri)
     {

--- a/src/Bicep.Core.UnitTests/Utils/TestEnvironment.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestEnvironment.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+using Bicep.Core.Utils;
+
+namespace Bicep.Core.UnitTests.Utils;
+
+public class TestEnvironment : IEnvironment
+{
+    private readonly ImmutableDictionary<string, string?> variables;
+
+    public TestEnvironment(ImmutableDictionary<string, string?> variables)
+    {
+        this.variables = variables;
+    }
+
+    public static IEnvironment Create(params (string key, string? value)[] variables)
+        => new TestEnvironment(variables.ToImmutableDictionary(x => x.key, x => x.value));
+
+    public string? GetVariable(string variable)
+        => variables.TryGetValue(variable, out var value) ? value : null;
+}

--- a/src/Bicep.Core/BicepCompiler.cs
+++ b/src/Bicep.Core/BicepCompiler.cs
@@ -9,6 +9,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core;
@@ -16,6 +17,7 @@ namespace Bicep.Core;
 public class BicepCompiler
 {
     private readonly IFeatureProviderFactory featureProviderFactory;
+    private readonly IEnvironment environment;
     private readonly INamespaceProvider namespaceProvider;
     private readonly IConfigurationManager configurationManager;
     private readonly IBicepAnalyzer bicepAnalyzer;
@@ -24,6 +26,7 @@ public class BicepCompiler
 
     public BicepCompiler(
         IFeatureProviderFactory featureProviderFactory,
+        IEnvironment environment,
         INamespaceProvider namespaceProvider,
         IConfigurationManager configurationManager,
         IBicepAnalyzer bicepAnalyzer,
@@ -31,6 +34,7 @@ public class BicepCompiler
         IModuleDispatcher moduleDispatcher)
     {
         this.featureProviderFactory = featureProviderFactory;
+        this.environment = environment;
         this.namespaceProvider = namespaceProvider;
         this.configurationManager = configurationManager;
         this.bicepAnalyzer = bicepAnalyzer;
@@ -57,6 +61,6 @@ public class BicepCompiler
             //TODO(asilverman): I want to inject here the logic that restores the providers
         }
 
-        return new Compilation(featureProviderFactory, namespaceProvider, sourceFileGrouping, configurationManager, bicepAnalyzer, moduleDispatcher);
+        return new Compilation(featureProviderFactory, environment, namespaceProvider, sourceFileGrouping, configurationManager, bicepAnalyzer, moduleDispatcher);
     }
 }

--- a/src/Bicep.Core/Rewriters/RewriterHelper.cs
+++ b/src/Bicep.Core/Rewriters/RewriterHelper.cs
@@ -15,7 +15,7 @@ namespace Bicep.Core.Rewriters
         {
             // Sometimes bicepFile does not exist in the previous compilation, in which case we fall back on the compilation's entry point model
             var prevModel = prevCompilation.SourceFileGrouping.FileResultByUri.ContainsKey(bicepFile.FileUri) ? prevCompilation.GetSemanticModel(bicepFile) : prevCompilation.GetEntrypointSemanticModel();
-            var semanticModel = new SemanticModel(prevCompilation, bicepFile, prevModel.FileResolver, prevModel.LinterAnalyzer, prevModel.Configuration, prevModel.Features);
+            var semanticModel = new SemanticModel(prevCompilation, bicepFile, prevModel.Environment, prevModel.FileResolver, prevModel.LinterAnalyzer, prevModel.Configuration, prevModel.Features);
             var newProgramSyntax = rewriteVisitorBuilder(semanticModel).Rewrite(bicepFile.ProgramSyntax);
 
             if (object.ReferenceEquals(bicepFile.ProgramSyntax, newProgramSyntax))

--- a/src/Bicep.Core/Semantics/Compilation.cs
+++ b/src/Bicep.Core/Semantics/Compilation.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.Semantics
@@ -21,9 +22,12 @@ namespace Bicep.Core.Semantics
         private readonly ImmutableDictionary<ISourceFile, Lazy<ISemanticModel>> lazySemanticModelLookup;
         private readonly IConfigurationManager configurationManager;
         private readonly IFeatureProviderFactory featureProviderFactory;
+        private readonly IEnvironment environment;
         private readonly IBicepAnalyzer linterAnalyzer;
 
-        public Compilation(IFeatureProviderFactory featureProviderFactory,
+        public Compilation(
+            IFeatureProviderFactory featureProviderFactory,
+            IEnvironment environment,
             INamespaceProvider namespaceProvider,
             SourceFileGrouping sourceFileGrouping,
             IConfigurationManager configurationManager,
@@ -32,6 +36,7 @@ namespace Bicep.Core.Semantics
             ImmutableDictionary<ISourceFile, ISemanticModel>? modelLookup = null)
         {
             this.featureProviderFactory = featureProviderFactory;
+            this.environment = environment;
             this.SourceFileGrouping = sourceFileGrouping;
             this.NamespaceProvider = namespaceProvider;
             this.configurationManager = configurationManager;
@@ -80,8 +85,10 @@ namespace Bicep.Core.Semantics
             this.GetSemanticModel(sourceFile) as T ??
             throw new ArgumentException($"Expected the semantic model type to be \"{typeof(T).Name}\".");
 
-        private SemanticModel CreateSemanticModel(BicepSourceFile bicepFile) => new SemanticModel(this,
+        private SemanticModel CreateSemanticModel(BicepSourceFile bicepFile) => new SemanticModel(
+            this,
             bicepFile,
+            environment,
             SourceFileGrouping.FileResolver,
             linterAnalyzer,
             configurationManager.GetConfiguration(bicepFile.FileUri),

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -10,6 +10,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Intermediate;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
+using Bicep.Core.Utils;
 
 namespace Bicep.Core.Semantics
 {
@@ -17,6 +18,7 @@ namespace Bicep.Core.Semantics
     {
         public delegate FunctionResult ResultBuilderDelegate(
             IBinder binder,
+            IEnvironment environment,
             IFileResolver fileResolver,
             IDiagnosticWriter diagnostics,
             FunctionCallSyntaxBase functionCall,

--- a/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
@@ -21,7 +21,7 @@ namespace Bicep.Core.Semantics
             Description = string.Empty;
             ReturnType = LanguageConstants.Any;
             FixedParameters = ImmutableArray.CreateBuilder<FixedFunctionParameter>();
-            ResultBuilder = (_, _, _, _, _) => new(LanguageConstants.Any);
+            ResultBuilder = (_, _, _, _, _, _) => new(LanguageConstants.Any);
             VariableParameter = null;
         }
 
@@ -79,7 +79,7 @@ namespace Bicep.Core.Semantics
         public FunctionOverloadBuilder WithReturnType(TypeSymbol returnType)
         {
             ReturnType = returnType;
-            ResultBuilder = (_, _, _, _, _) => new(returnType);
+            ResultBuilder = (_, _, _, _, _, _) => new(returnType);
 
             return this;
         }

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -19,6 +19,7 @@ using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Newtonsoft.Json.Linq;
@@ -59,7 +60,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("concat")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("concat", (_, _, _, _, argumentTypes) =>
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("concat", (_, _, _, _, _, argumentTypes) =>
                 {
                     if (argumentTypes.All(t => t is TupleType))
                     {
@@ -157,7 +158,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             yield return new FunctionOverloadBuilder("padLeft")
                 .WithReturnResultBuilder(
-                    TryDeriveLiteralReturnType("padLeft", (_, _, _, _, argumentTypes) =>
+                    TryDeriveLiteralReturnType("padLeft", (_, _, _, _, _, argumentTypes) =>
                     {
                         (long? minLength, long? maxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[0]);
 
@@ -187,13 +188,13 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("toLower")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toLower", (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string ? @string : LanguageConstants.String)), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toLower", (_, _, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string ? @string : LanguageConstants.String)), LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to lower case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to lower case.")
                 .Build();
 
             yield return new FunctionOverloadBuilder("toUpper")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toUpper", (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string ? @string : LanguageConstants.String)), LanguageConstants.String)
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("toUpper", (_, _, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string ? @string : LanguageConstants.String)), LanguageConstants.String)
                 .WithGenericDescription("Converts the specified string to upper case.")
                 .WithRequiredParameter("stringToChange", LanguageConstants.String, "The value to convert to upper case.")
                 .Build();
@@ -205,7 +206,7 @@ namespace Bicep.Core.Semantics.Namespaces
             static int? MaxLength(ObjectType @object) => @object.AdditionalPropertiesType is null ? @object.Properties.Count : null;
 
             yield return new FunctionOverloadBuilder("length")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("length", (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() switch
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("length", (_, _, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() switch
                 {
                     StringType @string => TypeFactory.CreateIntegerType(@string.MinLength ?? 0, @string.MaxLength, @string.ValidationFlags),
                     ObjectType @object => TypeFactory.CreateIntegerType(MinLength(@object), MaxLength(@object), @object.ValidationFlags),
@@ -222,7 +223,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             yield return new FunctionOverloadBuilder("length")
                 .WithReturnResultBuilder(
-                    (_, _, _, _, argumentTypes) => (argumentTypes.IsEmpty ? null : argumentTypes[0]) switch
+                    (_, _, _, _, _, argumentTypes) => (argumentTypes.IsEmpty ? null : argumentTypes[0]) switch
                     {
                         TupleType tupleType => new(TypeFactory.CreateIntegerLiteralType(tupleType.Items.Length)),
                         ArrayType arrayType => new(TypeFactory.CreateIntegerType(arrayType.MinLength ?? 0, arrayType.MaxLength)),
@@ -241,7 +242,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("join")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("join", (_, _, _, _, argumentTypes) =>
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("join", (_, _, _, _, _, argumentTypes) =>
                 {
                     (long delimiterMinLength, long? delimiterMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[1]);
 
@@ -328,7 +329,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("trim")
                 .WithReturnResultBuilder(
                     TryDeriveLiteralReturnType("trim",
-                        (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
+                        (_, _, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
                             ? TypeFactory.CreateStringType(minLength: null, @string.MaxLength, @string.ValidationFlags)
                             : LanguageConstants.String)),
                     LanguageConstants.String)
@@ -346,7 +347,7 @@ namespace Bicep.Core.Semantics.Namespaces
             // TODO: Docs deviation
             yield return new FunctionOverloadBuilder("substring")
                 .WithReturnResultBuilder(
-                    TryDeriveLiteralReturnType("substring", (_, _, _, _, argumentTypes) =>
+                    TryDeriveLiteralReturnType("substring", (_, _, _, _, _, argumentTypes) =>
                     {
                         var originalString = argumentTypes[0] as StringType;
                         var literalStartIndex = argumentTypes[1] as IntegerLiteralType;
@@ -398,7 +399,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("take")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", (_, _, _, functionCall, argumentTypes) =>
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", (_, _, _, _, functionCall, argumentTypes) =>
                 {
                     (long? originalMinLength, long? originalMaxLength) = argumentTypes[0] switch
                     {
@@ -440,7 +441,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("take")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", (_, _, _, functionCall, argumentTypes) =>
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("take", (_, _, _, _, functionCall, argumentTypes) =>
                 {
                     (long? originalMinLength, long? originalMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[0]);
                     (long minToTake, long maxToTake) = argumentTypes[1] switch
@@ -471,7 +472,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("skip")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", (_, _, _, functionCall, argumentTypes) =>
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", (_, _, _, _, functionCall, argumentTypes) =>
                 {
                     (long minToSkip, long maxToSkip) = argumentTypes[1] switch
                     {
@@ -506,7 +507,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("skip")
-                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", (_, _, _, functionCall, argumentTypes) =>
+                .WithReturnResultBuilder(TryDeriveLiteralReturnType("skip", (_, _, _, _, functionCall, argumentTypes) =>
                 {
                     (long? originalMinLength, long? originalMaxLength) = TypeHelper.GetMinAndMaxLengthOfStringified(argumentTypes[0]);
                     (long minToSkip, long maxToSkip) = argumentTypes[1] switch
@@ -603,7 +604,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("first")
-                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
+                .WithReturnResultBuilder((_, _, _, _, _, argumentTypes) => new(argumentTypes[0] switch
                 {
                     TupleType tupleType => tupleType.Items.FirstOrDefault()?.Type ?? LanguageConstants.Null,
                     ArrayType arrayType when arrayType.MinLength.HasValue && arrayType.MinLength.Value > 0 => arrayType.Item.Type,
@@ -618,7 +619,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("first")
                 .WithReturnResultBuilder(
                     TryDeriveLiteralReturnType("first",
-                        (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
+                        (_, _, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
                             ? TypeFactory.CreateStringType(@string.MinLength.HasValue ? Math.Min(@string.MinLength.Value, 1) : null, 1, @string.ValidationFlags)
                             : TypeFactory.CreateStringType(minLength: null, 1, argumentTypes[0].ValidationFlags))),
                     LanguageConstants.String)
@@ -628,7 +629,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .Build();
 
             yield return new FunctionOverloadBuilder("last")
-                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
+                .WithReturnResultBuilder((_, _, _, _, _, argumentTypes) => new(argumentTypes[0] switch
                 {
                     TupleType tupleType => tupleType.Items.LastOrDefault()?.Type ?? LanguageConstants.Null,
                     ArrayType arrayType when arrayType.MinLength.HasValue && arrayType.MinLength.Value > 0 => arrayType.Item.Type,
@@ -643,7 +644,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("last")
                 .WithReturnResultBuilder(
                     TryDeriveLiteralReturnType("last",
-                        (_, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
+                        (_, _, _, _, _, argumentTypes) => new(argumentTypes.FirstOrDefault() is StringType @string
                             ? TypeFactory.CreateStringType(@string.MinLength.HasValue ? Math.Min(@string.MinLength.Value, 1) : null, 1, @string.ValidationFlags)
                             : TypeFactory.CreateStringType(minLength: null, 1, argumentTypes[0].ValidationFlags))),
                     LanguageConstants.String)
@@ -730,7 +731,7 @@ namespace Bicep.Core.Semantics.Namespaces
 
             yield return new FunctionOverloadBuilder("range")
                 .WithReturnResultBuilder(
-                    (_, _, _, _, argumentTypes) =>
+                    (_, _, _, _, _, argumentTypes) =>
                     {
                         static TypeSymbol GetRangeReturnElementType(TypeSymbol arg0Type, TypeSymbol arg1Type) => (arg0Type, arg1Type) switch
                         {
@@ -907,7 +908,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return new FunctionOverloadBuilder("flatten")
                 .WithGenericDescription("Takes an array of arrays, and returns an array of sub-array elements, in the original order. Sub-arrays are only flattened once, not recursively.")
                 .WithRequiredParameter("array", new TypedArrayType(LanguageConstants.Array, TypeSymbolValidationFlags.Default), "The array of sub-arrays to flatten.")
-                .WithReturnResultBuilder((_, _, _, functionCall, argTypes) => new(TypeHelper.FlattenType(argTypes[0], functionCall.Arguments[0])), LanguageConstants.Array)
+                .WithReturnResultBuilder((_, _, _, _, functionCall, argTypes) => new(TypeHelper.FlattenType(argTypes[0], functionCall.Arguments[0])), LanguageConstants.Array)
                 .Build();
 
             yield return new FunctionOverloadBuilder("filter")
@@ -915,7 +916,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("array", LanguageConstants.Array, "The array to filter.")
                 .WithRequiredParameter("predicate", OneParamLambda(LanguageConstants.Any, LanguageConstants.Bool), "The predicate applied to each input array element. If false, the item will be filtered out of the output array.",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => OneParamLambda(t, LanguageConstants.Bool)))
-                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
+                .WithReturnResultBuilder((_, _, _, _, _, argumentTypes) => new(argumentTypes[0] switch
                 {
                     // If a tuple is filtered, each member of the resulting array will be assignable to <input tuple>.Item, but information about specific indices and tuple length is no longer reliable.
                     // For example, given a symbol `a` of type `[0, 1, 2, 3, 4]`, the expression `filter(a, x => x % 2 == 0)` returns an array in which each member is assignable to `0 | 1 | 2 | 3 | 4`,
@@ -931,7 +932,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("array", LanguageConstants.Array, "The array to map.")
                 .WithRequiredParameter("predicate", OneParamLambda(LanguageConstants.Any, LanguageConstants.Any), "The predicate applied to each input array element, in order to generate the output array.",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => OneParamLambda(t, LanguageConstants.Any)))
-                .WithReturnResultBuilder((binder, fileResolver, diagnostics, arguments, argumentTypes) => argumentTypes[1] switch
+                .WithReturnResultBuilder((binder, _, fileResolver, diagnostics, arguments, argumentTypes) => argumentTypes[1] switch
                 {
                     LambdaType lambdaType => new(new TypedArrayType(lambdaType.ReturnType.Type, TypeSymbolValidationFlags.Default)),
                     _ => new(LanguageConstants.Any),
@@ -943,7 +944,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("array", LanguageConstants.Array, "The array to sort.")
                 .WithRequiredParameter("predicate", TwoParamLambda(LanguageConstants.Any, LanguageConstants.Any, LanguageConstants.Bool), "The predicate used to compare two array elements for ordering. If true, the second element will be ordered after the first in the output array.",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => TwoParamLambda(t, t, LanguageConstants.Bool)))
-                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => new(argumentTypes[0] switch
+                .WithReturnResultBuilder((_, _, _, _, _, argumentTypes) => new(argumentTypes[0] switch
                 {
                     // When a tuple is sorted, the resultant array will be of the same length as the input tuple, but the information about which member resides at which index can no longer be relied upon.
                     TupleType tuple => tuple.ToTypedArray(),
@@ -958,7 +959,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithRequiredParameter("predicate", TwoParamLambda(LanguageConstants.Any, LanguageConstants.Any, LanguageConstants.Any), "The predicate used to aggregate the current value and the next value. ",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => TwoParamLambda(t, t, LanguageConstants.Any)))
                 .WithReturnType(LanguageConstants.Any)
-                .WithReturnResultBuilder((_, _, _, _, argumentTypes) => argumentTypes[2] switch
+                .WithReturnResultBuilder((_, _, _, _, _, argumentTypes) => argumentTypes[2] switch
                 {
                     LambdaType lambdaType => new(lambdaType.ReturnType.Type),
                     _ => new(LanguageConstants.Any),
@@ -973,7 +974,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .WithOptionalParameter("valuePredicate", OneParamLambda(LanguageConstants.Any, LanguageConstants.Any), "The optional predicate applied to each input array element to return the object value.",
                     calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => OneParamLambda(t, LanguageConstants.Any)))
                 .WithReturnType(LanguageConstants.Any)
-                .WithReturnResultBuilder((_, _, _, _, argumentTypes) =>
+                .WithReturnResultBuilder((_, _, _, _, _, argumentTypes) =>
                 {
                     if (argumentTypes.Length == 2 && argumentTypes[0] is ArrayType arrayArgType)
                     {
@@ -1039,14 +1040,14 @@ namespace Bicep.Core.Semantics.Namespaces
         }
 
         private static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, TypeSymbol nonLiteralReturnType) =>
-            TryDeriveLiteralReturnType(armFunctionName, (_, _, _, _, _) => new(nonLiteralReturnType));
+            TryDeriveLiteralReturnType(armFunctionName, (_, _, _, _, _, _) => new(nonLiteralReturnType));
 
         private static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, FunctionOverload.ResultBuilderDelegate nonLiteralReturnResultBuilder) =>
-            (binder, fileResolver, diagnostics, functionCall, argumentTypes) =>
+            (binder, environment, fileResolver, diagnostics, functionCall, argumentTypes) =>
             {
                 FunctionResult returnType = ArmFunctionReturnTypeEvaluator.TryEvaluate(armFunctionName, out var diagnosticBuilders, argumentTypes) is { } literalReturnType
                     ? new(literalReturnType)
-                    : nonLiteralReturnResultBuilder.Invoke(binder, fileResolver, diagnostics, functionCall, argumentTypes);
+                    : nonLiteralReturnResultBuilder.Invoke(binder, environment, fileResolver, diagnostics, functionCall, argumentTypes);
 
                 var diagnosticTarget = functionCall.Arguments.Any()
                     ? TextSpan.Between(functionCall.Arguments.First(), functionCall.Arguments.Last())
@@ -1074,7 +1075,7 @@ namespace Bicep.Core.Semantics.Namespaces
         private static LambdaType TwoParamLambda(TypeSymbol param1Type, TypeSymbol param2Type, TypeSymbol returnType)
             => new LambdaType(ImmutableArray.Create<ITypeReference>(param1Type, param2Type), returnType);
 
-        private static FunctionResult LoadTextContentResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult LoadTextContentResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
         {
             var arguments = functionCall.Arguments.ToImmutableArray();
             return TryLoadTextContentFromFile(binder, fileResolver, diagnostics,
@@ -1087,10 +1088,10 @@ namespace Bicep.Core.Semantics.Namespaces
                 : new(ErrorType.Create(errorDiagnostic));
         }
 
-        private static FunctionResult LoadJsonContentResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult LoadJsonContentResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
             => LoadContentResultBuilder(new JsonObjectParser(), binder, fileResolver, diagnostics, functionCall, argumentTypes);
 
-        private static FunctionResult LoadYamlContentResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult LoadYamlContentResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
             => LoadContentResultBuilder(new YamlObjectParser(), binder, fileResolver, diagnostics, functionCall, argumentTypes);
 
         private static FunctionResult LoadContentResultBuilder(ObjectParser objectParser, IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
@@ -1115,7 +1116,7 @@ namespace Bicep.Core.Semantics.Namespaces
             return new(ErrorType.Create(errorDiagnostic));
         }
 
-        private static FunctionResult ReadEnvironmentVariableResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult ReadEnvironmentVariableResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
         {
             var arguments = functionCall.Arguments.ToImmutableArray();
 
@@ -1124,7 +1125,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 return new(ErrorType.Create(DiagnosticBuilder.ForPosition(arguments[0]).CompileTimeConstantRequired()));
             }
             var envVariableName = stringLiteral.RawStringValue;
-            var envVariableValue = Environment.GetEnvironmentVariable(envVariableName);
+            var envVariableValue = environment.GetVariable(envVariableName);
 
             if (envVariableValue == null)
             {
@@ -1188,7 +1189,7 @@ namespace Bicep.Core.Semantics.Namespaces
             return true;
         }
 
-        private static FunctionResult LoadContentAsBase64ResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult LoadContentAsBase64ResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
         {
             var arguments = functionCall.Arguments.ToImmutableArray();
             if (argumentTypes[0] is not StringLiteralType filePathType)
@@ -1249,7 +1250,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     null),
                 TypeSymbolValidationFlags.Default);
 
-        private static FunctionResult ItemsResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult ItemsResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
         {
             if (argumentTypes[0] is not ObjectType objectType)
             {
@@ -1305,7 +1306,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 _ => LanguageConstants.Any,
             };
 
-        private static FunctionResult JsonResultBuilder(IBinder binder, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
+        private static FunctionResult JsonResultBuilder(IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
         {
             var arguments = functionCall.Arguments.ToImmutableArray();
             if (argumentTypes.Length != 1 || argumentTypes[0] is not StringLiteralType stringLiteral)

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -21,6 +21,7 @@ using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
 using Bicep.Core.TypeSystem;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.Semantics
@@ -44,7 +45,7 @@ namespace Bicep.Core.Semantics
         private readonly Lazy<ImmutableArray<DeclaredResourceMetadata>> declaredResourcesLazy;
         private readonly Lazy<ImmutableArray<IDiagnostic>> allDiagnostics;
 
-        public SemanticModel(Compilation compilation, BicepSourceFile sourceFile, IFileResolver fileResolver, IBicepAnalyzer linterAnalyzer, RootConfiguration configuration, IFeatureProvider features)
+        public SemanticModel(Compilation compilation, BicepSourceFile sourceFile, IEnvironment environment, IFileResolver fileResolver, IBicepAnalyzer linterAnalyzer, RootConfiguration configuration, IFeatureProvider features)
         {
             TraceBuildOperation(sourceFile, configuration);
 
@@ -52,6 +53,7 @@ namespace Bicep.Core.Semantics
             this.SourceFile = sourceFile;
             this.Configuration = configuration;
             this.Features = features;
+            this.Environment = environment;
             this.FileResolver = fileResolver;
 
             // create this in locked mode by default
@@ -61,7 +63,7 @@ namespace Bicep.Core.Semantics
             this.SymbolContext = symbolContext;
             this.Binder = new Binder(compilation.NamespaceProvider, features, sourceFile, this.SymbolContext);
             this.apiVersionProviderLazy = new Lazy<IApiVersionProvider>(() => new ApiVersionProvider(features, this.Binder.NamespaceResolver.GetAvailableResourceTypes()));
-            this.TypeManager = new TypeManager(features, Binder, fileResolver, this.ParsingErrorLookup, Compilation.SourceFileGrouping, Compilation, this.SourceFile.FileKind);
+            this.TypeManager = new TypeManager(features, Binder, environment, fileResolver, this.ParsingErrorLookup, Compilation.SourceFileGrouping, Compilation, this.SourceFile.FileKind);
 
             // name binding is done
             // allow type queries now
@@ -211,6 +213,7 @@ namespace Bicep.Core.Semantics
         }
 
         public BicepSourceFile SourceFile { get; }
+        public IEnvironment Environment { get; }
 
         public BicepSourceFileKind SourceFileKind => this.SourceFile.FileKind;
 

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -17,6 +17,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.TypeSystem
@@ -26,6 +27,7 @@ namespace Bicep.Core.TypeSystem
         private readonly IFeatureProvider features;
         private readonly ITypeManager typeManager;
         private readonly IBinder binder;
+        private readonly IEnvironment environment;
         private readonly IFileResolver fileResolver;
         private readonly IDiagnosticLookup parsingErrorLookup;
         private readonly ISourceFileLookup sourceFileLookup;
@@ -36,11 +38,12 @@ namespace Bicep.Core.TypeSystem
         private readonly ConcurrentDictionary<FunctionCallSyntaxBase, Expression> matchedFunctionResultValues;
         private readonly ConcurrentDictionary<CompileTimeImportDeclarationSyntax, ImmutableDictionary<string, TypeProperty>?> importableTypesByCompileTimeImportDeclaration;
 
-        public TypeAssignmentVisitor(ITypeManager typeManager, IFeatureProvider features, IBinder binder, IFileResolver fileResolver, IDiagnosticLookup parsingErrorLookup, ISourceFileLookup sourceFileLookup, ISemanticModelLookup semanticModelLookup, Workspaces.BicepSourceFileKind fileKind)
+        public TypeAssignmentVisitor(ITypeManager typeManager, IFeatureProvider features, IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticLookup parsingErrorLookup, ISourceFileLookup sourceFileLookup, ISemanticModelLookup semanticModelLookup, Workspaces.BicepSourceFileKind fileKind)
         {
             this.typeManager = typeManager;
             this.features = features;
             this.binder = binder;
+            this.environment = environment;
             this.fileResolver = fileResolver;
             this.parsingErrorLookup = parsingErrorLookup;
             this.sourceFileLookup = sourceFileLookup;
@@ -2046,7 +2049,7 @@ namespace Bicep.Core.TypeSystem
                 matchedFunctionOverloads.TryAdd(syntax, matchedOverload);
 
                 // return its type
-                var result = matchedOverload.ResultBuilder(binder, fileResolver, diagnosticWriter, syntax, argumentTypes);
+                var result = matchedOverload.ResultBuilder(binder, environment, fileResolver, diagnosticWriter, syntax, argumentTypes);
                 if (result.Value is not null)
                 {
                     matchedFunctionResultValues.TryAdd(syntax, result.Value);

--- a/src/Bicep.Core/TypeSystem/TypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/TypeManager.cs
@@ -7,6 +7,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Intermediate;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.TypeSystem
@@ -17,12 +18,12 @@ namespace Bicep.Core.TypeSystem
         private readonly TypeAssignmentVisitor typeAssignmentVisitor;
         private readonly DeclaredTypeManager declaredTypeManager;
 
-        public TypeManager(IFeatureProvider features, IBinder binder, IFileResolver fileResolver, IDiagnosticLookup parsingErrorLookup, ISourceFileLookup sourceFileLookup, ISemanticModelLookup semanticModelLookup, BicepSourceFileKind kind)
+        public TypeManager(IFeatureProvider features, IBinder binder, IEnvironment environment, IFileResolver fileResolver, IDiagnosticLookup parsingErrorLookup, ISourceFileLookup sourceFileLookup, ISemanticModelLookup semanticModelLookup, BicepSourceFileKind kind)
         {
             // bindings will be modified by name binding after this object is created
             // so we can't make an immutable copy here
             // (using the IReadOnlyDictionary to prevent accidental mutation)
-            this.typeAssignmentVisitor = new TypeAssignmentVisitor(this, features, binder, fileResolver, parsingErrorLookup, sourceFileLookup, semanticModelLookup, kind);
+            this.typeAssignmentVisitor = new TypeAssignmentVisitor(this, features, binder, environment, fileResolver, parsingErrorLookup, sourceFileLookup, semanticModelLookup, kind);
             this.declaredTypeManager = new DeclaredTypeManager(this, binder, features);
         }
 

--- a/src/Bicep.Core/Utils/Environment.cs
+++ b/src/Bicep.Core/Utils/Environment.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+namespace Bicep.Core.Utils;
+
+public class Environment : IEnvironment
+{
+    public string? GetVariable(string variable)
+        => System.Environment.GetEnvironmentVariable(variable);
+}

--- a/src/Bicep.Core/Utils/IEnvironment.cs
+++ b/src/Bicep.Core/Utils/IEnvironment.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+namespace Bicep.Core.Utils;
+
+public interface IEnvironment
+{
+    string? GetVariable(string variable);
+}

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -511,6 +511,7 @@ module moduleB './moduleB.bicep' = {
             var fileResolver = new InMemoryFileResolver(fileDict);
             var compilationProvider = new BicepCompilationProvider(
                 BicepTestConstants.FeatureProviderFactory,
+                BicepTestConstants.EmptyEnvironment,
                 TestTypeHelper.CreateEmptyProvider(),
                 fileResolver,
                 new ModuleDispatcher(

--- a/src/Bicep.LangServer/IServiceCollectionExtensions.cs
+++ b/src/Bicep.LangServer/IServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Utils;
 using Bicep.Decompiler;
 using Microsoft.Extensions.DependencyInjection;
 using IOFileSystem = System.IO.Abstractions.FileSystem;
@@ -29,6 +30,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IArtifactRegistryProvider, DefaultArtifactRegistryProvider>()
         .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
         .AddSingleton<IFileResolver, FileResolver>()
+        .AddSingleton<IEnvironment, Environment>()
         .AddSingleton<IFileSystem, IOFileSystem>()
         .AddSingleton<IConfigurationManager, ConfigurationManager>()
         .AddSingleton<IBicepAnalyzer, LinterAnalyzer>()

--- a/src/Bicep.LangServer/Program.cs
+++ b/src/Bicep.LangServer/Program.cs
@@ -42,7 +42,7 @@ namespace Bicep.LanguageServer
                 });
 
                 await parser.ParseArguments<CommandLineOptions>(args)
-                    .WithNotParsed((x) => Environment.Exit(1))
+                    .WithNotParsed((x) => System.Environment.Exit(1))
                     .WithParsedAsync(async options => await RunServer(options, cancellationToken));
             });
 

--- a/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
+++ b/src/Bicep.LangServer/Providers/BicepCompilationProvider.cs
@@ -8,6 +8,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -22,6 +23,7 @@ namespace Bicep.LanguageServer.Providers
     {
         private readonly IConfigurationManager configurationManager;
         private readonly IBicepAnalyzer bicepAnalyzer;
+        private readonly IEnvironment environment;
         private readonly IFeatureProviderFactory featureProviderFactory;
         private readonly INamespaceProvider namespaceProvider;
         private readonly IFileResolver fileResolver;
@@ -29,12 +31,14 @@ namespace Bicep.LanguageServer.Providers
 
         public BicepCompilationProvider(
             IFeatureProviderFactory featureProviderFactory,
+            IEnvironment environment,
             INamespaceProvider namespaceProvider,
             IFileResolver fileResolver,
             IModuleDispatcher moduleDispatcher,
             IConfigurationManager configurationManager,
             IBicepAnalyzer bicepAnalyzer)
         {
+            this.environment = environment;
             this.featureProviderFactory = featureProviderFactory;
             this.namespaceProvider = namespaceProvider;
             this.fileResolver = fileResolver;
@@ -76,6 +80,7 @@ namespace Bicep.LanguageServer.Providers
         {
             var compilation = new Compilation(
                 featureProviderFactory,
+                environment,
                 namespaceProvider,
                 syntaxTreeGrouping,
                 configurationManager,

--- a/src/Bicep.RegistryModuleTool/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Bicep.RegistryModuleTool/Extensions/IServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO.Abstractions;
 
@@ -29,6 +30,7 @@ namespace Bicep.RegistryModuleTool.Extensions
             .AddSingleton<IArtifactRegistryProvider, DefaultArtifactRegistryProvider>()
             .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
             .AddSingleton<IFileResolver, FileResolver>()
+            .AddSingleton<IEnvironment, Environment>()
             .AddSingleton<IConfigurationManager, ConfigurationManager>()
             .AddSingleton<IBicepAnalyzer, LinterAnalyzer>()
             .AddSingleton<IFeatureProviderFactory, FeatureProviderFactory>()

--- a/src/Bicep.Wasm/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Wasm/IServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.Utils;
 using Bicep.Decompiler;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,6 +29,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IArtifactRegistryProvider, EmptyModuleRegistryProvider>()
         .AddSingleton<ITokenCredentialFactory, TokenCredentialFactory>()
         .AddSingleton<IFileResolver, FileResolver>()
+        .AddSingleton<IEnvironment, Environment>()
         .AddSingleton<IFileSystem, MockFileSystem>()
         .AddSingleton<IConfigurationManager, ConfigurationManager>()
         .AddSingleton<IBicepAnalyzer, LinterAnalyzer>()


### PR DESCRIPTION
Mutable global state is a source of test flakiness.
- Introduce `IEnvironment` interface to avoid accidental dependencies between tests on env vars.
- Avoid using a shared `IWorkspace` in the `CompilationService`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12028)