### PR TITLE
Collapse unions of objects with an inferable discriminator into tagged unions

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedDiscriminatedObjectUnionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedDiscriminatedObjectUnionTests.cs
@@ -426,10 +426,8 @@ namespace Bicep.Core.IntegrationTests
             result.Should().OnlyContainDiagnostic("BCP364", DiagnosticLevel.Error, "The property \"type\" must be a required string literal on all union member types.");
         }
 
-        [DataTestMethod]
-        [DataRow("typeA | typeB")]
-        [DataRow("typeA | typeA")]
-        public void DiscriminatedObjectUnions_Error_Discriminator_DuplicatedAcrossMembers(string typeTest)
+        [TestMethod]
+        public void DiscriminatedObjectUnions_Error_Discriminator_DuplicatedAcrossMembers()
         {
             var result = CompilationHelper.Compile($$"""
                   type typeA = {
@@ -443,7 +441,7 @@ namespace Bicep.Core.IntegrationTests
                   }
 
                   @discriminator('type')
-                  type typeUnion = {{typeTest}}
+                  type typeUnion = typeA | typeB
                   """);
 
             result.Should().OnlyContainDiagnostic("BCP365", DiagnosticLevel.Error, "The value \"'a'\" for discriminator property \"type\" is duplicated across multiple union member types. The value must be unique across all union member types.");
@@ -452,8 +450,6 @@ namespace Bicep.Core.IntegrationTests
         [DataTestMethod]
         [DataRow("string")]
         [DataRow("object")]
-        [DataRow("'a' | 'b'")]
-        [DataRow("typeA | 'b'")]
         [DataRow("typeA")]
         [DataRow("(typeA | typeB)[]")]
         public void DiscriminatedObjectUnions_Error_DiscriminatorAppliedToNonObjectOnlyUnion(string typeTest)

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
@@ -183,15 +183,14 @@ type discriminatorPropertyNotRequiredStringLiteral2 = typeA | typeG
 
 @discriminator('type')
 type discriminatorDuplicatedMember1 = typeA | typeA
-//@[46:051) [BCP365 (Error)] The value "'a'" for discriminator property "type" is duplicated across multiple union member types. The value must be unique across all union member types. (CodeDescription: none) |typeA|
 
 @discriminator('type')
 type discriminatorDuplicatedMember2 = typeA | { type: 'a', config: object }
 //@[46:075) [BCP365 (Error)] The value "'a'" for discriminator property "type" is duplicated across multiple union member types. The value must be unique across all union member types. (CodeDescription: none) |{ type: 'a', config: object }|
 
 @discriminator('type')
-//@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
 type discriminatorOnlyOneNonNullMember1 = typeA | null
+//@[50:054) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |null|
 
 @discriminator('type')
 //@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
@@ -201,23 +200,23 @@ type discriminatorOnlyOneNonNullMember2 = (typeA)?
 type discriminatorMemberHasAdditionalProperties = typeA | typeE
 
 @discriminator('type')
-//@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
 type discriminatorSelfCycle1 = typeA | discriminatorSelfCycle1
 //@[05:028) [BCP298 (Error)] This type definition includes itself as required component, which creates a constraint that cannot be fulfilled. (CodeDescription: none) |discriminatorSelfCycle1|
+//@[39:062) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |discriminatorSelfCycle1|
 
 @discriminator('type')
-//@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
 type discriminatorSelfCycle2 = (typeA | discriminatorSelfCycle2)?
 //@[05:028) [BCP298 (Error)] This type definition includes itself as required component, which creates a constraint that cannot be fulfilled. (CodeDescription: none) |discriminatorSelfCycle2|
+//@[40:063) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |discriminatorSelfCycle2|
 
 @discriminator('type')
-//@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
 type discriminatorTopLevelCycleA = typeA | discriminatorTopLevelCycleB
 //@[05:032) [BCP299 (Error)] This type definition includes itself as a required component via a cycle ("discriminatorTopLevelCycleA" -> "discriminatorTopLevelCycleB"). (CodeDescription: none) |discriminatorTopLevelCycleA|
+//@[43:070) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |discriminatorTopLevelCycleB|
 @discriminator('type')
-//@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
 type discriminatorTopLevelCycleB = typeB | discriminatorTopLevelCycleA
 //@[05:032) [BCP299 (Error)] This type definition includes itself as a required component via a cycle ("discriminatorTopLevelCycleB" -> "discriminatorTopLevelCycleA"). (CodeDescription: none) |discriminatorTopLevelCycleB|
+//@[43:070) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |discriminatorTopLevelCycleA|
 
 @discriminator('type')
 type discriminatorInnerSelfCycle1 = typeA | {
@@ -265,7 +264,6 @@ type discriminatorInlineAdditionalPropsBadType1 = {
 type discriminatorInlineAdditionalPropsBadType2 = {
   @discriminator('type')
   *: typeA | typeA
-//@[13:018) [BCP365 (Error)] The value "'a'" for discriminator property "type" is duplicated across multiple union member types. The value must be unique across all union member types. (CodeDescription: none) |typeA|
 }
 
 type discriminatorInlineAdditionalPropsBadType3 = {
@@ -279,8 +277,8 @@ type discriminatorInlineAdditionalPropsCycle1 = {
 //@[05:045) [BCP298 (Error)] This type definition includes itself as required component, which creates a constraint that cannot be fulfilled. (CodeDescription: none) |discriminatorInlineAdditionalPropsCycle1|
   type: 'b'
   @discriminator('type')
-//@[02:024) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
   *: typeA | discriminatorInlineAdditionalPropsCycle1
+//@[13:053) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |discriminatorInlineAdditionalPropsCycle1|
 }
 
 @discriminator('type')
@@ -298,9 +296,10 @@ param discriminatorParamBadType1 typeA
 //@[06:032) [no-unused-params (Warning)] Parameter "discriminatorParamBadType1" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |discriminatorParamBadType1|
 
 @discriminator('type')
-//@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|
 param discriminatorParamBadType2 'a' | 'b'
 //@[06:032) [no-unused-params (Warning)] Parameter "discriminatorParamBadType2" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-params)) |discriminatorParamBadType2|
+//@[33:036) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |'a'|
+//@[39:042) [BCP286 (Error)] This union member is invalid because it cannot be assigned to the 'object' type. (CodeDescription: none) |'b'|
 
 @discriminator('type')
 //@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (CodeDescription: none) |@discriminator('type')|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.symbols.bicep
@@ -184,7 +184,7 @@ type discriminatorPropertyNotRequiredStringLiteral2 = typeA | typeG
 
 @discriminator('type')
 type discriminatorDuplicatedMember1 = typeA | typeA
-//@[5:35) TypeAlias discriminatorDuplicatedMember1. Type: error. Declaration start char: 0, length: 74
+//@[5:35) TypeAlias discriminatorDuplicatedMember1. Type: Type<{ type: 'a', value: string }>. Declaration start char: 0, length: 74
 
 @discriminator('type')
 type discriminatorDuplicatedMember2 = typeA | { type: 'a', config: object }

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/mixedArrayProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/mixedArrayProperties.json
@@ -2,7 +2,7 @@
   {
     "label": "one",
     "kind": "property",
-    "detail": "one",
+    "detail": "one (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `true`  \n"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevel.json
@@ -2,7 +2,7 @@
   {
     "label": "fifth",
     "kind": "property",
-    "detail": "fifth",
+    "detail": "fifth (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `[object, object]`  \n"
@@ -23,7 +23,7 @@
   {
     "label": "first",
     "kind": "property",
-    "detail": "first",
+    "detail": "first (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `true`  \n"
@@ -44,7 +44,7 @@
   {
     "label": "fourth",
     "kind": "property",
-    "detail": "fourth",
+    "detail": "fourth (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `'test'`  \n"
@@ -65,7 +65,7 @@
   {
     "label": "second",
     "kind": "property",
-    "detail": "second",
+    "detail": "second (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `false`  \n"
@@ -86,7 +86,7 @@
   {
     "label": "sixth",
     "kind": "property",
-    "detail": "sixth",
+    "detail": "sixth (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `[object]`  \n"
@@ -107,7 +107,7 @@
   {
     "label": "third",
     "kind": "property",
-    "detail": "third",
+    "detail": "third (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `42`  \n"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/oneArrayItemProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/oneArrayItemProperties.json
@@ -2,7 +2,7 @@
   {
     "label": "two",
     "kind": "property",
-    "detail": "two",
+    "detail": "two (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `44`  \n"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -2,7 +2,7 @@
   {
     "label": "'two'",
     "kind": "property",
-    "detail": "two",
+    "detail": "two (Required)",
     "documentation": {
       "kind": "markdown",
       "value": "Type: `44`  \n"

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.ir.bicep
@@ -399,7 +399,7 @@ type discriminatedUnion4 = discriminatedUnion1 | (discriminatedUnion2 | typeE)
 @discriminator('type')
 //@[000:0066) ├─DeclaredTypeExpression { Name = discriminatedUnion5 }
 type discriminatedUnion5 = (typeA | typeB)?
-//@[027:0043) | └─NullableTypeExpression { Name = null | { type: 'a', value: string } | { type: 'b', value: int } }
+//@[027:0043) | └─NullableTypeExpression { Name = null | ({ type: 'a', value: string } | { type: 'b', value: int }) }
 //@[028:0041) |   └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', value: int } }
 //@[028:0033) |     ├─TypeAliasReferenceExpression { Name = typeA }
 //@[036:0041) |     └─TypeAliasReferenceExpression { Name = typeB }
@@ -475,7 +475,7 @@ type inlineDiscriminatedUnion4 = {
   @discriminator('type')
 //@[002:0049) |   └─ObjectTypePropertyExpression
   prop: (typeA | typeC)?
-//@[008:0024) |     └─NullableTypeExpression { Name = null | { type: 'a', value: string } | { type: 'c', value: bool, value2: string } }
+//@[008:0024) |     └─NullableTypeExpression { Name = null | ({ type: 'a', value: string } | { type: 'c', value: bool, value2: string }) }
 //@[009:0022) |       └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'c', value: bool, value2: string } }
 //@[009:0014) |         ├─TypeAliasReferenceExpression { Name = typeA }
 //@[017:0022) |         └─TypeAliasReferenceExpression { Name = typeC }
@@ -509,7 +509,7 @@ type discriminatedUnionInlineAdditionalProps2 = {
   @discriminator('type')
 //@[002:0046) |   └─ObjectTypeAdditionalPropertiesExpression
   *: (typeA | typeB)?
-//@[005:0021) |     └─NullableTypeExpression { Name = null | { type: 'a', value: string } | { type: 'b', value: int } }
+//@[005:0021) |     └─NullableTypeExpression { Name = null | ({ type: 'a', value: string } | { type: 'b', value: int }) }
 //@[006:0019) |       └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', value: int } }
 //@[006:0011) |         ├─TypeAliasReferenceExpression { Name = typeA }
 //@[014:0019) |         └─TypeAliasReferenceExpression { Name = typeB }
@@ -551,7 +551,7 @@ type discriminatedUnionMemberOptionalCycle1 = {
   @discriminator('type')
 //@[002:0082) |   └─ObjectTypePropertyExpression
   prop: (typeA | discriminatedUnionMemberOptionalCycle1)?
-//@[008:0057) |     └─NullableTypeExpression { Name = null | { type: 'a', value: string } | { type: 'b', prop: (typeA | discriminatedUnionMemberOptionalCycle1)? } }
+//@[008:0057) |     └─NullableTypeExpression { Name = null | ({ type: 'a', value: string } | { type: 'b', prop: (typeA | discriminatedUnionMemberOptionalCycle1)? }) }
 //@[009:0055) |       └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', prop: (typeA | discriminatedUnionMemberOptionalCycle1)? } }
 //@[009:0014) |         ├─TypeAliasReferenceExpression { Name = typeA }
 //@[017:0055) |         └─TypeAliasReferenceExpression { Name = discriminatedUnionMemberOptionalCycle1 }
@@ -618,7 +618,7 @@ param paramInlineDiscriminatedUnion2 (typeA | typeB) = { type: 'b', value: 0 }
 @discriminator('type')
 //@[000:0076) ├─DeclaredParameterExpression { Name = paramInlineDiscriminatedUnion3 }
 param paramInlineDiscriminatedUnion3 (typeA | typeB)?
-//@[037:0053) | └─NullableTypeExpression { Name = null | { type: 'a', value: string } | { type: 'b', value: int } }
+//@[037:0053) | └─NullableTypeExpression { Name = null | ({ type: 'a', value: string } | { type: 'b', value: int }) }
 //@[038:0051) |   └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', value: int } }
 //@[038:0043) |     ├─TypeAliasReferenceExpression { Name = typeA }
 //@[046:0051) |     └─TypeAliasReferenceExpression { Name = typeB }
@@ -690,7 +690,7 @@ output outputInlineDiscriminatedUnion2 typeA | typeB | ({ type: 'c', value: int 
 @discriminator('type')
 //@[000:0085) └─DeclaredOutputExpression { Name = outputInlineDiscriminatedUnion3 }
 output outputInlineDiscriminatedUnion3 (typeA | typeB)? = null
-//@[039:0055)   ├─NullableTypeExpression { Name = null | { type: 'a', value: string } | { type: 'b', value: int } }
+//@[039:0055)   ├─NullableTypeExpression { Name = null | ({ type: 'a', value: string } | { type: 'b', value: int }) }
 //@[040:0053)   | └─DiscriminatedObjectTypeExpression { Name = { type: 'a', value: string } | { type: 'b', value: int } }
 //@[040:0045)   |   ├─TypeAliasReferenceExpression { Name = typeA }
 //@[048:0053)   |   └─TypeAliasReferenceExpression { Name = typeB }

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbols.bicep
@@ -166,7 +166,7 @@ type discriminatedUnion4 = discriminatedUnion1 | (discriminatedUnion2 | typeE)
 
 @discriminator('type')
 type discriminatedUnion5 = (typeA | typeB)?
-//@[5:24) TypeAlias discriminatedUnion5. Type: Type<null | { type: 'a', value: string } | { type: 'b', value: int }>. Declaration start char: 0, length: 66
+//@[5:24) TypeAlias discriminatedUnion5. Type: Type<null | ({ type: 'a', value: string } | { type: 'b', value: int })>. Declaration start char: 0, length: 66
 
 @discriminator('type')
 type discriminatedUnion6 = (typeA | typeB)!
@@ -254,7 +254,7 @@ type discriminatedUnionInlineTuple1 = [
 param paramDiscriminatedUnionTypeAlias1 discriminatedUnion1
 //@[6:39) Parameter paramDiscriminatedUnionTypeAlias1. Type: { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 59
 param paramDiscriminatedUnionTypeAlias2 discriminatedUnion5
-//@[6:39) Parameter paramDiscriminatedUnionTypeAlias2. Type: null | { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 59
+//@[6:39) Parameter paramDiscriminatedUnionTypeAlias2. Type: null | ({ type: 'a', value: string } | { type: 'b', value: int }). Declaration start char: 0, length: 59
 
 @discriminator('type')
 param paramInlineDiscriminatedUnion1 typeA | typeB
@@ -266,7 +266,7 @@ param paramInlineDiscriminatedUnion2 (typeA | typeB) = { type: 'b', value: 0 }
 
 @discriminator('type')
 param paramInlineDiscriminatedUnion3 (typeA | typeB)?
-//@[6:36) Parameter paramInlineDiscriminatedUnion3. Type: null | { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 76
+//@[6:36) Parameter paramInlineDiscriminatedUnion3. Type: null | ({ type: 'a', value: string } | { type: 'b', value: int }). Declaration start char: 0, length: 76
 
 output outputDiscriminatedUnionTypeAlias1 discriminatedUnion1 = { type: 'a', value: 'str' }
 //@[7:41) Output outputDiscriminatedUnionTypeAlias1. Type: { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 91
@@ -274,7 +274,7 @@ output outputDiscriminatedUnionTypeAlias1 discriminatedUnion1 = { type: 'a', val
 output outputDiscriminatedUnionTypeAlias2 discriminatedUnion1 = { type: 'a', value: 'str' }
 //@[7:41) Output outputDiscriminatedUnionTypeAlias2. Type: { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 114
 output outputDiscriminatedUnionTypeAlias3 discriminatedUnion5 = null
-//@[7:41) Output outputDiscriminatedUnionTypeAlias3. Type: null | { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 68
+//@[7:41) Output outputDiscriminatedUnionTypeAlias3. Type: null | ({ type: 'a', value: string } | { type: 'b', value: int }). Declaration start char: 0, length: 68
 
 @discriminator('type')
 output outputInlineDiscriminatedUnion1 typeA | typeB | { type: 'c', value: int } = { type: 'a', value: 'a' }
@@ -286,5 +286,5 @@ output outputInlineDiscriminatedUnion2 typeA | typeB | ({ type: 'c', value: int 
 
 @discriminator('type')
 output outputInlineDiscriminatedUnion3 (typeA | typeB)? = null
-//@[7:38) Output outputInlineDiscriminatedUnion3. Type: null | { type: 'a', value: string } | { type: 'b', value: int }. Declaration start char: 0, length: 85
+//@[7:38) Output outputInlineDiscriminatedUnion3. Type: null | ({ type: 'a', value: string } | { type: 'b', value: int }). Declaration start char: 0, length: 85
 

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -244,6 +244,8 @@ namespace Bicep.Core
 
         public static readonly ImmutableHashSet<string> ReservedTypeNames = ImmutableHashSet.Create<string>(IdentifierComparer, ResourceKeyword);
 
+        public static readonly ImmutableArray<string> DiscriminatorPreferenceOrder = ImmutableArray.Create("type", "kind");
+
         private static IEnumerable<TypeProperty> CreateParameterModifierMetadataProperties()
         {
             yield return new TypeProperty("description", String, TypePropertyFlags.Constant);

--- a/src/Bicep.Core/TypeSystem/DiscriminatedObjectType.cs
+++ b/src/Bicep.Core/TypeSystem/DiscriminatedObjectType.cs
@@ -50,6 +50,8 @@ namespace Bicep.Core.TypeSystem
 
         public override TypeKind TypeKind => TypeKind.DiscriminatedObject;
 
+        public override string FormatNameForCompoundTypes() => Name.IndexOf(' ') > -1 ? WrapTypeName() : Name;
+
         public ImmutableDictionary<string, ObjectType> UnionMembersByKey { get; }
 
         public override TypeSymbolValidationFlags ValidationFlags { get; }

--- a/src/Bicep.Core/TypeSystem/DiscriminatedObjectTypeBuilder.cs
+++ b/src/Bicep.Core/TypeSystem/DiscriminatedObjectTypeBuilder.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Bicep.Core.TypeSystem;
+
+public class DiscriminatedObjectTypeBuilder
+{
+    private readonly ImmutableHashSet<ObjectType>.Builder members = ImmutableHashSet.CreateBuilder<ObjectType>();
+    private readonly Dictionary<string, HashSet<string>> discriminatorCandidates = new();
+    private readonly string? requiredDiscriminator;
+
+    public DiscriminatedObjectTypeBuilder(string? requiredDiscriminator = null)
+    {
+        this.requiredDiscriminator = requiredDiscriminator;
+    }
+
+    public bool TryInclude(ObjectType @object)
+    {
+        if (members.Contains(@object))
+        {
+            return true;
+        }
+
+        if (members.Count == 0)
+        {
+            var foundViableDiscriminator = false;
+
+            foreach (var (name, property) in @object.Properties)
+            {
+                if (requiredDiscriminator is not null && name != requiredDiscriminator)
+                {
+                    continue;
+                }
+
+                if (property.Flags.HasFlag(TypePropertyFlags.Required) && property.TypeReference.Type is StringLiteralType { RawStringValue: string discriminatorValue })
+                {
+                    foundViableDiscriminator = true;
+                    discriminatorCandidates.Add(name, new(StringComparer.OrdinalIgnoreCase) { discriminatorValue });
+                }
+            }
+
+            if (!foundViableDiscriminator)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            var noLongerViableDiscriminators = ImmutableHashSet.CreateBuilder<string>();
+            Dictionary<string, string> stillViableDiscriminators = new();
+
+            foreach (var candidate in discriminatorCandidates.Keys)
+            {
+                // Eliminate any discriminator candidates for which:
+                if (!@object.Properties.TryGetValue(candidate, out var property) || // the property is not defined in @object, or
+                    !property.Flags.HasFlag(TypePropertyFlags.Required) || // the property is optional in @object, or
+                    property.TypeReference.Type is not StringLiteralType { RawStringValue: string discriminatorValue } || // the property does not have a string literal type in @object, or
+                    discriminatorCandidates[candidate].Contains(discriminatorValue)) // the value of the discriminator has already been claimed by another variant
+                {
+                    noLongerViableDiscriminators.Add(candidate);
+                }
+                else
+                {
+                    stillViableDiscriminators[candidate] = discriminatorValue;
+                }
+            }
+
+            // If adding @object would eliminate all possible discriminators, reject it
+            if (noLongerViableDiscriminators.SetEquals(discriminatorCandidates.Keys))
+            {
+                return false;
+            }
+
+            // otherwise, narrow the list of discriminator candidates
+            foreach (var toEliminate in noLongerViableDiscriminators)
+            {
+                discriminatorCandidates.Remove(toEliminate);
+            }
+            foreach (var (name, value) in stillViableDiscriminators)
+            {
+                discriminatorCandidates[name].Add(value);
+            }
+        }
+
+        members.Add(@object);
+        return true;
+    }
+
+    public (ImmutableHashSet<ObjectType> Members, ImmutableHashSet<string> ViableDiscriminators) Build()
+        => new(members.ToImmutable(), discriminatorCandidates.Keys.ToImmutableHashSet());
+}

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1171,7 +1171,7 @@ namespace Bicep.Core.TypeSystem
 
                         // we've not been able to find a declared object type for the containing object, or it doesn't contain a property matching this one.
                         // best we can do is to simply generate a property for the assigned type.
-                        return new TypeProperty(group.Key, resolvedType);
+                        return new TypeProperty(group.Key, resolvedType, TypePropertyFlags.Required);
                     });
 
                 var additionalProperties = syntax.Properties

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -62,9 +62,9 @@ namespace Bicep.Core.TypeSystem
 
         public static bool IsLiteralType(TypeSymbol type) => type switch
         {
-            StringLiteralType => true,
-            IntegerLiteralType => true,
-            BooleanLiteralType => true,
+            StringLiteralType or
+            IntegerLiteralType or
+            BooleanLiteralType or
             NullType => true,
 
             // A tuple can be a literal only if each item contained therein is also a literal
@@ -167,7 +167,7 @@ namespace Bicep.Core.TypeSystem
 
                     if (writeOnlyDiagnostic.Level == DiagnosticLevel.Error)
                     {
-                        return ErrorType.Create(Enumerable.Empty<ErrorDiagnostic>());
+                        return ErrorType.Empty();
                     }
                 }
 
@@ -215,7 +215,7 @@ namespace Bicep.Core.TypeSystem
 
             diagnostics.Write(unknownPropertyDiagnostic);
 
-            return (unknownPropertyDiagnostic.Level == DiagnosticLevel.Error) ? ErrorType.Create(Enumerable.Empty<ErrorDiagnostic>()) : LanguageConstants.Any;
+            return (unknownPropertyDiagnostic.Level == DiagnosticLevel.Error) ? ErrorType.Empty() : LanguageConstants.Any;
         }
 
         public static TypeSymbol FlattenType(TypeSymbol typeToFlatten, IPositionable argumentPosition)


### PR DESCRIPTION
Split off from work on #9736, which requires a couple changes that are easier to consider as standalone PRs.

This PR updates the `TypeCollapser` to handle unions of objects that share a required, string-literal-typed property for which each member of the union has a unique value. (If there are multiple viable discriminators, the `TypeCollapser` will try to use a property named `type` or `kind`, then fall back to the first viable discriminator name in an ordinal alphabetic sort.)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12129)