### PR TITLE
Update ExpressionRewriteVisitor to rewrite param and output type clauses

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.bicep
@@ -1,4 +1,4 @@
-import {foo, fizz} from 'modules/mod.bicep'
+import {foo, fizz, pop} from 'modules/mod.bicep'
 import * as mod2 from 'modules/mod2.bicep'
 import {
   'not-a-valid-bicep-identifier' as withInvalidIdentifier
@@ -6,5 +6,9 @@ import {
 } from 'modules/mod.json'
 
 var aliasedFoo = foo
+var aliasedBar = mod2.foo
 
 type fizzes = fizz[]
+
+param fizzParam mod2.fizz
+output magicWord pop = refersToCopyVariable[3].value

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.diagnostics.bicep
@@ -1,4 +1,4 @@
-import {foo, fizz} from 'modules/mod.bicep'
+import {foo, fizz, pop} from 'modules/mod.bicep'
 import * as mod2 from 'modules/mod2.bicep'
 import {
   'not-a-valid-bicep-identifier' as withInvalidIdentifier
@@ -7,6 +7,12 @@ import {
 
 var aliasedFoo = foo
 //@[4:14) [no-unused-vars (Warning)] Variable "aliasedFoo" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |aliasedFoo|
+var aliasedBar = mod2.foo
+//@[4:14) [no-unused-vars (Warning)] Variable "aliasedBar" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |aliasedBar|
 
 type fizzes = fizz[]
+
+param fizzParam mod2.fizz
+//@[6:15) [no-unused-params (Warning)] Parameter "fizzParam" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |fizzParam|
+output magicWord pop = refersToCopyVariable[3].value
 

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.formatted.bicep
@@ -1,4 +1,4 @@
-import { foo, fizz } from 'modules/mod.bicep'
+import { foo, fizz, pop } from 'modules/mod.bicep'
 import * as mod2 from 'modules/mod2.bicep'
 import {
   'not-a-valid-bicep-identifier' as withInvalidIdentifier
@@ -6,5 +6,9 @@ import {
 } from 'modules/mod.json'
 
 var aliasedFoo = foo
+var aliasedBar = mod2.foo
 
 type fizzes = fizz[]
+
+param fizzParam mod2.fizz
+output magicWord pop = refersToCopyVariable[3].value

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.ir.bicep
@@ -1,5 +1,5 @@
-import {foo, fizz} from 'modules/mod.bicep'
-//@[00:247) ProgramExpression
+import {foo, fizz, pop} from 'modules/mod.bicep'
+//@[00:358) ProgramExpression
 import * as mod2 from 'modules/mod2.bicep'
 import {
   'not-a-valid-bicep-identifier' as withInvalidIdentifier
@@ -7,11 +7,26 @@ import {
 } from 'modules/mod.json'
 
 var aliasedFoo = foo
-//@[00:020) └─DeclaredVariableExpression { Name = aliasedFoo }
-//@[17:020)   └─ImportedVariableReferenceExpression { Variable = foo }
+//@[00:020) ├─DeclaredVariableExpression { Name = aliasedFoo }
+//@[17:020) | └─ImportedVariableReferenceExpression { Variable = foo }
+var aliasedBar = mod2.foo
+//@[00:025) ├─DeclaredVariableExpression { Name = aliasedBar }
+//@[17:025) | └─WildcardImportVariablePropertyReferenceExpression { Variable = mod2.foo }
 
 type fizzes = fizz[]
 //@[00:020) ├─DeclaredTypeExpression { Name = fizzes }
 //@[14:020) | └─ArrayTypeExpression { Name = { property: pop? }[][] }
 //@[14:018) |   └─ImportedTypeReferenceExpression { Name = fizz }
+
+param fizzParam mod2.fizz
+//@[00:025) ├─DeclaredParameterExpression { Name = fizzParam }
+//@[16:025) | └─WildcardImportTypePropertyReferenceExpression { Name = mod2.fizz }
+output magicWord pop = refersToCopyVariable[3].value
+//@[00:052) └─DeclaredOutputExpression { Name = magicWord }
+//@[17:020)   ├─ImportedTypeReferenceExpression { Name = pop }
+//@[23:052)   └─AccessChainExpression
+//@[23:046)     ├─ArrayAccessExpression
+//@[44:045)     | ├─IntegerLiteralExpression { Value = 3 }
+//@[23:043)     | └─ImportedVariableReferenceExpression { Variable = refersToCopyVariable }
+//@[47:052)     └─StringLiteralExpression { Value = value }
 

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6589342864324340997"
+      "templateHash": "17634149553669977724"
     }
   },
   "definitions": {
@@ -20,19 +20,10 @@
       "type": "object",
       "properties": {
         "property": {
-          "$ref": "#/definitions/1.pop",
+          "$ref": "#/definitions/pop",
           "nullable": true
         }
       },
-      "metadata": {
-        "__bicep_imported_from!": {
-          "sourceTemplate": "modules/mod.bicep"
-        }
-      }
-    },
-    "1.pop": {
-      "type": "string",
-      "minLength": 3,
       "metadata": {
         "__bicep_imported_from!": {
           "sourceTemplate": "modules/mod.bicep"
@@ -60,6 +51,20 @@
           "sourceTemplate": "modules/mod.bicep"
         }
       }
+    },
+    "pop": {
+      "type": "string",
+      "minLength": 3,
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "modules/mod.bicep"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "fizzParam": {
+      "$ref": "#/definitions/3.fizz"
     }
   },
   "variables": {
@@ -74,6 +79,7 @@
       }
     ],
     "aliasedFoo": "[variables('foo')]",
+    "aliasedBar": "[variables('3.foo')]",
     "1.bar": "[variables('1.baz')]",
     "1.baz": "quux",
     "2.copyVariableCount": 10,
@@ -86,5 +92,11 @@
     "refersToCopyVariable": "[variables('2.copyVariable')]",
     "withInvalidIdentifier": "value"
   },
-  "resources": {}
+  "resources": {},
+  "outputs": {
+    "magicWord": {
+      "$ref": "#/definitions/pop",
+      "value": "[variables('refersToCopyVariable')[3].value]"
+    }
+  }
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.pprint.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.pprint.bicep
@@ -1,4 +1,4 @@
-import { foo, fizz } from 'modules/mod.bicep'
+import { foo, fizz, pop } from 'modules/mod.bicep'
 import * as mod2 from 'modules/mod2.bicep'
 import {
   'not-a-valid-bicep-identifier' as withInvalidIdentifier
@@ -6,5 +6,9 @@ import {
 } from 'modules/mod.json'
 
 var aliasedFoo = foo
+var aliasedBar = mod2.foo
 
 type fizzes = fizz[]
+
+param fizzParam mod2.fizz
+output magicWord pop = refersToCopyVariable[3].value

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.sourcemap.bicep
@@ -1,20 +1,12 @@
-import {foo, fizz} from 'modules/mod.bicep'
+import {foo, fizz, pop} from 'modules/mod.bicep'
 //@    "1.buzz": {
 //@      "type": "object",
 //@      "properties": {
 //@        "property": {
-//@          "$ref": "#/definitions/1.pop",
+//@          "$ref": "#/definitions/pop",
 //@          "nullable": true
 //@        }
 //@      },
-//@      "metadata": {
-//@        "__bicep_imported_from!": {
-//@          "sourceTemplate": "modules/mod.bicep"
-//@        }
-//@      }
-//@    },
-//@    "1.pop": {
-//@      "type": "string",
 //@      "metadata": {
 //@        "__bicep_imported_from!": {
 //@          "sourceTemplate": "modules/mod.bicep"
@@ -26,6 +18,14 @@ import {foo, fizz} from 'modules/mod.bicep'
 //@      "items": {
 //@        "$ref": "#/definitions/1.buzz"
 //@      },
+//@      "metadata": {
+//@        "__bicep_imported_from!": {
+//@          "sourceTemplate": "modules/mod.bicep"
+//@        }
+//@      }
+//@    },
+//@    "pop": {
+//@      "type": "string",
 //@      "metadata": {
 //@        "__bicep_imported_from!": {
 //@          "sourceTemplate": "modules/mod.bicep"
@@ -71,6 +71,8 @@ import {
 
 var aliasedFoo = foo
 //@    "aliasedFoo": "[variables('foo')]",
+var aliasedBar = mod2.foo
+//@    "aliasedBar": "[variables('3.foo')]",
 
 type fizzes = fizz[]
 //@    "fizzes": {
@@ -79,4 +81,14 @@ type fizzes = fizz[]
 //@        "$ref": "#/definitions/fizz"
 //@      }
 //@    },
+
+param fizzParam mod2.fizz
+//@    "fizzParam": {
+//@      "$ref": "#/definitions/3.fizz"
+//@    }
+output magicWord pop = refersToCopyVariable[3].value
+//@    "magicWord": {
+//@      "$ref": "#/definitions/pop",
+//@      "value": "[variables('refersToCopyVariable')[3].value]"
+//@    }
 

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6589342864324340997"
+      "templateHash": "17634149553669977724"
     }
   },
   "definitions": {
@@ -20,19 +20,10 @@
       "type": "object",
       "properties": {
         "property": {
-          "$ref": "#/definitions/1.pop",
+          "$ref": "#/definitions/pop",
           "nullable": true
         }
       },
-      "metadata": {
-        "__bicep_imported_from!": {
-          "sourceTemplate": "modules/mod.bicep"
-        }
-      }
-    },
-    "1.pop": {
-      "type": "string",
-      "minLength": 3,
       "metadata": {
         "__bicep_imported_from!": {
           "sourceTemplate": "modules/mod.bicep"
@@ -60,6 +51,20 @@
           "sourceTemplate": "modules/mod.bicep"
         }
       }
+    },
+    "pop": {
+      "type": "string",
+      "minLength": 3,
+      "metadata": {
+        "__bicep_imported_from!": {
+          "sourceTemplate": "modules/mod.bicep"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "fizzParam": {
+      "$ref": "#/definitions/3.fizz"
     }
   },
   "variables": {
@@ -74,6 +79,7 @@
       }
     ],
     "aliasedFoo": "[variables('foo')]",
+    "aliasedBar": "[variables('3.foo')]",
     "1.bar": "[variables('1.baz')]",
     "1.baz": "quux",
     "2.copyVariableCount": 10,
@@ -86,5 +92,11 @@
     "refersToCopyVariable": "[variables('2.copyVariable')]",
     "withInvalidIdentifier": "value"
   },
-  "resources": {}
+  "resources": {},
+  "outputs": {
+    "magicWord": {
+      "$ref": "#/definitions/pop",
+      "value": "[variables('refersToCopyVariable')[3].value]"
+    }
+  }
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.symbols.bicep
@@ -1,6 +1,7 @@
-import {foo, fizz} from 'modules/mod.bicep'
+import {foo, fizz, pop} from 'modules/mod.bicep'
 //@[08:11) Variable foo. Type: 'quux'. Declaration start char: 8, length: 3
 //@[13:17) TypeAlias fizz. Type: Type<{ property: pop? }[]>. Declaration start char: 13, length: 4
+//@[19:22) TypeAlias pop. Type: Type<string>. Declaration start char: 19, length: 3
 import * as mod2 from 'modules/mod2.bicep'
 //@[12:16) ImportedNamespace mod2. Type: mod2. Declaration start char: 7, length: 9
 import {
@@ -12,7 +13,14 @@ import {
 
 var aliasedFoo = foo
 //@[04:14) Variable aliasedFoo. Type: 'quux'. Declaration start char: 0, length: 20
+var aliasedBar = mod2.foo
+//@[04:14) Variable aliasedBar. Type: 'bar'. Declaration start char: 0, length: 25
 
 type fizzes = fizz[]
 //@[05:11) TypeAlias fizzes. Type: Type<{ property: pop? }[][]>. Declaration start char: 0, length: 20
+
+param fizzParam mod2.fizz
+//@[06:15) Parameter fizzParam. Type: 'buzz'. Declaration start char: 0, length: 25
+output magicWord pop = refersToCopyVariable[3].value
+//@[07:16) Output magicWord. Type: string. Declaration start char: 0, length: 52
 

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.syntax.bicep
@@ -1,8 +1,8 @@
-import {foo, fizz} from 'modules/mod.bicep'
-//@[00:247) ProgramSyntax
-//@[00:043) ├─CompileTimeImportDeclarationSyntax
+import {foo, fizz, pop} from 'modules/mod.bicep'
+//@[00:358) ProgramSyntax
+//@[00:048) ├─CompileTimeImportDeclarationSyntax
 //@[00:006) | ├─Token(Identifier) |import|
-//@[07:018) | ├─ImportedSymbolsListSyntax
+//@[07:023) | ├─ImportedSymbolsListSyntax
 //@[07:008) | | ├─Token(LeftBrace) |{|
 //@[08:011) | | ├─ImportedSymbolsListItemSyntax
 //@[08:011) | | | └─IdentifierSyntax
@@ -11,12 +11,16 @@ import {foo, fizz} from 'modules/mod.bicep'
 //@[13:017) | | ├─ImportedSymbolsListItemSyntax
 //@[13:017) | | | └─IdentifierSyntax
 //@[13:017) | | |   └─Token(Identifier) |fizz|
-//@[17:018) | | └─Token(RightBrace) |}|
-//@[19:043) | └─CompileTimeImportFromClauseSyntax
-//@[19:023) |   ├─Token(Identifier) |from|
-//@[24:043) |   └─StringSyntax
-//@[24:043) |     └─Token(StringComplete) |'modules/mod.bicep'|
-//@[43:044) ├─Token(NewLine) |\n|
+//@[17:018) | | ├─Token(Comma) |,|
+//@[19:022) | | ├─ImportedSymbolsListItemSyntax
+//@[19:022) | | | └─IdentifierSyntax
+//@[19:022) | | |   └─Token(Identifier) |pop|
+//@[22:023) | | └─Token(RightBrace) |}|
+//@[24:048) | └─CompileTimeImportFromClauseSyntax
+//@[24:028) |   ├─Token(Identifier) |from|
+//@[29:048) |   └─StringSyntax
+//@[29:048) |     └─Token(StringComplete) |'modules/mod.bicep'|
+//@[48:049) ├─Token(NewLine) |\n|
 import * as mod2 from 'modules/mod2.bicep'
 //@[00:042) ├─CompileTimeImportDeclarationSyntax
 //@[00:006) | ├─Token(Identifier) |import|
@@ -68,7 +72,21 @@ var aliasedFoo = foo
 //@[17:020) | └─VariableAccessSyntax
 //@[17:020) |   └─IdentifierSyntax
 //@[17:020) |     └─Token(Identifier) |foo|
-//@[20:022) ├─Token(NewLine) |\n\n|
+//@[20:021) ├─Token(NewLine) |\n|
+var aliasedBar = mod2.foo
+//@[00:025) ├─VariableDeclarationSyntax
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:014) | ├─IdentifierSyntax
+//@[04:014) | | └─Token(Identifier) |aliasedBar|
+//@[15:016) | ├─Token(Assignment) |=|
+//@[17:025) | └─PropertyAccessSyntax
+//@[17:021) |   ├─VariableAccessSyntax
+//@[17:021) |   | └─IdentifierSyntax
+//@[17:021) |   |   └─Token(Identifier) |mod2|
+//@[21:022) |   ├─Token(Dot) |.|
+//@[22:025) |   └─IdentifierSyntax
+//@[22:025) |     └─Token(Identifier) |foo|
+//@[25:027) ├─Token(NewLine) |\n\n|
 
 type fizzes = fizz[]
 //@[00:020) ├─TypeDeclarationSyntax
@@ -83,6 +101,42 @@ type fizzes = fizz[]
 //@[14:018) |   |     └─Token(Identifier) |fizz|
 //@[18:019) |   ├─Token(LeftSquare) |[|
 //@[19:020) |   └─Token(RightSquare) |]|
-//@[20:021) ├─Token(NewLine) |\n|
+//@[20:022) ├─Token(NewLine) |\n\n|
+
+param fizzParam mod2.fizz
+//@[00:025) ├─ParameterDeclarationSyntax
+//@[00:005) | ├─Token(Identifier) |param|
+//@[06:015) | ├─IdentifierSyntax
+//@[06:015) | | └─Token(Identifier) |fizzParam|
+//@[16:025) | └─PropertyAccessSyntax
+//@[16:020) |   ├─VariableAccessSyntax
+//@[16:020) |   | └─IdentifierSyntax
+//@[16:020) |   |   └─Token(Identifier) |mod2|
+//@[20:021) |   ├─Token(Dot) |.|
+//@[21:025) |   └─IdentifierSyntax
+//@[21:025) |     └─Token(Identifier) |fizz|
+//@[25:026) ├─Token(NewLine) |\n|
+output magicWord pop = refersToCopyVariable[3].value
+//@[00:052) ├─OutputDeclarationSyntax
+//@[00:006) | ├─Token(Identifier) |output|
+//@[07:016) | ├─IdentifierSyntax
+//@[07:016) | | └─Token(Identifier) |magicWord|
+//@[17:020) | ├─VariableAccessSyntax
+//@[17:020) | | └─IdentifierSyntax
+//@[17:020) | |   └─Token(Identifier) |pop|
+//@[21:022) | ├─Token(Assignment) |=|
+//@[23:052) | └─PropertyAccessSyntax
+//@[23:046) |   ├─ArrayAccessSyntax
+//@[23:043) |   | ├─VariableAccessSyntax
+//@[23:043) |   | | └─IdentifierSyntax
+//@[23:043) |   | |   └─Token(Identifier) |refersToCopyVariable|
+//@[43:044) |   | ├─Token(LeftSquare) |[|
+//@[44:045) |   | ├─IntegerLiteralSyntax
+//@[44:045) |   | | └─Token(Integer) |3|
+//@[45:046) |   | └─Token(RightSquare) |]|
+//@[46:047) |   ├─Token(Dot) |.|
+//@[47:052) |   └─IdentifierSyntax
+//@[47:052) |     └─Token(Identifier) |value|
+//@[52:053) ├─Token(NewLine) |\n|
 
 //@[00:000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.tokens.bicep
@@ -1,13 +1,15 @@
-import {foo, fizz} from 'modules/mod.bicep'
+import {foo, fizz, pop} from 'modules/mod.bicep'
 //@[00:06) Identifier |import|
 //@[07:08) LeftBrace |{|
 //@[08:11) Identifier |foo|
 //@[11:12) Comma |,|
 //@[13:17) Identifier |fizz|
-//@[17:18) RightBrace |}|
-//@[19:23) Identifier |from|
-//@[24:43) StringComplete |'modules/mod.bicep'|
-//@[43:44) NewLine |\n|
+//@[17:18) Comma |,|
+//@[19:22) Identifier |pop|
+//@[22:23) RightBrace |}|
+//@[24:28) Identifier |from|
+//@[29:48) StringComplete |'modules/mod.bicep'|
+//@[48:49) NewLine |\n|
 import * as mod2 from 'modules/mod2.bicep'
 //@[00:06) Identifier |import|
 //@[07:08) Asterisk |*|
@@ -39,7 +41,15 @@ var aliasedFoo = foo
 //@[04:14) Identifier |aliasedFoo|
 //@[15:16) Assignment |=|
 //@[17:20) Identifier |foo|
-//@[20:22) NewLine |\n\n|
+//@[20:21) NewLine |\n|
+var aliasedBar = mod2.foo
+//@[00:03) Identifier |var|
+//@[04:14) Identifier |aliasedBar|
+//@[15:16) Assignment |=|
+//@[17:21) Identifier |mod2|
+//@[21:22) Dot |.|
+//@[22:25) Identifier |foo|
+//@[25:27) NewLine |\n\n|
 
 type fizzes = fizz[]
 //@[00:04) Identifier |type|
@@ -48,6 +58,26 @@ type fizzes = fizz[]
 //@[14:18) Identifier |fizz|
 //@[18:19) LeftSquare |[|
 //@[19:20) RightSquare |]|
-//@[20:21) NewLine |\n|
+//@[20:22) NewLine |\n\n|
+
+param fizzParam mod2.fizz
+//@[00:05) Identifier |param|
+//@[06:15) Identifier |fizzParam|
+//@[16:20) Identifier |mod2|
+//@[20:21) Dot |.|
+//@[21:25) Identifier |fizz|
+//@[25:26) NewLine |\n|
+output magicWord pop = refersToCopyVariable[3].value
+//@[00:06) Identifier |output|
+//@[07:16) Identifier |magicWord|
+//@[17:20) Identifier |pop|
+//@[21:22) Assignment |=|
+//@[23:43) Identifier |refersToCopyVariable|
+//@[43:44) LeftSquare |[|
+//@[44:45) Integer |3|
+//@[45:46) RightSquare |]|
+//@[46:47) Dot |.|
+//@[47:52) Identifier |value|
+//@[52:53) NewLine |\n|
 
 //@[00:00) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/modules/mod.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/modules/mod.bicep
@@ -13,4 +13,5 @@ type buzz = {
 }
 
 @minLength(3)
+@export()
 type pop = string

--- a/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.ir.bicep
@@ -2,12 +2,14 @@
 //@[00:1589) ProgramExpression
 @sys.description('string output description')
 //@[00:0076) ├─DeclaredOutputExpression { Name = myStr }
+//@[17:0044) | ├─StringLiteralExpression { Value = string output description }
 output myStr string = 'hello'
 //@[13:0019) | ├─AmbientTypeReferenceExpression { Name = string }
 //@[22:0029) | └─StringLiteralExpression { Value = hello }
 
 @sys.description('int output description')
 //@[00:0064) ├─DeclaredOutputExpression { Name = myInt }
+//@[17:0041) | ├─StringLiteralExpression { Value = int output description }
 output myInt int = 7
 //@[13:0016) | ├─AmbientTypeReferenceExpression { Name = int }
 //@[19:0020) | └─IntegerLiteralExpression { Value = 7 }
@@ -24,6 +26,7 @@ output myOtherInt int = 20 / 13 + 80 % -4
 
 @sys.description('bool output description')
 //@[00:0072) ├─DeclaredOutputExpression { Name = myBool }
+//@[17:0042) | ├─StringLiteralExpression { Value = bool output description }
 output myBool bool = !false
 //@[14:0018) | ├─AmbientTypeReferenceExpression { Name = bool }
 //@[21:0027) | └─UnaryExpression { Operator = Not }
@@ -35,6 +38,7 @@ output myOtherBool bool = true
 
 @sys.description('object array description')
 //@[00:0075) ├─DeclaredOutputExpression { Name = suchEmpty }
+//@[17:0043) | ├─StringLiteralExpression { Value = object array description }
 output suchEmpty array = [
 //@[17:0022) | ├─AmbientTypeReferenceExpression { Name = array }
 //@[25:0029) | └─ArrayExpression
@@ -48,6 +52,7 @@ output suchEmpty2 object = {
 
 @sys.description('object output description')
 //@[00:0225) ├─DeclaredOutputExpression { Name = obj }
+//@[17:0044) | ├─StringLiteralExpression { Value = object output description }
 output obj object = {
 //@[11:0017) | ├─AmbientTypeReferenceExpression { Name = object }
 //@[20:0178) | └─ObjectExpression

--- a/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
@@ -120,9 +120,11 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     public virtual Expression ReplaceLambdaExpression(LambdaExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Body, out var body);
+            TryRewriteCollectionOfNullablesStrict(expression.ParameterTypes, out var parameterTypes) |
+            TryRewrite(expression.Body, out var body) |
+            TryRewriteStrict(expression.OutputType, out var outputType);
 
-        return hasChanges ? expression with { Body = body } : expression;
+        return hasChanges ? expression with { Body = body, ParameterTypes = parameterTypes, OutputType = outputType } : expression;
     }
 
     void IExpressionVisitor.VisitLambdaVariableReferenceExpression(LambdaVariableReferenceExpression expression) => ReplaceCurrent(expression, ReplaceLambdaVariableReferenceExpression);
@@ -240,45 +242,75 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     public virtual Expression ReplaceDeclaredMetadataExpression(DeclaredMetadataExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Value, out var value);
+            TryRewrite(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges ? expression with { Value = value, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredProviderExpression(DeclaredProviderExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredProviderExpression);
     public virtual Expression ReplaceDeclaredProviderExpression(DeclaredProviderExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Config, out var config);
+            TryRewrite(expression.Config, out var config) |
+            TryRewrite(expression.Description, out var description);
 
-        return hasChanges ? expression with { Config = config } : expression;
+        return hasChanges ? expression with { Config = config, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredParameterExpression(DeclaredParameterExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredParameterExpression);
     public virtual Expression ReplaceDeclaredParameterExpression(DeclaredParameterExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.DefaultValue, out var defaultValue);
+            TryRewrite(expression.DefaultValue, out var defaultValue) |
+            TryRewriteStrict(expression.Type, out var type) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Metadata, out var metadata) |
+            TryRewrite(expression.Secure, out var secure) |
+            TryRewrite(expression.MinLength, out var minLength) |
+            TryRewrite(expression.MaxLength, out var maxLength) |
+            TryRewrite(expression.MinValue, out var minValue) |
+            TryRewrite(expression.MaxValue, out var maxValue) |
+            TryRewrite(expression.Sealed, out var @sealed) |
+            TryRewrite(expression.AllowedValues, out var allowedValues);
 
-        return hasChanges ? expression with { DefaultValue = defaultValue } : expression;
+        return hasChanges
+            ? expression with
+            {
+                DefaultValue = defaultValue,
+                Type = type,
+                Description = description,
+                Metadata = metadata,
+                Secure = secure,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Sealed = @sealed,
+                AllowedValues = allowedValues,
+            }
+            : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredVariableExpression(DeclaredVariableExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredVariableExpression);
     public virtual Expression ReplaceDeclaredVariableExpression(DeclaredVariableExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Value, out var value);
+            TryRewrite(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Exported, out var exported);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges ? expression with { Value = value, Description = description, Exported = exported } : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredFunctionExpression(DeclaredFunctionExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredFunctionExpression);
     public virtual Expression ReplaceDeclaredFunctionExpression(DeclaredFunctionExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Lambda, out var lambda);
+            TryRewrite(expression.Lambda, out var lambda) |
+            TryRewrite(expression.Description, out var description);
 
-        return hasChanges ? expression with { Lambda = lambda } : expression;
+        return hasChanges ? expression with { Lambda = lambda, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitUserDefinedFunctionCallExpression(UserDefinedFunctionCallExpression expression) => ReplaceCurrent(expression, ReplaceUserDefinedFunctionCallExpression);
@@ -294,18 +326,42 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     public virtual Expression ReplaceDeclaredOutputExpression(DeclaredOutputExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Value, out var value);
+            TryRewrite(expression.Value, out var value) |
+            TryRewriteStrict(expression.Type, out var type) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Metadata, out var metadata) |
+            TryRewrite(expression.Secure, out var secure) |
+            TryRewrite(expression.MinLength, out var minLength) |
+            TryRewrite(expression.MaxLength, out var maxLength) |
+            TryRewrite(expression.MinValue, out var minValue) |
+            TryRewrite(expression.MaxValue, out var maxValue) |
+            TryRewrite(expression.Sealed, out var @sealed);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges
+            ? expression with
+            {
+                Value = value,
+                Type = type,
+                Description = description,
+                Metadata = metadata,
+                Secure = secure,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Sealed = @sealed,
+            }
+            : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredAssertExpression(DeclaredAssertExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredAssertExpression);
     public virtual Expression ReplaceDeclaredAssertExpression(DeclaredAssertExpression expression)
     {
         var hasChanges =
-            TryRewrite(expression.Value, out var value);
+            TryRewrite(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges ? expression with { Value = value, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredResourceExpression(DeclaredResourceExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredResourceExpression);
@@ -313,9 +369,10 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Body, out var body) |
-            TryRewriteStrict(expression.DependsOn, out var dependsOn);
+            TryRewriteStrict(expression.DependsOn, out var dependsOn) |
+            TryRewrite(expression.Description, out var description);
 
-        return hasChanges ? expression with { Body = body, DependsOn = dependsOn } : expression;
+        return hasChanges ? expression with { Body = body, DependsOn = dependsOn, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredModuleExpression(DeclaredModuleExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredModuleExpression);
@@ -324,9 +381,10 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         var hasChanges =
             TryRewrite(expression.Body, out var body) |
             TryRewrite(expression.Parameters, out var parameters) |
-            TryRewriteStrict(expression.DependsOn, out var dependsOn);
+            TryRewriteStrict(expression.DependsOn, out var dependsOn) |
+            TryRewrite(expression.Description, out var description);
 
-        return hasChanges ? expression with { Body = body, Parameters = parameters, DependsOn = dependsOn } : expression;
+        return hasChanges ? expression with { Body = body, Parameters = parameters, DependsOn = dependsOn, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitResourceDependencyExpression(ResourceDependencyExpression expression) => ReplaceCurrent(expression, ReplaceResourceDependencyExpression);
@@ -342,9 +400,32 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     public virtual Expression ReplaceDeclaredTypeExpression(DeclaredTypeExpression expression)
     {
         var hasChanges =
-            TryRewriteStrict(expression.Value, out var value);
+            TryRewriteStrict(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Metadata, out var metadata) |
+            TryRewrite(expression.Secure, out var secure) |
+            TryRewrite(expression.MinLength, out var minLength) |
+            TryRewrite(expression.MaxLength, out var maxLength) |
+            TryRewrite(expression.MinValue, out var minValue) |
+            TryRewrite(expression.MaxValue, out var maxValue) |
+            TryRewrite(expression.Sealed, out var @sealed) |
+            TryRewrite(expression.Exported, out var exported);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges
+            ? expression with
+            {
+                Value = value,
+                Description = description,
+                Metadata = metadata,
+                Secure = secure,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Sealed = @sealed,
+                Exported = exported,
+            }
+            : expression;
     }
 
     void IExpressionVisitor.VisitAmbientTypeReferenceExpression(AmbientTypeReferenceExpression expression) => ReplaceCurrent(expression, ReplaceAmbientTypeReferenceExpression);
@@ -405,18 +486,60 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     public virtual Expression ReplaceObjectTypePropertyExpression(ObjectTypePropertyExpression expression)
     {
         var hasChanges =
-            TryRewriteStrict(expression.Value, out var value);
+            TryRewriteStrict(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Metadata, out var metadata) |
+            TryRewrite(expression.Secure, out var secure) |
+            TryRewrite(expression.MinLength, out var minLength) |
+            TryRewrite(expression.MaxLength, out var maxLength) |
+            TryRewrite(expression.MinValue, out var minValue) |
+            TryRewrite(expression.MaxValue, out var maxValue) |
+            TryRewrite(expression.Sealed, out var @sealed);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges
+            ? expression with
+            {
+                Value = value,
+                Description = description,
+                Metadata = metadata,
+                Secure = secure,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Sealed = @sealed,
+            }
+            : expression;
     }
 
     void IExpressionVisitor.VisitObjectTypeAdditionalPropertiesExpression(ObjectTypeAdditionalPropertiesExpression expression) => ReplaceCurrent(expression, ReplaceObjectTypeAdditionalPropertiesExpression);
     public virtual Expression ReplaceObjectTypeAdditionalPropertiesExpression(ObjectTypeAdditionalPropertiesExpression expression)
     {
         var hasChanges =
-            TryRewriteStrict(expression.Value, out var value);
+            TryRewriteStrict(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Metadata, out var metadata) |
+            TryRewrite(expression.Secure, out var secure) |
+            TryRewrite(expression.MinLength, out var minLength) |
+            TryRewrite(expression.MaxLength, out var maxLength) |
+            TryRewrite(expression.MinValue, out var minValue) |
+            TryRewrite(expression.MaxValue, out var maxValue) |
+            TryRewrite(expression.Sealed, out var @sealed);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges
+            ? expression with
+            {
+                Value = value,
+                Description = description,
+                Metadata = metadata,
+                Secure = secure,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Sealed = @sealed,
+            }
+            : expression;
     }
 
     void IExpressionVisitor.VisitObjectTypeExpression(ObjectTypeExpression expression) => ReplaceCurrent(expression, ReplaceObjectTypeExpression);
@@ -435,9 +558,30 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     public virtual Expression ReplaceTupleTypeItemExpression(TupleTypeItemExpression expression)
     {
         var hasChanges =
-            TryRewriteStrict(expression.Value, out var value);
+            TryRewriteStrict(expression.Value, out var value) |
+            TryRewrite(expression.Description, out var description) |
+            TryRewrite(expression.Metadata, out var metadata) |
+            TryRewrite(expression.Secure, out var secure) |
+            TryRewrite(expression.MinLength, out var minLength) |
+            TryRewrite(expression.MaxLength, out var maxLength) |
+            TryRewrite(expression.MinValue, out var minValue) |
+            TryRewrite(expression.MaxValue, out var maxValue) |
+            TryRewrite(expression.Sealed, out var @sealed);
 
-        return hasChanges ? expression with { Value = value } : expression;
+        return hasChanges
+            ? expression with
+            {
+                Value = value,
+                Description = description,
+                Metadata = metadata,
+                Secure = secure,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Sealed = @sealed,
+            }
+            : expression;
     }
 
     void IExpressionVisitor.VisitTupleTypeExpression(TupleTypeExpression expression) => ReplaceCurrent(expression, ReplaceTupleTypeExpression);
@@ -590,19 +734,38 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         where TExpression : Expression
     {
         var hasChanges = false;
-        var newExpressionList = new List<TExpression>();
+        var newExpressionList = ImmutableArray.CreateBuilder<TExpression>(expressions.Length);
         foreach (var expression in expressions)
         {
             hasChanges |= TryRewriteStrict(expression, out var newExpression);
             newExpressionList.Add(newExpression);
         }
 
-        newExpressions = hasChanges ? newExpressionList.ToImmutableArray() : expressions;
+        newExpressions = hasChanges ? newExpressionList.ToImmutable() : expressions;
         return hasChanges;
     }
 
     private bool TryRewrite(ImmutableArray<Expression> expressions, out ImmutableArray<Expression> newExpressions)
         => TryRewriteStrict(expressions, out newExpressions);
+
+    private bool TryRewriteCollectionOfNullablesStrict<TExpression>(ImmutableArray<TExpression?> expressions, out ImmutableArray<TExpression?> newExpressions)
+        where TExpression : Expression
+    {
+        var hasChanges = false;
+        var newExpressionList = ImmutableArray.CreateBuilder<TExpression?>(expressions.Length);
+        foreach (var expression in expressions)
+        {
+            var modified = expression;
+            if (expression is not null)
+            {
+                hasChanges |= TryRewriteStrict(expression, out modified);
+            }
+            newExpressionList.Add(modified);
+        }
+
+        newExpressions = hasChanges ? newExpressionList.ToImmutable() : expressions;
+        return hasChanges;
+    }
 
     private void ReplaceCurrent<TExpression>(TExpression expression, Func<TExpression, Expression> replaceFunc)
         where TExpression : Expression

--- a/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
@@ -243,7 +243,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description);
+            TryRewriteDescription(expression, out var description);
 
         return hasChanges ? expression with { Value = value, Description = description } : expression;
     }
@@ -253,7 +253,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Config, out var config) |
-            TryRewrite(expression.Description, out var description);
+            TryRewriteDescription(expression, out var description);
 
         return hasChanges ? expression with { Config = config, Description = description } : expression;
     }
@@ -264,14 +264,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         var hasChanges =
             TryRewrite(expression.DefaultValue, out var defaultValue) |
             TryRewriteStrict(expression.Type, out var type) |
-            TryRewrite(expression.Description, out var description) |
-            TryRewrite(expression.Metadata, out var metadata) |
-            TryRewrite(expression.Secure, out var secure) |
-            TryRewrite(expression.MinLength, out var minLength) |
-            TryRewrite(expression.MaxLength, out var maxLength) |
-            TryRewrite(expression.MinValue, out var minValue) |
-            TryRewrite(expression.MaxValue, out var maxValue) |
-            TryRewrite(expression.Sealed, out var @sealed) |
+            TryRewriteTypeDecorators(expression, out var description, out var metadata, out var secure, out var minLength, out var maxLength, out var minValue, out var maxValue, out var @sealed) |
             TryRewrite(expression.AllowedValues, out var allowedValues);
 
         return hasChanges
@@ -297,7 +290,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description) |
+            TryRewriteDescription(expression, out var description) |
             TryRewrite(expression.Exported, out var exported);
 
         return hasChanges ? expression with { Value = value, Description = description, Exported = exported } : expression;
@@ -308,7 +301,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Lambda, out var lambda) |
-            TryRewrite(expression.Description, out var description);
+            TryRewriteDescription(expression, out var description);
 
         return hasChanges ? expression with { Lambda = lambda, Description = description } : expression;
     }
@@ -328,14 +321,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         var hasChanges =
             TryRewrite(expression.Value, out var value) |
             TryRewriteStrict(expression.Type, out var type) |
-            TryRewrite(expression.Description, out var description) |
-            TryRewrite(expression.Metadata, out var metadata) |
-            TryRewrite(expression.Secure, out var secure) |
-            TryRewrite(expression.MinLength, out var minLength) |
-            TryRewrite(expression.MaxLength, out var maxLength) |
-            TryRewrite(expression.MinValue, out var minValue) |
-            TryRewrite(expression.MaxValue, out var maxValue) |
-            TryRewrite(expression.Sealed, out var @sealed);
+            TryRewriteTypeDecorators(expression, out var description, out var metadata, out var secure, out var minLength, out var maxLength, out var minValue, out var maxValue, out var @sealed);
 
         return hasChanges
             ? expression with
@@ -359,7 +345,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description);
+            TryRewriteDescription(expression, out var description);
 
         return hasChanges ? expression with { Value = value, Description = description } : expression;
     }
@@ -370,7 +356,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         var hasChanges =
             TryRewrite(expression.Body, out var body) |
             TryRewriteStrict(expression.DependsOn, out var dependsOn) |
-            TryRewrite(expression.Description, out var description);
+            TryRewriteDescription(expression, out var description);
 
         return hasChanges ? expression with { Body = body, DependsOn = dependsOn, Description = description } : expression;
     }
@@ -382,7 +368,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
             TryRewrite(expression.Body, out var body) |
             TryRewrite(expression.Parameters, out var parameters) |
             TryRewriteStrict(expression.DependsOn, out var dependsOn) |
-            TryRewrite(expression.Description, out var description);
+            TryRewriteDescription(expression, out var description);
 
         return hasChanges ? expression with { Body = body, Parameters = parameters, DependsOn = dependsOn, Description = description } : expression;
     }
@@ -401,14 +387,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewriteStrict(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description) |
-            TryRewrite(expression.Metadata, out var metadata) |
-            TryRewrite(expression.Secure, out var secure) |
-            TryRewrite(expression.MinLength, out var minLength) |
-            TryRewrite(expression.MaxLength, out var maxLength) |
-            TryRewrite(expression.MinValue, out var minValue) |
-            TryRewrite(expression.MaxValue, out var maxValue) |
-            TryRewrite(expression.Sealed, out var @sealed) |
+            TryRewriteTypeDecorators(expression, out var description, out var metadata, out var secure, out var minLength, out var maxLength, out var minValue, out var maxValue, out var @sealed) |
             TryRewrite(expression.Exported, out var exported);
 
         return hasChanges
@@ -487,14 +466,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewriteStrict(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description) |
-            TryRewrite(expression.Metadata, out var metadata) |
-            TryRewrite(expression.Secure, out var secure) |
-            TryRewrite(expression.MinLength, out var minLength) |
-            TryRewrite(expression.MaxLength, out var maxLength) |
-            TryRewrite(expression.MinValue, out var minValue) |
-            TryRewrite(expression.MaxValue, out var maxValue) |
-            TryRewrite(expression.Sealed, out var @sealed);
+            TryRewriteTypeDecorators(expression, out var description, out var metadata, out var secure, out var minLength, out var maxLength, out var minValue, out var maxValue, out var @sealed);
 
         return hasChanges
             ? expression with
@@ -517,14 +489,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewriteStrict(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description) |
-            TryRewrite(expression.Metadata, out var metadata) |
-            TryRewrite(expression.Secure, out var secure) |
-            TryRewrite(expression.MinLength, out var minLength) |
-            TryRewrite(expression.MaxLength, out var maxLength) |
-            TryRewrite(expression.MinValue, out var minValue) |
-            TryRewrite(expression.MaxValue, out var maxValue) |
-            TryRewrite(expression.Sealed, out var @sealed);
+            TryRewriteTypeDecorators(expression, out var description, out var metadata, out var secure, out var minLength, out var maxLength, out var minValue, out var maxValue, out var @sealed);
 
         return hasChanges
             ? expression with
@@ -559,14 +524,7 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewriteStrict(expression.Value, out var value) |
-            TryRewrite(expression.Description, out var description) |
-            TryRewrite(expression.Metadata, out var metadata) |
-            TryRewrite(expression.Secure, out var secure) |
-            TryRewrite(expression.MinLength, out var minLength) |
-            TryRewrite(expression.MaxLength, out var maxLength) |
-            TryRewrite(expression.MinValue, out var minValue) |
-            TryRewrite(expression.MaxValue, out var maxValue) |
-            TryRewrite(expression.Sealed, out var @sealed);
+            TryRewriteTypeDecorators(expression, out var description, out var metadata, out var secure, out var minLength, out var maxLength, out var minValue, out var maxValue, out var @sealed);
 
         return hasChanges
             ? expression with
@@ -705,6 +663,27 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     }
 
     private Expression? current;
+
+    private bool TryRewriteDescription(DescribableExpression expression, out Expression? description)
+        => TryRewrite(expression.Description, out description);
+
+    private bool TryRewriteTypeDecorators(TypeDeclaringExpression expression,
+        out Expression? description,
+        out Expression? metadata,
+        out Expression? secure,
+        out Expression? minLength,
+        out Expression? maxLength,
+        out Expression? minValue,
+        out Expression? maxValue,
+        out Expression? @sealed) =>
+            TryRewriteDescription(expression, out description) |
+            TryRewrite(expression.Metadata, out metadata) |
+            TryRewrite(expression.Secure, out secure) |
+            TryRewrite(expression.MinLength, out minLength) |
+            TryRewrite(expression.MaxLength, out maxLength) |
+            TryRewrite(expression.MinValue, out minValue) |
+            TryRewrite(expression.MaxValue, out maxValue) |
+            TryRewrite(expression.Sealed, out @sealed);
 
     private bool TryRewriteStrict<TExpression>(TExpression? expression, [NotNullIfNotNull("expression")] out TExpression? newExpression)
         where TExpression : Expression

--- a/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
@@ -192,6 +192,7 @@ public abstract class ExpressionVisitor : IExpressionVisitor
 
     public virtual void VisitDeclaredOutputExpression(DeclaredOutputExpression expression)
     {
+        VisitTypeDeclaringExpression(expression);
         Visit(expression.Type);
         Visit(expression.Value);
     }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -1160,6 +1160,10 @@ param foo|bar = true
                         tooltip.Should().Contain($"{@namespace.Name} namespace");
                         break;
 
+                    case WildcardImportSymbol wildcardImport:
+                        tooltip.Should().Contain($"{wildcardImport.Name} namespace");
+                        break;
+
                     default:
                         throw new AssertFailedException($"Unexpected symbol type '{symbol.GetType().Name}'");
                 }


### PR DESCRIPTION
Resolves #12052 

A recent PR (#12048) updated TemplateWriter to preprocess a template's references to imported symbols. This new step uses an `ExpressionRewriteVisitor`, which had not been kept up to date when new properties were added various kinds of IR expressions.

The PR also adds a few more lines to the `Imports_LF` baseline scenario to exercise additional behavior. The scenario had originally been written to validate the mechanics of importing types and variables but didn't cover the mechanics of *using* imported symbols in a template.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12055)