### PR TITLE
Match incoming formatting automation PRs by title and body rather than by label

### DIFF
--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -27,22 +27,25 @@ configuration:
             base: main
             title: "Reformat code"
             body: "Update code to match the house style 😎"
-            labels: 'code-formatting-automation'
         - closeIssue
     - description: Approve PRs submitted by microsoft-github-policy-service with the "code-formatting-automation" label
       triggerOnOwnActions: True
       if:
       - payloadType: Pull_Request
-      - hasLabel:
-          label: 'code-formatting-automation'
-      - not:
-          hasLabel:
-            label: auto-merge
       - isActivitySender:
           user: microsoft-github-policy-service[bot]
+      - isAction: Opened
+      - titleContains:
+          pattern: "Reformat code"
+          isRegex: False
+      - bodyContains:
+          pattern: "Update code to match the house style 😎"
+          isRegex: False
       then:
       - approvePullRequest:
           comment: ':shipit:'
+      - addLabel:
+          label: 'code-formatting-automation'
       - addLabel:
           label: auto-merge
       - enableAutoMerge:

--- a/.github/policies/prAutoApproval.formatter.yml
+++ b/.github/policies/prAutoApproval.formatter.yml
@@ -27,6 +27,7 @@ configuration:
             base: main
             title: "Reformat code"
             body: "Update code to match the house style 😎"
+            labels: 'code-formatting-automation'
         - closeIssue
     - description: Approve PRs submitted by microsoft-github-policy-service with the "code-formatting-automation" label
       triggerOnOwnActions: True


### PR DESCRIPTION
GH policy does not at present provide a way to attach a label to a PR that it creates.