### PR TITLE
Remove inaccurate channel output during deploy

### DIFF
--- a/src/vscode-bicep/src/commands/deploy.ts
+++ b/src/vscode-bicep/src/commands/deploy.ts
@@ -538,9 +538,6 @@ export class DeployCommand implements Command {
     showErrorMessage: boolean,
   ): Promise<boolean> {
     if (path.endsWith(".bicepparam")) {
-      this.outputChannelManager.appendToOutputChannel(
-        `Bicep Parameter file used in deployment -> ${path}`,
-      );
       return true;
     }
 
@@ -575,9 +572,6 @@ export class DeployCommand implements Command {
       return false;
     }
 
-    this.outputChannelManager.appendToOutputChannel(
-      `JSON Parameter file used in deployment -> ${path}`,
-    );
     return true;
   }
 


### PR DESCRIPTION
During deployment preparation, the name of all params and bicepparams files that are found are displayed in the output channel:

<img width="1309" alt="image" src="https://github.com/Azure/bicep/assets/6913354/64e6c1bb-b619-445e-8477-e3a7477e28e3">

This used to display only the one actually selected by the user, but that is handled elsewhere, so just removing this.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12058)