### PR TITLE
All resources/dates should be fake in linter tests

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRule_InReferenceFunctions_Tests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRule_InReferenceFunctions_Tests.cs
@@ -48,6 +48,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     bicep);
                 using (new AssertionScope().WithFullSource(result.BicepFile))
                 {
+                    UseRecentApiVersionRuleTests.VerifyAllTypesAndDatesAreFake(result.BicepFile.GetOriginalSource());
+
                     var actual = UseRecentApiVersionRule.GetFunctionCallInfos(result.Compilation.GetEntrypointSemanticModel());
                     actual.Should().HaveCount(1, "Expecting a single function call per test");
                     var typedActual = new ExpectedFunctionInfo(
@@ -110,71 +112,71 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             )]
             [DataRow(
                 @"
-                    param apiversion string = '2022-01-01'
+                    param apiversion string = '2422-01-01'
                     output a object = reference('Fake.DBforMySQL/servers', apiversion)
                 ",
                 "reference('Fake.DBforMySQL/servers', apiversion)",
                 "Fake.DBforMySQL/servers",
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
-                    var apiversion = '2022-01-01'
+                    var apiversion = '2422-01-01'
                     output a object = reference('Fake.DBforMySQL/servers', apiversion)
                 ",
                 "reference('Fake.DBforMySQL/servers', apiversion)",
                 "Fake.DBforMySQL/servers",
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
-                    param p string = '2022-01-01'
+                    param p string = '2422-01-01'
                     var apiversion = p
                     output a object = reference('Fake.DBforMySQL/servers', apiversion)
                 ",
                 "reference('Fake.DBforMySQL/servers', apiversion)",
                 "Fake.DBforMySQL/servers",
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
                     param p2 string = 'Fake.DBforMySQL/servers'
                     var resType = p2
-                    param p1 string = '2022-01-01'
+                    param p1 string = '2422-01-01'
                     var apiversion = p1
                     output a object = reference(resType, apiversion)
                 ",
                 "reference(resType, apiversion)",
                 "Fake.DBforMySQL/servers",
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
                     param p2 string = 'Fake.DBforMySQL-servers'
                     var resType = p2
-                    param p1 string = '2022-01-01'
+                    param p1 string = '2422-01-01'
                     var apiversion = p1
                     output a object = reference(resType, apiversion)
                 ",
                 "reference(resType, apiversion)",
                 null, // not valid
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
-                    output o1 string = reference('Fake.Resources/deployments/SettingUpVirtualNetwork', '2015-01-01').outputs.dbSubnetRef.value
+                    output o1 string = reference('Fake.Resources/deployments/SettingUpVirtualNetwork', '2415-01-01').outputs.dbSubnetRef.value
                 ",
-                "reference('Fake.Resources/deployments/SettingUpVirtualNetwork', '2015-01-01')",
+                "reference('Fake.Resources/deployments/SettingUpVirtualNetwork', '2415-01-01')",
                 "Fake.Resources/deployments",
-                "2015-01-01"
+                "2415-01-01"
             )]
             [DataRow(
                 @"
-                    output o1 string = reference(resourceId('Fake.Resources/deployments/SettingUpVirtualNetwork'), '2015-01-01').outputs.dbSubnetRef.value
+                    output o1 string = reference(resourceId('Fake.Resources/deployments/SettingUpVirtualNetwork'), '2415-01-01').outputs.dbSubnetRef.value
                 ",
-                "reference(resourceId('Fake.Resources/deployments/SettingUpVirtualNetwork'), '2015-01-01')",
+                "reference(resourceId('Fake.Resources/deployments/SettingUpVirtualNetwork'), '2415-01-01')",
                 "Fake.Resources/deployments",
-                "2015-01-01"
+                "2415-01-01"
             )]
             [DataTestMethod]
             public void GetFunctionCallInfo_Reference_NoResourceId(string bicep, string expectedFunctionCall, string? expectedResourceType, string? expectedApiVerion)
@@ -185,11 +187,11 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             [DataRow(
                 @"
                     var lbPublicIPName = 'lbPublicIPName'
-                    output o string = reference(resourceId('Microsoft.Network/publicIPAddresses', lbPublicIPName),'2020-08-01').dnsSettings.fqdn
+                    output o string = reference(resourceId('Fake.Network/publicIPAddresses', lbPublicIPName),'2420-08-01').dnsSettings.fqdn
                 ",
-                "reference(resourceId('Microsoft.Network/publicIPAddresses', lbPublicIPName), '2020-08-01')",
-                "Microsoft.Network/publicIPAddresses",
-                "2020-08-01"
+                "reference(resourceId('Fake.Network/publicIPAddresses', lbPublicIPName), '2420-08-01')",
+                "Fake.Network/publicIPAddresses",
+                "2420-08-01"
             )]
             [DataRow(
                 @"
@@ -201,35 +203,35 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             )]
             [DataRow(
                 @"
-                    output a object = reference(resourceId('Fake.DBforMySQL/servers'), '2022-01-01')
+                    output a object = reference(resourceId('Fake.DBforMySQL/servers'), '2422-01-01')
                 ",
-                "reference(resourceId('Fake.DBforMySQL/servers'), '2022-01-01')",
+                "reference(resourceId('Fake.DBforMySQL/servers'), '2422-01-01')",
                 "Fake.DBforMySQL/servers",
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
-                    output a object = reference(resourceId('FakeDBforMySQL/servers'), '2022-01-01')
+                    output a object = reference(resourceId('FakeDBforMySQL/servers'), '2422-01-01')
                 ",
-                "reference(resourceId('FakeDBforMySQL/servers'), '2022-01-01')",
+                "reference(resourceId('FakeDBforMySQL/servers'), '2422-01-01')",
                 null, // not valid
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
-                    output a object = reference(resourceId('Fake.DBforMySQL'), '2022-01-01')
+                    output a object = reference(resourceId('Fake.DBforMySQL'), '2422-01-01')
                 ",
-                "reference(resourceId('Fake.DBforMySQL'), '2022-01-01')",
+                "reference(resourceId('Fake.DBforMySQL'), '2422-01-01')",
                 null, // not valid
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
-                    output a object = reference(resourceId('Fake.DBforMySQL/servers/whatever'), '2022-01-01')
+                    output a object = reference(resourceId('Fake.DBforMySQL/servers/whatever'), '2422-01-01')
                 ",
-                "reference(resourceId('Fake.DBforMySQL/servers/whatever'), '2022-01-01')",
+                "reference(resourceId('Fake.DBforMySQL/servers/whatever'), '2422-01-01')",
                 "Fake.DBforMySQL/servers",
-                "2022-01-01"
+                "2422-01-01"
             )]
             [DataRow(
                 @"
@@ -258,8 +260,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     var listAccountSasRequestContent = {
                       signedServices: 'bfqt'
                       signedPermission: 'rwdlacup'
-                      signedStart: '2021-06-02T00:00:00Z'
-                      signedExpiry: '2030-10-30T00:00:00Z'
+                      signedStart: '2421-06-02T00:00:00Z'
+                      signedExpiry: '2430-10-30T00:00:00Z'
                       signedResourceTypes: 'sco'
                     }
                     output output1 object = listAccountSas(resourceId('Fake.Network/publicIPAddresses', 'test'), '2415-06-15', listAccountSasRequestContent)
@@ -525,7 +527,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             {
                 string bicep = @"
                     targetScope = 'managementGroup'
-                    resource diagnostics_aa_deploy_policy 'Microsoft.Authorization/policyDefinitions@2023-04-01' = {
+                    resource diagnostics_aa_deploy_policy 'Fake.Authorization/policyDefinitions@2423-04-01' = {
                       name: 'diagnostics-aa-deploy-policy'
                       properties: {
                         parameters: {
@@ -551,27 +553,27 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         policyRule: {
                           if: {
                             field: 'type'
-                            equals: 'Microsoft.Automation/automationAccounts'
+                            equals: 'Fake.Automation/automationAccounts'
                           }
                           then: {
                             effect: 'deployIfNotExists'
                             details: {
-                              type: 'Microsoft.Insights/diagnosticSettings'
+                              type: 'Fake.Insights/diagnosticSettings'
                               roleDefinitionIds: [
-                                '/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
+                                '/providers/Fake.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
                               ]
                               existenceCondition: {
                                 allOf: [
                                   {
-                                    field: 'Microsoft.Insights/diagnosticSettings/logs.enabled'
+                                    field: 'Fake.Insights/diagnosticSettings/logs.enabled'
                                     equals: 'True'
                                   }
                                   {
-                                    field: 'Microsoft.Insights/diagnosticSettings/metrics.enabled'
+                                    field: 'Fake.Insights/diagnosticSettings/metrics.enabled'
                                     equals: 'True'
                                   }
                                   {
-                                    field: 'Microsoft.Insights/diagnosticSettings/workspaceId'
+                                    field: 'Fake.Insights/diagnosticSettings/workspaceId'
                                     matchInsensitively: '[parameters(\'logAnalytics\')]'
                                   }
                                 ]
@@ -596,9 +598,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                                     resources: [
                                       {
                                         name: '[parameters(\'profileName\')]'
-                                        type: 'Microsoft.Insights/diagnosticSettings'
-                                        apiVersion: '2021-05-01-preview'
-                                        scope: '[resourceId(\'Microsoft.Automation/automationAccounts\', parameters(\'resourceName\'))]'
+                                        type: 'Fake.Insights/diagnosticSettings'
+                                        apiVersion: '2421-05-01-preview'
+                                        scope: '[resourceId(\'Fake.Automation/automationAccounts\', parameters(\'resourceName\'))]'
                                         properties: {
                                           workspaceId: '[parameters(\'logAnalytics\')]'
                                           metrics: [
@@ -650,7 +652,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 ";
                 CompileAndTestWithFakeDateAndTypes(bicep,
                     ResourceScope.ResourceGroup,
-                    Array.Empty<string>(),
+                    FakeResourceTypes.SubscriptionScopeTypes,
                     "2422-07-04",
                     Array.Empty<string>());
             }
@@ -735,7 +737,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             {
                 string bicep = @"
                     param resourceType string = 'Fake.DBforMySQL/servers'
-                    param apiversion string = '2000-01-01'
+                    param apiversion string = '2400-01-01'
                     output a object = reference(resourceType, apiversion)
                 ";
                 CompileAndTestWithFakeDateAndTypes(bicep,
@@ -743,7 +745,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     FakeResourceTypes.ResourceScopeTypes,
                     "2422-07-04",
                 new string[] {
-                    "[4] Could not find apiVersion 2000-01-01 for Fake.DBforMySQL/servers. Acceptable versions: 2417-12-01"
+                    "[4] Could not find apiVersion 2400-01-01 for Fake.DBforMySQL/servers. Acceptable versions: 2417-12-01"
                 });
             }
 
@@ -818,7 +820,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             public void ReferenceFunction_NoResourceType_Ignore()
             {
                 string bicep = @"
-                    output a object = reference(resourceId('Fake.DBforMySQL.servers', 'test'), '2001-01-01')
+                    output a object = reference(resourceId('Fake.DBforMySQL.servers', 'test'), '2401-01-01')
                 ";
                 CompileAndTestWithFakeDateAndTypes(bicep,
                     ResourceScope.ResourceGroup,
@@ -904,14 +906,14 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         //           versions available.Line: 15, Column: 24
                         //        Valid Api Versions Microsoft.ManagedIdentity / userAssignedIdentities :
                         //        2018 - 11 - 30
-                        //        2022 - 01 - 31 - PREVIEW
+                        //        2422 - 01 - 31 - PREVIEW
                         //        2021 - 09 - 30 - PREVIEW
                         //        Api versions must be the latest or under 2 years old(730 days) - API version used by:
                         //            reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userAssignedIdentityName')), '2015-08-31-PREVIEW')
                         //        is 2535 days old Line: 15, Column: 24
                         //        Valid Api Versions for Microsoft.ManagedIdentity / userAssignedIdentities :
                         //        2018 - 11 - 30
-                        //        2022 - 01 - 31 - PREVIEW
+                        //        2422 - 01 - 31 - PREVIEW
                         "[7] Use more recent API version for 'Fake.ManagedIdentity/userAssignedIdentities'. '2415-08-31-preview' is 2499 days old, should be no more than 730 days old, or the most recent. Acceptable versions: 2418-11-30",
                         "[12] Use more recent API version for 'Fake.ManagedIdentity/userAssignedIdentities'. '2415-08-31-preview' is 2499 days old, should be no more than 730 days old, or the most recent. Acceptable versions: 2418-11-30",
                     });
@@ -967,8 +969,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                          //           list(resourceId('Microsoft.Network/publicIPAddresses', 'test'), '2015-06-15')
                          //       is 2612 days old Line: 11, Column: 24
                          //       Valid Api Versions for Microsoft.Network/publicIPAddresses :
-                         //       2022 - 01 - 01
-                         //       2022 - 01 - 01
+                         //       2422 - 01 - 01
+                         //       2422 - 01 - 01
                          //       2021 - 12 - 01
                          //       2021 - 08 - 01
                          //       2021 - 06 - 01
@@ -990,8 +992,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     var listAccountSasRequestContent = {
                       signedServices: 'bfqt'
                       signedPermission: 'rwdlacup'
-                      signedStart: '2021-06-02T00:00:00Z'
-                      signedExpiry: '2030-10-30T00:00:00Z'
+                      signedStart: '2421-06-02T00:00:00Z'
+                      signedExpiry: '2430-10-30T00:00:00Z'
                       signedResourceTypes: 'sco'
                     }
 
@@ -1067,19 +1069,14 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             {
                 string bicep = @"
                     var lbPublicIPName = 'lbPublicIPName'
-                    output o string = reference(resourceId('Microsoft.Network/publicIPAddresses', lbPublicIPName),'2020-08-01').dnsSettings.fqdn
+                    output o string = reference(resourceId('Fake.Network/privateIPAddresses', lbPublicIPName),'2420-08-01').dnsSettings.fqdn
                 ";
                 CompileAndTestWithFakeDateAndTypes(bicep,
                     ResourceScope.ResourceGroup,
                 FakeResourceTypes.ResourceScopeTypes,
                 "2422-07-04",
                     new string[] {
-                        // TTK result:
-                        //[-] apiVersions Should Be Recent In Reference Functions(57 ms)
-                        //    Api versions must be the latest or under 2 years old(730 days) - API version used by:
-                        //        reference(resourceId('Microsoft.Network/publicIPAddresses', variables('lbPublicIPName')), '2020-08-01')
-                        //    is 742 days old Line: 499, Column: 18
-                        "[3] Could not find resource type \"Microsoft.Network/publicIPAddresses\"."
+                        "[3] Could not find resource type \"Fake.Network/privateIPAddresses\". Did you mean \"Fake.Network/publicIPAddresses\"?"
                     });
             }
 
@@ -1088,7 +1085,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             {
                 string bicep = @"
                     var lbPublicIPName = 'lbPublicIPName'
-                    output o string = reference(resourceId('Fake.Network/publicIPAddress', lbPublicIPName),'2020-08-01').dnsSettings.fqdn
+                    output o string = reference(resourceId('Fake.Network/publicIPAddress', lbPublicIPName),'2420-08-01').dnsSettings.fqdn
                 ";
                 CompileAndTestWithFakeDateAndTypes(bicep,
                     ResourceScope.ResourceGroup,
@@ -1163,9 +1160,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             public void Reference_ResourceName()
             {
                 string bicep = @"
-                    output output string = reference('lbPublicIPName', '2020-01-01').outputs.dbSubnetRef.value
+                    output output string = reference('lbPublicIPName', '2420-01-01').outputs.dbSubnetRef.value
 
-                    resource lbPublicIPName 'Fake.Network/publicIPAddresses@2020-11-01' = {
+                    resource lbPublicIPName 'Fake.Network/publicIPAddresses@2420-12-01' = {
                       name: 'lbPublicIPName'
                     #disable-next-line no-hardcoded-location
                       location: 'location'
@@ -1182,7 +1179,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 FakeResourceTypes.ResourceScopeTypes,
                 "2422-07-04",
                     new string[] {
-                        "[2] Could not find apiVersion 2020-01-01 for Fake.Network/publicIPAddresses. Acceptable versions: 2420-11-01, 2420-08-01", "[4] Could not find apiVersion 2020-11-01 for Fake.Network/publicIPAddresses. Acceptable versions: 2420-11-01, 2420-08-01",
+                        "[2] Could not find apiVersion 2420-01-01 for Fake.Network/publicIPAddresses. Acceptable versions: 2420-11-01, 2420-08-01",
+                        "[4] Could not find apiVersion 2420-12-01 for Fake.Network/publicIPAddresses. Acceptable versions: 2420-11-01, 2420-08-01",
                     });
             }
 

--- a/src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs
+++ b/src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs
@@ -4595,8 +4595,8 @@ Fake.ServiceBus/namespaces@2417-04-01
 Fake.ServiceBus/namespaces@2418-01-01-preview
 Fake.ServiceBus/namespaces@2421-01-01-preview
 Fake.ServiceBus/namespaces@2421-06-01-preview
-Fake.ServiceBus/namespaces@2021-11-01
-Fake.ServiceBus/namespaces@2022-01-01-preview
+Fake.ServiceBus/namespaces@2321-11-01
+Fake.ServiceBus/namespaces@2322-01-01-preview
 Fake.ServiceBus/namespaces/AuthorizationRules@2415-08-01
 Fake.ServiceBus/namespaces/AuthorizationRules@2417-04-01
 Fake.ServiceBus/namespaces/AuthorizationRules@2418-01-01-preview
@@ -6184,6 +6184,7 @@ Fake.Authorization/policydefinitions@2419-09-01
 Fake.Authorization/policydefinitions@2420-03-01
 Fake.Authorization/policydefinitions@2420-09-01
 Fake.Authorization/policydefinitions@2421-06-01
+Fake.Authorization/policydefinitions@2423-04-01
 Fake.Authorization/policyassignments@2415-10-01-preview
 Fake.Authorization/policyassignments@2416-04-01
 Fake.Authorization/policyassignments@2416-12-01


### PR DESCRIPTION
These were supposed to all be fake, but a bunch got through.  Now we verify they're all fake.

Fixes https://github.com/Azure/bicep/issues/12034

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12043)