### PR TITLE
Fix compiled representation of wildcard variable property references

### DIFF
--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmTypeToExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmTypeToExpressionConverter.cs
@@ -143,7 +143,7 @@ internal class ArmTypeToExpressionConverter
 
         if (schemaNode.Ref?.Value is string @ref)
         {
-            return new TypeAliasReferenceExpression(sourceSyntax, typePointerToSymbolNameMapping[@ref], bicepType);
+            return new SynthesizedTypeAliasReferenceExpression(sourceSyntax, typePointerToSymbolNameMapping[@ref], bicepType);
         }
 
         return schemaNode.Type.Value switch

--- a/src/Bicep.Core/Emit/CompileTimeImports/ImportReferenceExpressionRewriter.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ImportReferenceExpressionRewriter.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Bicep.Core.Intermediate;
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.Emit.CompileTimeImports;
+
+internal class ImportReferenceExpressionRewriter : ExpressionRewriteVisitor
+{
+    private readonly ImmutableDictionary<ImportedSymbol, string> importedSymbolNames;
+    private readonly ImmutableDictionary<WildcardImportPropertyReference, string> wildcardImportPropertyNames;
+    private readonly SyntaxBase? sourceSyntax;
+
+    public ImportReferenceExpressionRewriter(ImmutableDictionary<ImportedSymbol, string> importedSymbolNames,
+        ImmutableDictionary<WildcardImportPropertyReference, string> wildcardImportPropertyNames,
+        SyntaxBase? sourceSyntax)
+    {
+        this.importedSymbolNames = importedSymbolNames;
+        this.wildcardImportPropertyNames = wildcardImportPropertyNames;
+        this.sourceSyntax = sourceSyntax;
+    }
+
+    public Expression ReplaceImportReferences(Expression expression) => Replace(expression);
+
+    public override Expression ReplaceImportedTypeReferenceExpression(ImportedTypeReferenceExpression expression)
+        => new SynthesizedTypeAliasReferenceExpression(sourceSyntax ?? expression.SourceSyntax, importedSymbolNames[expression.Symbol], expression.ExpressedType);
+
+    public override Expression ReplaceWildcardImportPropertyReferenceExpression(WildcardImportTypePropertyReferenceExpression expression)
+        => new SynthesizedTypeAliasReferenceExpression(sourceSyntax ?? expression.SourceSyntax, wildcardImportPropertyNames[new(expression.ImportSymbol, expression.PropertyName)], expression.ExpressedType);
+
+    public override Expression ReplaceImportedVariableReferenceExpression(ImportedVariableReferenceExpression expression)
+        => new SynthesizedVariableReferenceExpression(sourceSyntax ?? expression.SourceSyntax, importedSymbolNames[expression.Variable]);
+
+    public override Expression ReplaceWildcardImportVariablePropertyReferenceExpression(WildcardImportVariablePropertyReferenceExpression expression)
+        => new SynthesizedVariableReferenceExpression(sourceSyntax ?? expression.SourceSyntax, wildcardImportPropertyNames[new(expression.ImportSymbol, expression.PropertyName)]);
+}

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -141,12 +141,6 @@ namespace Bicep.Core.Emit
                 case SynthesizedVariableReferenceExpression exp:
                     return CreateFunction("variables", new JTokenExpression(exp.Name));
 
-                case ImportedVariableReferenceExpression exp:
-                    return CreateFunction("variables", new JTokenExpression(exp.Variable.Name));
-
-                case WildcardImportVariablePropertyReferenceExpression exp:
-                    return AppendProperties(CreateFunction("variables", new JTokenExpression(exp.ImportSymbol.Name)), new JTokenExpression(exp.PropertyName));
-
                 case ParametersReferenceExpression exp:
                     return CreateFunction("parameters", new JTokenExpression(exp.Parameter.Name));
 

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -628,12 +628,24 @@ public record FullyQualifiedAmbientTypeReferenceExpression(
 
 public record TypeAliasReferenceExpression(
     SyntaxBase? SourceSyntax,
-    string Name,
+    TypeAliasSymbol Symbol,
     TypeSymbol ExpressedType
 ) : TypeExpression(SourceSyntax, ExpressedType)
 {
     public override void Accept(IExpressionVisitor visitor)
         => visitor.VisitTypeAliasReferenceExpression(this);
+
+    protected override object? GetDebugAttributes() => new { Symbol.Name };
+}
+
+public record SynthesizedTypeAliasReferenceExpression(
+    SyntaxBase? SourceSyntax,
+    string Name,
+    TypeSymbol ExpressedType
+) : TypeExpression(SourceSyntax, ExpressedType)
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitSynthesizedTypeAliasReferenceExpression(this);
 
     protected override object? GetDebugAttributes() => new { Name };
 }

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -242,7 +242,7 @@ public class ExpressionBuilder
             VariableAccessSyntax variableAccess => Context.SemanticModel.Binder.GetSymbolInfo(syntax) switch
             {
                 AmbientTypeSymbol ambientType => new AmbientTypeReferenceExpression(syntax, ambientType.Name, ambientType.Type),
-                TypeAliasSymbol typeAlias => new TypeAliasReferenceExpression(syntax, typeAlias.Name, typeAlias.Type),
+                TypeAliasSymbol typeAlias => new TypeAliasReferenceExpression(syntax, typeAlias, typeAlias.Type),
                 ImportedSymbol importedSymbol when importedSymbol.Kind == SymbolKind.TypeAlias => new ImportedTypeReferenceExpression(syntax, importedSymbol, importedSymbol.Type),
                 Symbol otherwise => throw new ArgumentException($"Encountered unexpected symbol of type {otherwise.GetType()} in a type expression."),
                 _ => throw new ArgumentException($"Unable to locate symbol for name '{variableAccess.Name.IdentifierName}'.")

--- a/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
@@ -365,6 +365,12 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         return expression;
     }
 
+    void IExpressionVisitor.VisitSynthesizedTypeAliasReferenceExpression(SynthesizedTypeAliasReferenceExpression expression) => ReplaceCurrent(expression, ReplaceSynthesizedTypeAliasReferenceExpression);
+    public virtual Expression ReplaceSynthesizedTypeAliasReferenceExpression(SynthesizedTypeAliasReferenceExpression expression)
+    {
+        return expression;
+    }
+
     void IExpressionVisitor.VisitStringLiteralTypeExpression(StringLiteralTypeExpression expression) => ReplaceCurrent(expression, ReplaceStringLiteralTypeExpression);
     public virtual Expression ReplaceStringLiteralTypeExpression(StringLiteralTypeExpression expression)
     {
@@ -527,13 +533,14 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
             TryRewriteStrict(expression.Metadata, out var metadata) |
             TryRewriteStrict(expression.Providers, out var providers) |
             TryRewriteStrict(expression.Parameters, out var parameters) |
+            TryRewriteStrict(expression.Types, out var types) |
             TryRewriteStrict(expression.Variables, out var variables) |
             TryRewriteStrict(expression.Functions, out var functions) |
             TryRewriteStrict(expression.Resources, out var resources) |
             TryRewriteStrict(expression.Modules, out var modules) |
             TryRewriteStrict(expression.Outputs, out var outputs);
 
-        return hasChanges ? expression with { Metadata = metadata, Providers = providers, Parameters = parameters, Variables = variables, Functions = functions, Resources = resources, Modules = modules, Outputs = outputs } : expression;
+        return hasChanges ? expression with { Metadata = metadata, Providers = providers, Parameters = parameters, Types = types, Variables = variables, Functions = functions, Resources = resources, Modules = modules, Outputs = outputs } : expression;
     }
 
     protected virtual Expression Replace(Expression expression) => ReplaceInternal(expression);

--- a/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
@@ -252,6 +252,10 @@ public abstract class ExpressionVisitor : IExpressionVisitor
     {
     }
 
+    public virtual void VisitSynthesizedTypeAliasReferenceExpression(SynthesizedTypeAliasReferenceExpression expression)
+    {
+    }
+
     public virtual void VisitStringLiteralTypeExpression(StringLiteralTypeExpression expression)
     {
     }

--- a/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
@@ -93,6 +93,8 @@ public interface IExpressionVisitor
 
     void VisitTypeAliasReferenceExpression(TypeAliasReferenceExpression expression);
 
+    void VisitSynthesizedTypeAliasReferenceExpression(SynthesizedTypeAliasReferenceExpression expression);
+
     void VisitStringLiteralTypeExpression(StringLiteralTypeExpression expression);
 
     void VisitIntegerLiteralTypeExpression(IntegerLiteralTypeExpression expression);


### PR DESCRIPTION
Resolves #12042 

#11879 introduced a regression in references to variables imported with via wildcard syntax were represented in a template's compiled form. For example,

```
import * as mod from 'mod.bicep'
output s string = mod.s
```

would generate a value of `"[variables('mod').s]"` in the compiled template. When implementing variable imports for `.bicepparam` files, I took the shortcut of generating a object value for wildcard imports whose properties were all the variables exported from the imported model. There was a gap in test coverage for variable imports in `.bicep` files, so the regression was not picked up. This PR updates how wildcard imports are handled in `.bicepparam` files to remove the aforementioned shortcut. 

The PR also adds an extra step in `TemplateWriter`: after `.bicep` files are converted to the compiler's intermediate representation, expressions referring to imported values are replaced with expressions that refer to "synthetic" variables and types.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12048)