### PR TITLE
Update CyclicCheckVisitor to prohibit self references within an access expression in type syntax

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -801,6 +801,21 @@ param myParam string
         result.Should().NotHaveAnyDiagnostics();
     }
 
+    [TestMethod]
+    public void Self_reference_permitted_in_object_type_additional_properties()
+    {
+        var result = CompilationHelper.Compile("""
+            type anObject = {
+                id: int
+                flag: bool
+                someData: string
+                *: anObject
+            }
+            """);
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
+
     // https://github.com/azure/bicep/issues/12070
     [TestMethod]
     public void Self_property_deref_does_not_blow_the_stack()

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.bicep
@@ -200,12 +200,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
   *: string
 }
 
-type discriminatorInlineAdditionalPropsCycle1 = {
-  type: 'b'
-  @discriminator('type')
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-}
-
 @discriminator('type')
 type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string } | { type: 'A', value: int }
 

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
@@ -275,14 +275,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
   *: string
 }
 
-type discriminatorInlineAdditionalPropsCycle1 = {
-//@[05:045) [BCP298 (Error)] This type definition includes itself as required component, which creates a constraint that cannot be fulfilled. (CodeDescription: none) |discriminatorInlineAdditionalPropsCycle1|
-  type: 'b'
-  @discriminator('type')
-//@[02:024) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-}
-
 @discriminator('type')
 type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string } | { type: 'A', value: int }
 //@[83:108) [BCP365 (Error)] The value "'A'" for discriminator property "type" is duplicated across multiple union member types. The value must be unique across all union member types. (CodeDescription: none) |{ type: 'A', value: int }|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.formatted.bicep
@@ -200,12 +200,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
   *: string
 }
 
-type discriminatorInlineAdditionalPropsCycle1 = {
-  type: 'b'
-  @discriminator('type')
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-}
-
 @discriminator('type')
 type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string } | { type: 'A', value: int }
 

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.pprint.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.pprint.bicep
@@ -200,12 +200,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
   *: string
 }
 
-type discriminatorInlineAdditionalPropsCycle1 = {
-  type: 'b'
-  @discriminator('type')
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-}
-
 @discriminator('type')
 type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string } | {
   type: 'A'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.symbols.bicep
@@ -263,13 +263,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
   *: string
 }
 
-type discriminatorInlineAdditionalPropsCycle1 = {
-//@[5:45) TypeAlias discriminatorInlineAdditionalPropsCycle1. Type: error. Declaration start char: 0, length: 142
-  type: 'b'
-  @discriminator('type')
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-}
-
 @discriminator('type')
 type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string } | { type: 'A', value: int }
 //@[5:49) TypeAlias discriminatedUnionDuplicateMemberInsensitive. Type: error. Declaration start char: 0, length: 131

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 type 44
-//@[000:4686) ProgramSyntax
+//@[000:4542) ProgramSyntax
 //@[000:0007) ├─TypeDeclarationSyntax
 //@[000:0004) | ├─Token(Identifier) |type|
 //@[005:0007) | ├─IdentifierSyntax
@@ -1600,54 +1600,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
 //@[005:0011) |   |   └─IdentifierSyntax
 //@[005:0011) |   |     └─Token(Identifier) |string|
 //@[011:0012) |   ├─Token(NewLine) |\n|
-}
-//@[000:0001) |   └─Token(RightBrace) |}|
-//@[001:0003) ├─Token(NewLine) |\n\n|
-
-type discriminatorInlineAdditionalPropsCycle1 = {
-//@[000:0142) ├─TypeDeclarationSyntax
-//@[000:0004) | ├─Token(Identifier) |type|
-//@[005:0045) | ├─IdentifierSyntax
-//@[005:0045) | | └─Token(Identifier) |discriminatorInlineAdditionalPropsCycle1|
-//@[046:0047) | ├─Token(Assignment) |=|
-//@[048:0142) | └─ObjectTypeSyntax
-//@[048:0049) |   ├─Token(LeftBrace) |{|
-//@[049:0050) |   ├─Token(NewLine) |\n|
-  type: 'b'
-//@[002:0011) |   ├─ObjectTypePropertySyntax
-//@[002:0006) |   | ├─IdentifierSyntax
-//@[002:0006) |   | | └─Token(Identifier) |type|
-//@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
-//@[008:0011) |   |   └─Token(StringComplete) |'b'|
-//@[011:0012) |   ├─Token(NewLine) |\n|
-  @discriminator('type')
-//@[002:0078) |   ├─ObjectTypeAdditionalPropertiesSyntax
-//@[002:0024) |   | ├─DecoratorSyntax
-//@[002:0003) |   | | ├─Token(At) |@|
-//@[003:0024) |   | | └─FunctionCallSyntax
-//@[003:0016) |   | |   ├─IdentifierSyntax
-//@[003:0016) |   | |   | └─Token(Identifier) |discriminator|
-//@[016:0017) |   | |   ├─Token(LeftParen) |(|
-//@[017:0023) |   | |   ├─FunctionArgumentSyntax
-//@[017:0023) |   | |   | └─StringSyntax
-//@[017:0023) |   | |   |   └─Token(StringComplete) |'type'|
-//@[023:0024) |   | |   └─Token(RightParen) |)|
-//@[024:0025) |   | ├─Token(NewLine) |\n|
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-//@[002:0003) |   | ├─Token(Asterisk) |*|
-//@[003:0004) |   | ├─Token(Colon) |:|
-//@[005:0053) |   | └─UnionTypeSyntax
-//@[005:0010) |   |   ├─UnionTypeMemberSyntax
-//@[005:0010) |   |   | └─VariableAccessSyntax
-//@[005:0010) |   |   |   └─IdentifierSyntax
-//@[005:0010) |   |   |     └─Token(Identifier) |typeA|
-//@[011:0012) |   |   ├─Token(Pipe) |||
-//@[013:0053) |   |   └─UnionTypeMemberSyntax
-//@[013:0053) |   |     └─VariableAccessSyntax
-//@[013:0053) |   |       └─IdentifierSyntax
-//@[013:0053) |   |         └─Token(Identifier) |discriminatorInlineAdditionalPropsCycle1|
-//@[053:0054) |   ├─Token(NewLine) |\n|
 }
 //@[000:0001) |   └─Token(RightBrace) |}|
 //@[001:0003) ├─Token(NewLine) |\n\n|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.tokens.bicep
@@ -943,35 +943,6 @@ type discriminatorInlineAdditionalPropsBadType3 = {
 //@[000:001) RightBrace |}|
 //@[001:003) NewLine |\n\n|
 
-type discriminatorInlineAdditionalPropsCycle1 = {
-//@[000:004) Identifier |type|
-//@[005:045) Identifier |discriminatorInlineAdditionalPropsCycle1|
-//@[046:047) Assignment |=|
-//@[048:049) LeftBrace |{|
-//@[049:050) NewLine |\n|
-  type: 'b'
-//@[002:006) Identifier |type|
-//@[006:007) Colon |:|
-//@[008:011) StringComplete |'b'|
-//@[011:012) NewLine |\n|
-  @discriminator('type')
-//@[002:003) At |@|
-//@[003:016) Identifier |discriminator|
-//@[016:017) LeftParen |(|
-//@[017:023) StringComplete |'type'|
-//@[023:024) RightParen |)|
-//@[024:025) NewLine |\n|
-  *: typeA | discriminatorInlineAdditionalPropsCycle1
-//@[002:003) Asterisk |*|
-//@[003:004) Colon |:|
-//@[005:010) Identifier |typeA|
-//@[011:012) Pipe |||
-//@[013:053) Identifier |discriminatorInlineAdditionalPropsCycle1|
-//@[053:054) NewLine |\n|
-}
-//@[000:001) RightBrace |}|
-//@[001:003) NewLine |\n\n|
-
 @discriminator('type')
 //@[000:001) At |@|
 //@[001:014) Identifier |discriminator|

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.bicep
@@ -194,6 +194,12 @@ type discriminatedUnionMemberOptionalCycle1 = {
   prop: (typeA | discriminatedUnionMemberOptionalCycle1)?
 }
 
+type discriminatedUnionMemberOptionalCycle2 = {
+  type: 'b'
+  @discriminator('type')
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+}
+
 type discriminatedUnionTuple1 = [
   discriminatedUnion1
   string

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.diagnostics.bicep
@@ -198,6 +198,12 @@ type discriminatedUnionMemberOptionalCycle1 = {
   prop: (typeA | discriminatedUnionMemberOptionalCycle1)?
 }
 
+type discriminatedUnionMemberOptionalCycle2 = {
+  type: 'b'
+  @discriminator('type')
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+}
+
 type discriminatedUnionTuple1 = [
   discriminatedUnion1
   string

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.formatted.bicep
@@ -194,6 +194,12 @@ type discriminatedUnionMemberOptionalCycle1 = {
   prop: (typeA | discriminatedUnionMemberOptionalCycle1)?
 }
 
+type discriminatedUnionMemberOptionalCycle2 = {
+  type: 'b'
+  @discriminator('type')
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+}
+
 type discriminatedUnionTuple1 = [
   discriminatedUnion1
   string

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 @description('The foo type')
-//@[000:4814) ProgramExpression
+//@[000:4954) ProgramExpression
 //@[000:0299) ├─DeclaredTypeExpression { Name = foo }
 //@[013:0027) | ├─StringLiteralExpression { Value = The foo type }
 @sealed()
@@ -555,6 +555,20 @@ type discriminatedUnionMemberOptionalCycle1 = {
 //@[009:0055) |       └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', prop: (typeA | discriminatedUnionMemberOptionalCycle1)? } }
 //@[009:0014) |         ├─TypeAliasReferenceExpression { Name = typeA }
 //@[017:0055) |         └─TypeAliasReferenceExpression { Name = discriminatedUnionMemberOptionalCycle1 }
+}
+
+type discriminatedUnionMemberOptionalCycle2 = {
+//@[000:0138) ├─DeclaredTypeExpression { Name = discriminatedUnionMemberOptionalCycle2 }
+//@[046:0138) | └─ObjectTypeExpression { Name = { type: 'b', *: typeA | discriminatedUnionMemberOptionalCycle1 } }
+  type: 'b'
+//@[002:0011) |   ├─ObjectTypePropertyExpression
+//@[008:0011) |   | └─StringLiteralTypeExpression { Name = 'b' }
+  @discriminator('type')
+//@[002:0076) |   └─ObjectTypeAdditionalPropertiesExpression
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+//@[005:0051) |     └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', prop: (typeA | discriminatedUnionMemberOptionalCycle1)? } }
+//@[005:0010) |       ├─TypeAliasReferenceExpression { Name = typeA }
+//@[013:0051) |       └─TypeAliasReferenceExpression { Name = discriminatedUnionMemberOptionalCycle1 }
 }
 
 type discriminatedUnionTuple1 = [

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10222832372327950937"
+      "templateHash": "10900403552106448310"
     }
   },
   "definitions": {
@@ -757,6 +757,31 @@
             }
           },
           "nullable": true
+        }
+      }
+    },
+    "discriminatedUnionMemberOptionalCycle2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "allowedValues": [
+            "b"
+          ]
+        }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "a": {
+              "$ref": "#/definitions/typeA"
+            },
+            "b": {
+              "$ref": "#/definitions/discriminatedUnionMemberOptionalCycle1"
+            }
+          }
         }
       }
     },

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.pprint.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.pprint.bicep
@@ -205,6 +205,12 @@ type discriminatedUnionMemberOptionalCycle1 = {
   prop: (typeA | discriminatedUnionMemberOptionalCycle1)?
 }
 
+type discriminatedUnionMemberOptionalCycle2 = {
+  type: 'b'
+  @discriminator('type')
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+}
+
 type discriminatedUnionTuple1 = [discriminatedUnion1, string]
 
 type discriminatedUnionInlineTuple1 = [

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
@@ -1012,6 +1012,37 @@ type discriminatedUnionMemberOptionalCycle1 = {
 //@        }
 }
 
+type discriminatedUnionMemberOptionalCycle2 = {
+//@    "discriminatedUnionMemberOptionalCycle2": {
+//@      "type": "object",
+//@      "properties": {
+//@      },
+//@    },
+  type: 'b'
+//@        "type": {
+//@          "type": "string",
+//@          "allowedValues": [
+//@            "b"
+//@          ]
+//@        }
+  @discriminator('type')
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+//@      "additionalProperties": {
+//@        "type": "object",
+//@        "discriminator": {
+//@          "propertyName": "type",
+//@          "mapping": {
+//@            "a": {
+//@              "$ref": "#/definitions/typeA"
+//@            },
+//@            "b": {
+//@              "$ref": "#/definitions/discriminatedUnionMemberOptionalCycle1"
+//@            }
+//@          }
+//@        }
+//@      }
+}
+
 type discriminatedUnionTuple1 = [
 //@    "discriminatedUnionTuple1": {
 //@      "type": "array",

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10222832372327950937"
+      "templateHash": "10900403552106448310"
     }
   },
   "definitions": {
@@ -757,6 +757,31 @@
             }
           },
           "nullable": true
+        }
+      }
+    },
+    "discriminatedUnionMemberOptionalCycle2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "allowedValues": [
+            "b"
+          ]
+        }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "a": {
+              "$ref": "#/definitions/typeA"
+            },
+            "b": {
+              "$ref": "#/definitions/discriminatedUnionMemberOptionalCycle1"
+            }
+          }
         }
       }
     },

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbols.bicep
@@ -238,6 +238,13 @@ type discriminatedUnionMemberOptionalCycle1 = {
   prop: (typeA | discriminatedUnionMemberOptionalCycle1)?
 }
 
+type discriminatedUnionMemberOptionalCycle2 = {
+//@[5:43) TypeAlias discriminatedUnionMemberOptionalCycle2. Type: Type<{ type: 'b', *: typeA | discriminatedUnionMemberOptionalCycle1 }>. Declaration start char: 0, length: 138
+  type: 'b'
+  @discriminator('type')
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+}
+
 type discriminatedUnionTuple1 = [
 //@[5:29) TypeAlias discriminatedUnionTuple1. Type: Type<[discriminatedUnion1, string]>. Declaration start char: 0, length: 66
   discriminatedUnion1

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 @description('The foo type')
-//@[000:4814) ProgramSyntax
+//@[000:4954) ProgramSyntax
 //@[000:0299) ├─TypeDeclarationSyntax
 //@[000:0028) | ├─DecoratorSyntax
 //@[000:0001) | | ├─Token(At) |@|
@@ -1847,6 +1847,54 @@ type discriminatedUnionMemberOptionalCycle1 = {
 //@[055:0056) |   |   | └─Token(RightParen) |)|
 //@[056:0057) |   |   └─Token(Question) |?|
 //@[057:0058) |   ├─Token(NewLine) |\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0003) ├─Token(NewLine) |\n\n|
+
+type discriminatedUnionMemberOptionalCycle2 = {
+//@[000:0138) ├─TypeDeclarationSyntax
+//@[000:0004) | ├─Token(Identifier) |type|
+//@[005:0043) | ├─IdentifierSyntax
+//@[005:0043) | | └─Token(Identifier) |discriminatedUnionMemberOptionalCycle2|
+//@[044:0045) | ├─Token(Assignment) |=|
+//@[046:0138) | └─ObjectTypeSyntax
+//@[046:0047) |   ├─Token(LeftBrace) |{|
+//@[047:0048) |   ├─Token(NewLine) |\n|
+  type: 'b'
+//@[002:0011) |   ├─ObjectTypePropertySyntax
+//@[002:0006) |   | ├─IdentifierSyntax
+//@[002:0006) |   | | └─Token(Identifier) |type|
+//@[006:0007) |   | ├─Token(Colon) |:|
+//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   |   └─Token(StringComplete) |'b'|
+//@[011:0012) |   ├─Token(NewLine) |\n|
+  @discriminator('type')
+//@[002:0076) |   ├─ObjectTypeAdditionalPropertiesSyntax
+//@[002:0024) |   | ├─DecoratorSyntax
+//@[002:0003) |   | | ├─Token(At) |@|
+//@[003:0024) |   | | └─FunctionCallSyntax
+//@[003:0016) |   | |   ├─IdentifierSyntax
+//@[003:0016) |   | |   | └─Token(Identifier) |discriminator|
+//@[016:0017) |   | |   ├─Token(LeftParen) |(|
+//@[017:0023) |   | |   ├─FunctionArgumentSyntax
+//@[017:0023) |   | |   | └─StringSyntax
+//@[017:0023) |   | |   |   └─Token(StringComplete) |'type'|
+//@[023:0024) |   | |   └─Token(RightParen) |)|
+//@[024:0025) |   | ├─Token(NewLine) |\n|
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+//@[002:0003) |   | ├─Token(Asterisk) |*|
+//@[003:0004) |   | ├─Token(Colon) |:|
+//@[005:0051) |   | └─UnionTypeSyntax
+//@[005:0010) |   |   ├─UnionTypeMemberSyntax
+//@[005:0010) |   |   | └─VariableAccessSyntax
+//@[005:0010) |   |   |   └─IdentifierSyntax
+//@[005:0010) |   |   |     └─Token(Identifier) |typeA|
+//@[011:0012) |   |   ├─Token(Pipe) |||
+//@[013:0051) |   |   └─UnionTypeMemberSyntax
+//@[013:0051) |   |     └─VariableAccessSyntax
+//@[013:0051) |   |       └─IdentifierSyntax
+//@[013:0051) |   |         └─Token(Identifier) |discriminatedUnionMemberOptionalCycle1|
+//@[051:0052) |   ├─Token(NewLine) |\n|
 }
 //@[000:0001) |   └─Token(RightBrace) |}|
 //@[001:0003) ├─Token(NewLine) |\n\n|

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.tokens.bicep
@@ -1084,6 +1084,35 @@ type discriminatedUnionMemberOptionalCycle1 = {
 //@[000:001) RightBrace |}|
 //@[001:003) NewLine |\n\n|
 
+type discriminatedUnionMemberOptionalCycle2 = {
+//@[000:004) Identifier |type|
+//@[005:043) Identifier |discriminatedUnionMemberOptionalCycle2|
+//@[044:045) Assignment |=|
+//@[046:047) LeftBrace |{|
+//@[047:048) NewLine |\n|
+  type: 'b'
+//@[002:006) Identifier |type|
+//@[006:007) Colon |:|
+//@[008:011) StringComplete |'b'|
+//@[011:012) NewLine |\n|
+  @discriminator('type')
+//@[002:003) At |@|
+//@[003:016) Identifier |discriminator|
+//@[016:017) LeftParen |(|
+//@[017:023) StringComplete |'type'|
+//@[023:024) RightParen |)|
+//@[024:025) NewLine |\n|
+  *: typeA | discriminatedUnionMemberOptionalCycle1
+//@[002:003) Asterisk |*|
+//@[003:004) Colon |:|
+//@[005:010) Identifier |typeA|
+//@[011:012) Pipe |||
+//@[013:051) Identifier |discriminatedUnionMemberOptionalCycle1|
+//@[051:052) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:003) NewLine |\n\n|
+
 type discriminatedUnionTuple1 = [
 //@[000:004) Identifier |type|
 //@[005:029) Identifier |discriminatedUnionTuple1|

--- a/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
@@ -158,6 +158,9 @@ namespace Bicep.Core.TypeSystem
         public override void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
             => WithSelfReferencePermitted(() => base.VisitObjectTypePropertySyntax(syntax), selfReferencePermitted: true);
 
+        public override void VisitObjectTypeAdditionalPropertiesSyntax(ObjectTypeAdditionalPropertiesSyntax syntax)
+            => WithSelfReferencePermitted(() => base.VisitObjectTypeAdditionalPropertiesSyntax(syntax), selfReferencePermitted: true);
+
         public override void VisitTupleTypeItemSyntax(TupleTypeItemSyntax syntax)
             => WithSelfReferencePermitted(() => base.VisitTupleTypeItemSyntax(syntax), selfReferencePermitted: true);
 

--- a/src/Bicep.Core/TypeSystem/CyclicTypeCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicTypeCheckVisitor.cs
@@ -63,28 +63,21 @@ public sealed class CyclicTypeCheckVisitor : AstVisitor
     }
 
     public override void VisitArrayTypeSyntax(ArrayTypeSyntax syntax)
-    {
-        enteredTypeContainer = true;
-        base.VisitArrayTypeSyntax(syntax);
-    }
+        => WithEnteredTypeContainerState(() => base.VisitArrayTypeSyntax(syntax), enteredTypeContainer: true);
 
     public override void VisitArrayTypeMemberSyntax(ArrayTypeMemberSyntax syntax)
-        => VisitContainedTypeSyntax(syntax, base.VisitArrayTypeMemberSyntax);
+    {
+        VisitContainedTypeSyntax(syntax, base.VisitArrayTypeMemberSyntax);
+    }
 
     public override void VisitObjectTypeSyntax(ObjectTypeSyntax syntax)
-    {
-        enteredTypeContainer = true;
-        base.VisitObjectTypeSyntax(syntax);
-    }
+        => WithEnteredTypeContainerState(() => base.VisitObjectTypeSyntax(syntax), enteredTypeContainer: true);
 
     public override void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
         => VisitContainedTypeSyntax(syntax, base.VisitObjectTypePropertySyntax);
 
     public override void VisitTupleTypeSyntax(TupleTypeSyntax syntax)
-    {
-        enteredTypeContainer = true;
-        base.VisitTupleTypeSyntax(syntax);
-    }
+        => WithEnteredTypeContainerState(() => base.VisitTupleTypeSyntax(syntax), enteredTypeContainer: true);
 
     public override void VisitTupleTypeItemSyntax(TupleTypeItemSyntax syntax)
         => VisitContainedTypeSyntax(syntax, base.VisitTupleTypeItemSyntax);
@@ -101,6 +94,14 @@ public sealed class CyclicTypeCheckVisitor : AstVisitor
 
     public override void VisitUnionTypeMemberSyntax(UnionTypeMemberSyntax syntax)
         => VisitContainedTypeSyntax(syntax, base.VisitUnionTypeMemberSyntax);
+
+    private void WithEnteredTypeContainerState(Action action, bool enteredTypeContainer)
+    {
+        var previousEnteredTypeContainerState = this.enteredTypeContainer;
+        this.enteredTypeContainer = enteredTypeContainer;
+        action();
+        this.enteredTypeContainer = previousEnteredTypeContainerState;
+    }
 
     private void VisitContainedTypeSyntax<TSyntax>(TSyntax syntax, Action<TSyntax> visitBaseFunc) where TSyntax : SyntaxBase
     {

--- a/src/Bicep.Core/TypeSystem/CyclicTypeCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicTypeCheckVisitor.cs
@@ -76,6 +76,10 @@ public sealed class CyclicTypeCheckVisitor : AstVisitor
     public override void VisitObjectTypePropertySyntax(ObjectTypePropertySyntax syntax)
         => VisitContainedTypeSyntax(syntax, base.VisitObjectTypePropertySyntax);
 
+    // An additional properties type notation always permits zero or more additional properties of the specified type, so
+    // recursion is permitted here even if the specified type is non-nullable.
+    public override void VisitObjectTypeAdditionalPropertiesSyntax(ObjectTypeAdditionalPropertiesSyntax syntax) {}
+
     public override void VisitTupleTypeSyntax(TupleTypeSyntax syntax)
         => WithEnteredTypeContainerState(() => base.VisitTupleTypeSyntax(syntax), enteredTypeContainer: true);
 


### PR DESCRIPTION
Resolves #12070 

`CyclicTypeVisitor` permits cycles within type expressions to allow for recursive type definitions. However, this can cause an unhandled stack overflow when a property or array access expression is within a "type container expression" (e.g., `ObjectTypePropertySyntax`), since access expressions will try to resolve the type of their base expression. For example:

```bicep
type UsesPermittedRecursion = {
  property: UsesPermittedRecursion? // <-- this is the kind of recursion we want to allow
}

type CausesStackOverflow = {
  property: CausesStackOverflow.property // <-- this wouldn't be a valid type, but we should show a diagnostic, not blow the stack
}
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12072)