### PR TITLE
Add user-assigned identity credential options to Bicep configuration

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -511,7 +511,7 @@ module empty 'br:{{registry}}/{{repository}}@{{digest}}' = {
 
             result.Should().Be(1);
             output.Should().BeEmpty();
-            error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: \"The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.\".");
+            error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.");
         }
 
         [TestMethod]
@@ -539,7 +539,7 @@ module empty 'br:{{registry}}/{{repository}}@{{digest}}' = {
 
             result.Should().Be(1);
             output.Should().BeEmpty();
-            error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: \"Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed. LineNumber: 8 | BytePositionInLine: 0.\".");
+            error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed. LineNumber: 8 | BytePositionInLine: 0.");
         }
 
         [DataRow(new string[] { })]

--- a/src/Bicep.Cli.IntegrationTests/LintCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/LintCommandTests.cs
@@ -189,7 +189,7 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
 
         result.Should().Be(1);
         output.Should().BeEmpty();
-        error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: \"The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.\".");
+        error.Should().StartWith($"{inputFile}(1,1) : Error BCP271: Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.");
     }
 
     [TestMethod]

--- a/src/Bicep.Core.UnitTests/Assertions/RootConfigurationAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/RootConfigurationAssertions.cs
@@ -4,7 +4,6 @@
 using Bicep.Core.Configuration;
 using FluentAssertions;
 using FluentAssertions.Primitives;
-using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.UnitTests.Assertions
 {
@@ -24,9 +23,9 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<RootConfigurationAssertions> HaveContents(string contents, string because = "", params object[] becauseArgs)
         {
-            var actual = JToken.Parse(Subject.ToUtf8Json());
-            var expected = JToken.Parse(contents);
-            actual.Should().DeepEqual(expected, because, becauseArgs);
+            var actual = Subject.ToUtf8Json().ReplaceLineEndings();
+            var expected = contents.ReplaceLineEndings();
+            actual.Should().Be(expected, because, becauseArgs);
             return new AndConstraint<RootConfigurationAssertions>(this);
         }
     }

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -352,7 +352,7 @@ namespace Bicep.Core.UnitTests.Configuration
             var diagnostics = sut.GetConfiguration(sourceFileUri).DiagnosticBuilders.Select(b => b(DiagnosticBuilder.ForDocumentStart())).ToList();
             diagnostics.Count.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurataionPath}\" as valid JSON: \"The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.\".");
+            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurataionPath}\" as valid JSON: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.");
         }
 
         [TestMethod]
@@ -379,7 +379,7 @@ namespace Bicep.Core.UnitTests.Configuration
             var diagnostics = sut.GetConfiguration(sourceFileUri).DiagnosticBuilders.Select(b => b(DiagnosticBuilder.ForDocumentStart())).ToList();
             diagnostics.Count.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().Be($"Could not load the Bicep configuration file \"{configurataionPath}\": \"Not allowed.\".");
+            diagnostics[0].Message.Should().Be($"Could not load the Bicep configuration file \"{configurataionPath}\": Not allowed.");
         }
 
         [TestMethod]
@@ -401,57 +401,66 @@ namespace Bicep.Core.UnitTests.Configuration
             var diagnostics = configuration.DiagnosticBuilders.Select(b => b(DiagnosticBuilder.ForDocumentStart())).ToList();
             diagnostics.Count.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Info);
-            diagnostics[0].Message.Should().Be("Error scanning \"foo\" for bicep configuration: \"Oops.\".");
+            diagnostics[0].Message.Should().Be("Error scanning \"foo\" for bicep configuration: Oops.");
             configuration.ToUtf8Json().Should().Be(IConfigurationManager.GetBuiltInConfiguration().ToUtf8Json());
         }
 
         [DataTestMethod]
-        [DataRow(@"{
-  ""cloud"": {
-    ""currentProfile"": ""MyCloud""
-  }
-}", "The cloud profile \"MyCloud\" does not exist in the Bicep configuration \"__CONFIGURATION_PATH__\". Available profiles include \"AzureChinaCloud\", \"AzureCloud\", \"AzureUSGovernment\".")]
-        [DataRow(@"{
-  ""cloud"": {
-    ""currentProfile"": ""MyCloud"",
-    ""profiles"": {
-      ""MyCloud"": {
-      }
-    }
-  }
-}", "The cloud profile \"MyCloud\" in the Bicep configuration \"__CONFIGURATION_PATH__\". The \"resourceManagerEndpoint\" property cannot be null or undefined.")]
-        [DataRow(@"{
-  ""cloud"": {
-    ""currentProfile"": ""MyCloud"",
-    ""profiles"": {
-      ""MyCloud"": {
-        ""resourceManagerEndpoint"": ""Not and URL""
-      }
-    }
-  }
-}", "The cloud profile \"MyCloud\" in the Bicep configuration \"__CONFIGURATION_PATH__\" is invalid. The value of the \"resourceManagerEndpoint\" property \"Not and URL\" is not a valid URL.")]
-        [DataRow(@"{
-  ""cloud"": {
-    ""currentProfile"": ""MyCloud"",
-    ""profiles"": {
-      ""MyCloud"": {
-        ""resourceManagerEndpoint"": ""https://example.invalid""
-      }
-    }
-  }
-}",
-            "The cloud profile \"MyCloud\" in the Bicep configuration \"__CONFIGURATION_PATH__\". The \"activeDirectoryAuthority\" property cannot be null or undefined.")]
-        [DataRow(@"{
-  ""cloud"": {
-    ""currentProfile"": ""MyCloud"",
-    ""profiles"": {
-      ""MyCloud"": {
-        ""resourceManagerEndpoint"": ""https://example.invalid"",
-        ""activeDirectoryAuthority"": ""Not an URL""
-      }
-    }
-  }
-}", "The cloud profile \"MyCloud\" in the Bicep configuration \"__CONFIGURATION_PATH__\" is invalid. The value of the \"activeDirectoryAuthority\" property \"Not an URL\" is not a valid URL.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "currentProfile": "MyCloud"
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" does not exist. Available profiles include ""AzureChinaCloud"", ""AzureCloud"", ""AzureUSGovernment"".")]
+        [DataRow("""
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The ""resourceManagerEndpoint"" property cannot be null or undefined.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                    "resourceManagerEndpoint": "Not and URL"
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""resourceManagerEndpoint"" property ""Not and URL"" is not a valid URL.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                    "resourceManagerEndpoint": "https://example.invalid"
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The ""activeDirectoryAuthority"" property cannot be null or undefined.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                    "resourceManagerEndpoint": "https://example.invalid",
+                    "activeDirectoryAuthority": "Not an URL"
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""activeDirectoryAuthority"" property ""Not an URL"" is not a valid URL.")]
         public void GetConfiguration_InvalidCurrentCloudProfile_PropagatesConfigurationDiagnostic(string configurationContents, string expectedExceptionMessage)
         {
             // Arrange.
@@ -468,7 +477,77 @@ namespace Bicep.Core.UnitTests.Configuration
             var diagnostics = sut.GetConfiguration(sourceFileUri).DiagnosticBuilders.Select(b => b(DiagnosticBuilder.ForDocumentStart())).ToList();
             diagnostics.Count.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": \"{expectedExceptionMessage.Replace("__CONFIGURATION_PATH__", configurationPath)}\".");
+            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": {expectedExceptionMessage}");
+        }
+
+        [TestMethod]
+        [DataRow("""
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned"
+                    }
+                }
+              }
+            }
+            """, @"The managed-identity configuration is invalid. Either ""clientId"" or ""resourceId"" must be set for user-assigned identity.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "foo",
+                        "resourceId": "bar"
+                    }
+                }
+              }
+            }
+            """, @"The managed-identity configuration is invalid. ""clientId"" and ""resourceId"" cannot be set at the same time for user-assigned identity.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "foo"
+                    }
+                }
+              }
+            }
+            """, @"The managed-identity configuration is invalid. ""clientId"" must be a GUID.")]
+        [DataRow("""
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned",
+                        "resourceId": "bar"
+                    }
+                }
+              }
+            }
+            """, @"The managed-identity configuration is invalid. ""resourceId"" must be a valid Azure resource identifier.")]
+        public void GetConfiguration_InvalidUserAssignedIdentityOptions_PropagatesConfigurationDiagnostic(string configurationContents, string expectedExceptionMessage)
+        {
+            // Arrange.
+            var configurationPath = CreatePath("path/to/bicepconfig.json");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                [configurationPath] = configurationContents,
+            });
+
+            var sut = new ConfigurationManager(fileSystem);
+            var sourceFileUri = new Uri(CreatePath("path/to/main.bicep"));
+
+            // Act.
+            var diagnostics = sut.GetConfiguration(sourceFileUri).DiagnosticBuilders.Select(b => b(DiagnosticBuilder.ForDocumentStart())).ToList();
+
+            // Assert.
+            diagnostics.Count.Should().Be(1);
+            diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
+            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": {expectedExceptionMessage}");
         }
 
         [TestMethod]
@@ -492,7 +571,13 @@ namespace Bicep.Core.UnitTests.Configuration
                     "credentialPrecedence": [
                         "AzurePowerShell",
                         "VisualStudioCode"
-                    ]
+                    ],
+                    "credentialOptions": {
+                      "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "00000000-0000-0000-0000-000000000000"
+                      }
+                    }
                   },
                   "moduleAliases": {
                     "ts": {
@@ -584,13 +669,18 @@ namespace Bicep.Core.UnitTests.Configuration
                     "credentialPrecedence": [
                       "AzurePowerShell",
                       "VisualStudioCode"
-                    ]
+                    ],
+                    "credentialOptions": {
+                      "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "00000000-0000-0000-0000-000000000000"
+                      }
+                    }
                   },
                   "moduleAliases": {
                     "ts": {
                       "mySpecPath": {
-                        "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173",
-                        "resourceGroup": null
+                        "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
                       }
                     },
                     "br": {
@@ -599,8 +689,7 @@ namespace Bicep.Core.UnitTests.Configuration
                         "modulePath": "root/modules"
                       },
                       "myRegistry": {
-                        "registry": "localhost:8000",
-                        "modulePath": null
+                        "registry": "localhost:8000"
                       },
                       "public": {
                         "registry": "mcr.microsoft.com",

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -111,7 +111,7 @@ namespace Bicep.Core.Configuration
             return configuration;
         }
 
-        private RootConfiguration GetDefaultConfiguration() => IConfigurationManager.GetBuiltInConfiguration();
+        private static RootConfiguration GetDefaultConfiguration() => IConfigurationManager.GetBuiltInConfiguration();
 
         private (RootConfiguration?, DiagnosticBuilder.DiagnosticBuilderDelegate?) LoadConfiguration(Uri configurationUri)
         {

--- a/src/Bicep.Core/Configuration/ManagedIdentityType.cs
+++ b/src/Bicep.Core/Configuration/ManagedIdentityType.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Bicep.Core.Configuration
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ManagedIdentityType
+    {
+        SystemAssigned,
+
+        UserAssigned,
+    }
+}

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1552,23 +1552,23 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic UnparsableBicepConfigFile(string configurationPath, string parsingErrorMessage) => new(
                 TextSpan,
                 "BCP271",
-                $"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: \"{parsingErrorMessage}\".");
+                $"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: {parsingErrorMessage.TrimEnd('.')}.");
 
             public ErrorDiagnostic UnloadableBicepConfigFile(string configurationPath, string loadErrorMessage) => new(
                 TextSpan,
                 "BCP272",
-                $"Could not load the Bicep configuration file \"{configurationPath}\": \"{loadErrorMessage}\".");
+                $"Could not load the Bicep configuration file \"{configurationPath}\": {loadErrorMessage.TrimEnd('.')}.");
 
             public ErrorDiagnostic InvalidBicepConfigFile(string configurationPath, string parsingErrorMessage) => new(
                 TextSpan,
                 "BCP273",
-                $"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": \"{parsingErrorMessage}\".");
+                $"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": {parsingErrorMessage.TrimEnd('.')}.");
 
             public Diagnostic PotentialConfigDirectoryCouldNotBeScanned(string? directoryPath, string scanErrorMessage) => new(
                 TextSpan,
                 DiagnosticLevel.Info, // should this be a warning instead?
                 "BCP274",
-                $"Error scanning \"{directoryPath}\" for bicep configuration: \"{scanErrorMessage}\".");
+                $"Error scanning \"{directoryPath}\" for bicep configuration: {scanErrorMessage.TrimEnd('.')}.");
 
             public ErrorDiagnostic FoundDirectoryInsteadOfFile(string directoryPath) => new(
                 TextSpan,

--- a/src/Bicep.Core/Json/JsonElementFactory.cs
+++ b/src/Bicep.Core/Json/JsonElementFactory.cs
@@ -18,6 +18,7 @@ namespace Bicep.Core.Json
 
         private static readonly JsonSerializerOptions DefaultSerializeOptions = new()
         {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             Converters = { new JsonStringEnumConverter() },
         };

--- a/src/Bicep.Core/Registry/Auth/ITokenCredentialFactory.cs
+++ b/src/Bicep.Core/Registry/Auth/ITokenCredentialFactory.cs
@@ -10,8 +10,8 @@ namespace Bicep.Core.Registry.Auth
 {
     public interface ITokenCredentialFactory
     {
-        TokenCredential CreateChain(IEnumerable<CredentialType> credentialPrecedence, Uri authorityUri);
+        TokenCredential CreateChain(IEnumerable<CredentialType> credentialPrecedence, CredentialOptions? credentialOptions, Uri authorityUri);
 
-        TokenCredential CreateSingle(CredentialType credentialType, Uri authorityUri);
+        TokenCredential CreateSingle(CredentialType credentialType, CredentialOptions? credentialOptions, Uri authorityUri);
     }
 }

--- a/src/Bicep.Core/Registry/Auth/TokenCredentialFactory.cs
+++ b/src/Bicep.Core/Registry/Auth/TokenCredentialFactory.cs
@@ -12,23 +12,47 @@ namespace Bicep.Core.Registry.Auth
 {
     public class TokenCredentialFactory : ITokenCredentialFactory
     {
-        public TokenCredential CreateChain(IEnumerable<CredentialType> credentialPrecedence, Uri authorityUri)
+        public TokenCredential CreateChain(IEnumerable<CredentialType> credentialPrecedence, CredentialOptions? credentialOptions, Uri authorityUri)
         {
             if (!credentialPrecedence.Any())
             {
                 throw new ArgumentException("At least one credential type must be provided.");
             }
 
-            var tokenCredentials = credentialPrecedence.Select(credentialType => CreateSingle(credentialType, authorityUri)).ToArray();
+            var tokenCredentials = credentialPrecedence.Select(credentialType => CreateSingle(credentialType, credentialOptions, authorityUri)).ToArray();
 
             return new ChainedTokenCredential(tokenCredentials);
         }
 
-        public TokenCredential CreateSingle(CredentialType credentialType, Uri authorityUri) =>
-            credentialType switch
+        public TokenCredential CreateSingle(CredentialType credentialType, CredentialOptions? credentialOptions, Uri authorityUri)
+        {
+            if (credentialType is CredentialType.ManagedIdentity)
+            {
+                var managedIdentityType = credentialOptions?.ManagedIdentity?.Type ?? ManagedIdentityType.SystemAssigned;
+
+                if (managedIdentityType is ManagedIdentityType.SystemAssigned)
+                {
+                    return new ManagedIdentityCredential(options: new() { AuthorityHost = authorityUri });
+                }
+
+                // Handle user-assigned identity.
+                if (credentialOptions?.ManagedIdentity?.ClientId is { } clientId)
+                {
+                    return new ManagedIdentityCredential(clientId, new() { AuthorityHost = authorityUri });
+                }
+
+                if (credentialOptions?.ManagedIdentity?.ResourceId is { } resourceId)
+                {
+                    return new ManagedIdentityCredential(new ResourceIdentifier(resourceId), new() { AuthorityHost = authorityUri });
+                }
+
+                // This is a defensive check. ClientId and ResourceId should already be validated when binding the cloud configuration.
+                throw new InvalidOperationException("ClientId and ResourceId cannot be null at the same time for user-assigned identity.");
+            }
+
+            return credentialType switch
             {
                 CredentialType.Environment => new EnvironmentCredential(new() { AuthorityHost = authorityUri }),
-                CredentialType.ManagedIdentity => new ManagedIdentityCredential(options: new() { AuthorityHost = authorityUri }),
                 CredentialType.VisualStudio => new VisualStudioCredential(new() { AuthorityHost = authorityUri }),
                 CredentialType.VisualStudioCode => new VisualStudioCodeCredential(new() { AuthorityHost = authorityUri }),
                 // AzureCLICrediential does not accept options. Azure CLI has built-in cloud profiles so AuthorityHost is not needed.
@@ -37,5 +61,7 @@ namespace Bicep.Core.Registry.Auth
 
                 _ => throw new NotImplementedException($"Unexpected credential type '{credentialType}'.")
             };
+
+        }
     }
 }

--- a/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
+++ b/src/Bicep.Core/Registry/ContainerRegistryClientFactory.cs
@@ -24,7 +24,7 @@ namespace Bicep.Core.Registry
             options.Diagnostics.ApplySharedContainerRegistrySettings();
             options.Audience = new ContainerRegistryAudience(configuration.Cloud.ResourceManagerAudience);
 
-            var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.ActiveDirectoryAuthorityUri);
+            var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.CredentialOptions, configuration.Cloud.ActiveDirectoryAuthorityUri);
 
             return new(registryUri, repository, credential, options);
         }

--- a/src/Bicep.Core/Registry/TemplateSpecRepositoryFactory.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecRepositoryFactory.cs
@@ -23,7 +23,7 @@ namespace Bicep.Core.Registry
             options.Diagnostics.ApplySharedResourceManagerSettings();
             options.Environment = new ArmEnvironment(configuration.Cloud.ResourceManagerEndpointUri, configuration.Cloud.AuthenticationScope);
 
-            var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.ActiveDirectoryAuthorityUri);
+            var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.CredentialOptions, configuration.Cloud.ActiveDirectoryAuthorityUri);
             var armClient = new ArmClient(credential, subscriptionId, options);
 
             return new TemplateSpecRepository(armClient);

--- a/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
@@ -103,7 +103,7 @@ namespace Bicep.LangServer.UnitTests.Configuration
             diagnostics.Should().SatisfyRespectively(
                 x =>
                 {
-                    x.Message.Should().Be(@$"Failed to parse the contents of the Bicep configuration file ""{configFilePath}"" as valid JSON: ""Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed. LineNumber: 8 | BytePositionInLine: 13."".");
+                    x.Message.Should().Be(@$"Failed to parse the contents of the Bicep configuration file ""{configFilePath}"" as valid JSON: Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed. LineNumber: 8 | BytePositionInLine: 13.");
                     x.Severity.Should().Be(DiagnosticSeverity.Error);
                     x.Code?.String.Should().Be("BCP271");
                     x.Range.Should().Be(new Range

--- a/src/Bicep.LangServer/Providers/AzResourceProvider.cs
+++ b/src/Bicep.LangServer/Providers/AzResourceProvider.cs
@@ -32,7 +32,7 @@ namespace Bicep.LanguageServer.Providers
                 options.SetApiVersion(new ResourceType(resourceType), apiVersion);
             }
 
-            var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.ActiveDirectoryAuthorityUri);
+            var credential = this.credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.CredentialOptions, configuration.Cloud.ActiveDirectoryAuthorityUri);
 
             return new ArmClient(credential, subscriptionId, options);
         }

--- a/src/Bicep.LangServer/Providers/AzureContainerRegistriesProvider.cs
+++ b/src/Bicep.LangServer/Providers/AzureContainerRegistriesProvider.cs
@@ -75,7 +75,7 @@ namespace Bicep.LanguageServer.Providers
         private ArmClient GetArmClient(Uri templateUri)
         {
             var rootConfiguration = configurationManager.GetConfiguration(templateUri);
-            var credential = tokenCredentialFactory.CreateChain(rootConfiguration.Cloud.CredentialPrecedence, rootConfiguration.Cloud.ActiveDirectoryAuthorityUri);
+            var credential = tokenCredentialFactory.CreateChain(rootConfiguration.Cloud.CredentialPrecedence, rootConfiguration.Cloud.CredentialOptions, rootConfiguration.Cloud.ActiveDirectoryAuthorityUri);
 
             var options = new ArmClientOptions();
             options.Diagnostics.ApplySharedResourceManagerSettings();

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -6,19 +6,14 @@
   "$comment5": "                                                                                                        ",
   "$comment6": "Also, please add appropriate tests in Bicep.Core.UnitTests.Diagnostics.BicepConfigSchemaTests to verify this file's contents'",
   "$comment9": "=========================================================================================================",
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Bicep Configuration",
   "definitions": {
     "level": {
       "title": "Diagnostic Level",
       "description": "Type of diagnostic to display, most rules default to warning",
       "type": "string",
-      "enum": [
-        "off",
-        "info",
-        "warning",
-        "error"
-      ]
+      "enum": ["off", "info", "warning", "error"]
     },
     "rule-def-level-warning": {
       "type": "object",
@@ -30,9 +25,7 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": [
-        "level"
-      ]
+      "required": ["level"]
     },
     "rule-def-level-error": {
       "type": "object",
@@ -44,9 +37,7 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": [
-        "level"
-      ]
+      "required": ["level"]
     },
     "rule-def-level-off": {
       "type": "object",
@@ -58,17 +49,12 @@
           "$ref": "#/definitions/level"
         }
       },
-      "required": [
-        "level"
-      ]
+      "required": ["level"]
     },
     "cloudProfile": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "resourceManagerEndpoint",
-        "activeDirectoryAuthority"
-      ],
+      "required": ["resourceManagerEndpoint", "activeDirectoryAuthority"],
       "properties": {
         "resourceManagerEndpoint": {
           "title": "Resource Manager Endpoint",
@@ -98,10 +84,7 @@
     "templateSpecModuleAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "subscription",
-        "resourceGroup"
-      ],
+      "required": ["subscription", "resourceGroup"],
       "properties": {
         "subscription": {
           "title": "Subscription ID",
@@ -122,9 +105,7 @@
     "bicepRegistryModuleAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "registry"
-      ],
+      "required": ["registry"],
       "properties": {
         "registry": {
           "title": "Registry",
@@ -144,9 +125,7 @@
     "bicepRegistryProviderAlias": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "registry"
-      ],
+      "required": ["registry"],
       "properties": {
         "registry": {
           "title": "Registry",
@@ -171,20 +150,14 @@
       "title": "Cloud",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "currentProfile"
-      ],
+      "required": ["currentProfile"],
       "properties": {
         "currentProfile": {
           "title": "Current Profile",
           "description": "The current cloud profile",
           "anyOf": [
             {
-              "enum": [
-                "AzureCloud",
-                "AzureChinaCloud",
-                "AzureUSGovernment"
-              ]
+              "enum": ["AzureCloud", "AzureChinaCloud", "AzureUSGovernment"]
             },
             {
               "type": "string"
@@ -209,6 +182,44 @@
           },
           "minItems": 1,
           "uniqueItems": true
+        },
+        "credentialOptions": {
+          "title": "Credential Options",
+          "description": "Credential options for the credential types specified in credentialPrecedence.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "managedIdentity": {
+              "title": "Managed Identity",
+              "description": "The managed identity options",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "title": "Managed Identity Type",
+                  "description": "The managed identity type",
+                  "type": "string",
+                  "enum": ["SystemAssigned", "UserAssigned"],
+                  "default": "SystemAssigned",
+                  "enumDescriptions": [
+                    "Use a system-assigned managed identity",
+                    "Use a user-assigned managed identity"
+                  ]
+                },
+                "clientId": {
+                  "title": "Client ID",
+                  "description": "The user-assigned managed identity client ID",
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "resourceId": {
+                  "title": "Resource ID",
+                  "description": "The user-assigned managed identity resource ID",
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -411,9 +422,7 @@
                         "excludedhosts": {
                           "description": "Customize the list of hosts to allow even if they contain an excluded host as a substring",
                           "type": "array",
-                          "default": [
-                            "schema.management.azure.com"
-                          ],
+                          "default": ["schema.management.azure.com"],
                           "items": {
                             "$id": "#/analyzers/core/rules/no-hardcoded-env-urls/excludedhosts/items",
                             "title": "Items",
@@ -720,19 +729,12 @@
         "indentKind": {
           "type": "string",
           "description": "The indentation kind",
-          "enum": [
-            "Space",
-            "Tab"
-          ]
+          "enum": ["Space", "Tab"]
         },
         "newlineKind": {
           "type": "string",
           "description": "The newline kind",
-          "enum": [
-            "LF",
-            "CRLF",
-            "CR"
-          ]
+          "enum": ["LF", "CRLF", "CR"]
         },
         "indentSize": {
           "type": "integer",


### PR DESCRIPTION
The PR adds the following Bicep configuration section to support authentication using user-assigned identities:

```diff
{
  "cloud": {
    "currentProfile": "AzureCloud",
+   "credentialOptions": {
+      "managedIdentity": {
+        "type": "SystemAssigned | UserAssigned",
+        "clientId": "User-assigned identity cliend ID",
+        "resourceId": "User-assigned identity resource ID"
+      }
+    }
  }
}
```

Fixes #12185.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12265)