### PR TITLE
change GH policy to add back 'needs:triage' rather than 'needs:attention'

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -56,7 +56,7 @@ configuration:
       - addLabel:
           label: 'Needs: Triage :mag:'
 
-    - description: "Replace 'Needs: Author Feedback' with 'Needs: Attention' label when author comments"
+    - description: "Replace 'Needs: Author Feedback' with 'Needs: Triage' label when author comments"
       if:
       - payloadType: Issue_Comment
       - isAction:
@@ -68,7 +68,7 @@ configuration:
       - isOpen
       then:
       - addLabel:
-          label: 'Needs: Attention :wave:'
+          label: 'Needs: Triage :mag:'
       - removeLabel:
           label: 'Needs: Author Feedback'
 


### PR DESCRIPTION
Ideal workflow is:

* add "needs: author feedback" and remove "needs: triage" so it is out of the queue
* if user doesn't respond, close issue (already working)
* if user does respond, then add triage label back and remove author feedback. This will put it back in our normal workflow for triaging issues.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12264)