### PR TITLE
Correct terminating token for tuple parsing recovery

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -849,4 +849,17 @@ param myParam string
             ("BCP289", DiagnosticLevel.Error, "The type definition is not valid."),
         });
     }
+
+    [TestMethod]
+    [Timeout(5_000)]
+    public void Parsing_incomplete_tuple_type_expressions_halts()
+    {
+        var result = CompilationHelper.Compile("""
+            type myType = {
+                name: [string
+            }
+            """);
+
+        result.Template.Should().BeNull();
+    }
 }

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -1421,8 +1421,11 @@ namespace Bicep.Core.Parsing
             return new TupleTypeSyntax(openBracket, itemsOrTokens, closeBracket);
         }
 
-        private SyntaxBase TupleMemberType() => new TupleTypeItemSyntax(DecorableSyntaxLeadingNodes().ToImmutableArray(),
-            WithRecovery(() => TypeExpression(), RecoveryFlags.None, TokenType.NewLine, TokenType.RightBrace));
+        private SyntaxBase TupleMemberType() => WithRecovery(
+            () => new TupleTypeItemSyntax(DecorableSyntaxLeadingNodes().ToImmutableArray(), TypeExpression()),
+            RecoveryFlags.None,
+            TokenType.NewLine,
+            TokenType.RightSquare);
 
         protected IEnumerable<SyntaxBase> DecorableSyntaxLeadingNodes()
         {


### PR DESCRIPTION
Resolves #12126 

The terminating tokens passed to `WithRecovery` when parsing tuple type members were `'\n'` and `'}'` instead of `'\n'` and `']'` (likely due to a copy/paste error).

This would cause the parser to hang when it encountered a `'}'` in a position where the parser expected a standalone type expression, as the parser would neither be able to parse the `'}'` nor advance past it in https://github.com/Azure/bicep/blob/main/src/Bicep.Core/Parsing/BaseParser.cs#L1259-L1270
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12140)