### PR TITLE
Write "{}" for config (breaking change, 11482)

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/MockRegistryAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/MockRegistryAssertions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Json;
 using Bicep.Core.Registry.Oci;
 using Bicep.Core.UnitTests.Registry;
 using Bicep.Core.UnitTests.Utils;
@@ -72,10 +73,10 @@ namespace Bicep.Core.UnitTests.Assertions
                 {
                     var configBytes = this.Subject.Blobs[config.Digest];
                     config.Size.Should().Be(configBytes.ToArray().Length, "Config size field should match config size");
-                    JsonDocument? configJson = null;
-                    var convertToJson = () => configJson = JsonDocument.Parse(configBytes.Text);
+                    JsonElement? configJson = null;
+                    var convertToJson = () => configJson = JsonElementFactory.CreateElement(configBytes.Text);
                     convertToJson.Should().NotThrow("Config should be a valid JSON object");
-                    configJson!.RootElement.ValueKind.Should().Be(JsonValueKind.Object, "Config should be a JSON object");
+                    configJson!.Value.ValueKind.Should().Be(JsonValueKind.Object, "Config should be a JSON object");
                 }
 
                 manifest.Layers.Should().HaveCountLessThanOrEqualTo(2, "modules should have one or two layers");

--- a/src/Bicep.Core/Json/JsonElementFactory.cs
+++ b/src/Bicep.Core/Json/JsonElementFactory.cs
@@ -26,7 +26,7 @@ namespace Bicep.Core.Json
         {
             using var document = JsonDocument.Parse(utf8Json, options ?? DefaultJsonDocumentOptions);
 
-            // JsonDocument is IDisposable, so we need to clone RootElement.
+            // JsonDocument is disposed when leaving scope, so we need to clone RootElement.
             // See: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0#jsondocument-is-idisposable.
             return document.RootElement.Clone();
         }

--- a/src/Bicep.Core/Registry/OciModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/OciModuleRegistry.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Containers.ContainerRegistry;
@@ -298,9 +299,9 @@ namespace Bicep.Core.Registry
 
         public override async Task PublishArtifact(OciModuleReference moduleReference, Stream compiledArmTemplate, Stream? bicepSources, string? documentationUri, string? description)
         {
-            // Write out an empty config for now
-            // NOTE: Bicep v0.20 and earlier will throw if it finds a non-empty config
-            var config = new StreamDescriptor(Stream.Null, BicepMediaTypes.BicepModuleConfigV1);
+            // This needs to be valid JSON, otherwise there may be compatibility issues.
+            // NOTE: Bicep v0.20 and earlier will throw on this, so it's a breaking change.
+            var config = new StreamDescriptor(new MemoryStream(Encoding.UTF8.GetBytes("{}")), BicepMediaTypes.BicepModuleConfigV1);
 
             List<StreamDescriptor> layers = new List<StreamDescriptor>();
             layers.Add(new StreamDescriptor(compiledArmTemplate, BicepMediaTypes.BicepModuleLayerV1Json));


### PR DESCRIPTION
Fixes https://github.com/Azure/bicep/issues/11482

This is a breaking change that keeps v0.20 or earlier from restoring modules published with versions with this change.

The original breaking change notification doesn't seem to have made it into the release notes, but we can put this into the new version:

> This is a breaking change in how modules are published.  This change will affect v0.20 and earlier, keeping them from being able to restore modules created in v0.23 or later.
> v0.20 or earlier: Can read modules published with v0.22 or earlier. Will get an error trying to restore a module published with v0.23 or later.
> v0.21, v0.22: Can read modules published earlier or later. Modules published with v0.21 can be read by earlier and later versions.
> v0.23: Can read modules published earlier or later. Modules published with v0.23 can be read by v0.21 and later.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12057)