### PR TITLE
Rename `IAzResourceTypeLoader` and `IAzResourceTypeLoaderFactory` classes since they are not specific to AZ

### DIFF
--- a/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Bicep.Decompiler;
@@ -54,7 +55,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
-        .AddSingleton<IAzResourceTypeLoader, AzResourceTypeLoader>()
+        .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
         .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
         .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()

--- a/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
@@ -56,7 +56,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
         .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
-        .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
+        .AddSingleton<IResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
         .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()
         .AddSingleton<IModuleDispatcher, ModuleDispatcher>()

--- a/src/Bicep.Core.IntegrationTests/Extensibility/TestExtensibilityNamespaceProvider.cs
+++ b/src/Bicep.Core.IntegrationTests/Extensibility/TestExtensibilityNamespaceProvider.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Bicep.Core.Features;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.IntegrationTests.Extensibility;
@@ -14,7 +13,7 @@ public class TestExtensibilityNamespaceProvider : INamespaceProvider
 {
     private readonly INamespaceProvider defaultNamespaceProvider;
 
-    public TestExtensibilityNamespaceProvider(IAzResourceTypeLoaderFactory azResourceTypeLoaderFactory)
+    public TestExtensibilityNamespaceProvider(IResourceTypeLoaderFactory azResourceTypeLoaderFactory)
     {
         defaultNamespaceProvider = new DefaultNamespaceProvider(azResourceTypeLoaderFactory);
     }

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -13,6 +13,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Json;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Configuration;
 using Bicep.Core.UnitTests.Features;
@@ -64,7 +65,7 @@ namespace Bicep.Core.UnitTests
 
         public static readonly IFeatureProvider Features = new OverriddenFeatureProvider(new FeatureProvider(BuiltInConfiguration), FeatureOverrides);
 
-        public static readonly IAzResourceTypeLoader BuiltinAzResourceTypeLoader = BicepTestConstants.AzResourceTypeLoaderFactory.GetResourceTypeLoader(null, BicepTestConstants.Features)!;
+        public static readonly IResourceTypeLoader BuiltinAzResourceTypeLoader = BicepTestConstants.AzResourceTypeLoaderFactory.GetResourceTypeLoader(null, BicepTestConstants.Features)!;
 
         public static readonly IServiceProvider EmptyServiceProvider = new Mock<IServiceProvider>(MockBehavior.Loose).Object;
         public static readonly IArtifactRegistryProvider RegistryProvider = new DefaultArtifactRegistryProvider(EmptyServiceProvider, FileResolver, ClientFactory, TemplateSpecRepositoryFactory, FeatureProviderFactory, BuiltInOnlyConfigurationManager);

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -41,7 +41,7 @@ namespace Bicep.Core.UnitTests
 
         public static readonly IFeatureProviderFactory FeatureProviderFactory = new OverriddenFeatureProviderFactory(new FeatureProviderFactory(ConfigurationManager), FeatureOverrides);
 
-        public static readonly IAzResourceTypeLoaderFactory AzResourceTypeLoaderFactory = new AzResourceTypeLoaderFactory(FeatureProviderFactory, new AzResourceTypeLoader());
+        public static readonly IResourceTypeLoaderFactory AzResourceTypeLoaderFactory = new AzResourceTypeLoaderFactory(FeatureProviderFactory, new AzResourceTypeLoader());
 
         public static readonly INamespaceProvider NamespaceProvider = new DefaultNamespaceProvider(AzResourceTypeLoaderFactory);
 

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
@@ -12,7 +12,7 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.Text;
-using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
@@ -45,7 +45,7 @@ public class LinterRuleTestsBase
         OnCompileErrors OnCompileErrors = OnCompileErrors.Default,
         IncludePosition IncludePosition = IncludePosition.Default,
         Func<RootConfiguration, RootConfiguration>? ConfigurationPatch = null,
-        IAzResourceTypeLoader? AzResourceTypeLoader = null,
+        IResourceTypeLoader? AzResourceTypeLoader = null,
         (string path, string contents)[]? AdditionalFiles = null,
         FeatureProviderOverrides? FeatureOverrides = null
     );

--- a/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
         .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
-        .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
+        .AddSingleton<IResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
         .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()
         .AddSingleton<IModuleDispatcher, ModuleDispatcher>()
@@ -104,7 +104,7 @@ public static class IServiceCollectionExtensions
 
     public static IServiceCollection WithAzResourceTypeLoaderFactory(this IServiceCollection services, IResourceTypeLoader loader)
     {
-        var factory = StrictMock.Of<IAzResourceTypeLoaderFactory>();
+        var factory = StrictMock.Of<IResourceTypeLoaderFactory>();
         factory.Setup(m => m.GetResourceTypeLoader(It.IsAny<string>(), It.IsAny<IFeatureProvider>())).Returns(loader);
         factory.Setup(m => m.GetBuiltInTypeLoader()).Returns(loader);
         return Register(services, factory.Object);

--- a/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ public static class IServiceCollectionExtensions
 {
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
-        .AddSingleton<IAzResourceTypeLoader, AzResourceTypeLoader>()
+        .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
         .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
         .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()
@@ -102,7 +102,7 @@ public static class IServiceCollectionExtensions
         => services.WithAzResourceTypeLoaderFactory(
             TestTypeHelper.CreateAzResourceTypeLoaderWithTypes(resourceTypes));
 
-    public static IServiceCollection WithAzResourceTypeLoaderFactory(this IServiceCollection services, IAzResourceTypeLoader loader)
+    public static IServiceCollection WithAzResourceTypeLoaderFactory(this IServiceCollection services, IResourceTypeLoader loader)
     {
         var factory = StrictMock.Of<IAzResourceTypeLoaderFactory>();
         factory.Setup(m => m.GetResourceTypeLoader(It.IsAny<string>(), It.IsAny<IFeatureProvider>())).Returns(loader);

--- a/src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs
+++ b/src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Bicep.Core.Resources;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Az;
 using Moq;
 
 namespace Bicep.Core.UnitTests.Mock
@@ -6338,10 +6337,10 @@ Fake.Support/supportTickets/communications@2419-05-01-preview
 Fake.Support/supportTickets/communications@2420-04-01
 Fake.Web/publishingCredentials@2415-08-01";
 
-        public static Mock<IAzResourceTypeLoader> GetAzResourceTypeLoaderWithInjectedTypes(string[] resourceTypes)
+        public static Mock<IResourceTypeLoader> GetAzResourceTypeLoaderWithInjectedTypes(string[] resourceTypes)
         {
             var fakeResourceTypeReferences = FakeResourceTypes.GetFakeResourceTypeReferences(resourceTypes);
-            var typesLoader = StrictMock.Of<IAzResourceTypeLoader>();
+            var typesLoader = StrictMock.Of<IResourceTypeLoader>();
             typesLoader.Setup(m => m.LoadType(It.IsAny<ResourceTypeReference>()))
                 .Returns<ResourceTypeReference>((tr) => new ResourceTypeComponents(
                     tr,

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -10,7 +10,6 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.FileSystem;
 using Bicep.Core.Workspaces;
@@ -62,7 +61,7 @@ namespace Bicep.Core.UnitTests.Utils
             return Compile(services.BuildCompilation(sourceFileDict, entryUri));
         }
 
-        public static CompilationResult Compile(IAzResourceTypeLoader resourceTypeLoader, params (string fileName, string fileContents)[] files)
+        public static CompilationResult Compile(IResourceTypeLoader resourceTypeLoader, params (string fileName, string fileContents)[] files)
             => Compile(new ServiceBuilder().WithFeatureOverrides(BicepTestConstants.FeatureOverrides).WithAzResourceTypeLoader(resourceTypeLoader), files);
 
         public static CompilationResult Compile(params (string fileName, string fileContents)[] files)

--- a/src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs
@@ -10,7 +10,6 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.Workspaces;
 
@@ -45,7 +44,7 @@ public static class ServiceBuilderExtensions
     public static ServiceBuilder WithAzResources(this ServiceBuilder serviceBuilder, IEnumerable<ResourceTypeComponents> resourceTypes)
         => serviceBuilder.WithRegistration(x => x.WithAzResources(resourceTypes));
 
-    public static ServiceBuilder WithAzResourceTypeLoader(this ServiceBuilder serviceBuilder, IAzResourceTypeLoader azResourceTypeLoader)
+    public static ServiceBuilder WithAzResourceTypeLoader(this ServiceBuilder serviceBuilder, IResourceTypeLoader azResourceTypeLoader)
         => serviceBuilder.WithRegistration(x => x.WithAzResourceTypeLoaderFactory(azResourceTypeLoader));
 
     public static ServiceBuilder WithEmptyAzResources(this ServiceBuilder serviceBuilder)

--- a/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
@@ -39,9 +39,9 @@ namespace Bicep.Core.UnitTests.Utils
         public static IResourceTypeLoader CreateAzResourceTypeLoaderWithTypes(IEnumerable<ResourceTypeComponents> resourceTypes)
             => new TestResourceTypeLoader(resourceTypes);
 
-        public static IAzResourceTypeLoaderFactory CreateAzResourceTypeLoaderFactory(IResourceTypeLoader loader)
+        public static IResourceTypeLoaderFactory CreateAzResourceTypeLoaderFactory(IResourceTypeLoader loader)
         {
-            var factory = StrictMock.Of<IAzResourceTypeLoaderFactory>();
+            var factory = StrictMock.Of<IResourceTypeLoaderFactory>();
             factory.Setup(m => m.GetResourceTypeLoader(It.IsAny<string>(), It.IsAny<IFeatureProvider>())).Returns(loader);
             factory.Setup(m => m.GetBuiltInTypeLoader()).Returns(loader);
             return factory.Object;

--- a/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
@@ -17,7 +17,7 @@ namespace Bicep.Core.UnitTests.Utils
 {
     public static class TestTypeHelper
     {
-        private class TestResourceTypeLoader : IAzResourceTypeLoader
+        private class TestResourceTypeLoader : IResourceTypeLoader
         {
             private readonly ImmutableDictionary<ResourceTypeReference, ResourceTypeComponents> resourceTypes;
 
@@ -33,13 +33,13 @@ namespace Bicep.Core.UnitTests.Utils
                 => resourceTypes.Keys;
         }
 
-        public static IAzResourceTypeLoader CreateEmptyAzResourceTypeLoader()
+        public static IResourceTypeLoader CreateEmptyAzResourceTypeLoader()
             => new TestResourceTypeLoader(Enumerable.Empty<ResourceTypeComponents>());
 
-        public static IAzResourceTypeLoader CreateAzResourceTypeLoaderWithTypes(IEnumerable<ResourceTypeComponents> resourceTypes)
+        public static IResourceTypeLoader CreateAzResourceTypeLoaderWithTypes(IEnumerable<ResourceTypeComponents> resourceTypes)
             => new TestResourceTypeLoader(resourceTypes);
 
-        public static IAzResourceTypeLoaderFactory CreateAzResourceTypeLoaderFactory(IAzResourceTypeLoader loader)
+        public static IAzResourceTypeLoaderFactory CreateAzResourceTypeLoaderFactory(IResourceTypeLoader loader)
         {
             var factory = StrictMock.Of<IAzResourceTypeLoaderFactory>();
             factory.Setup(m => m.GetResourceTypeLoader(It.IsAny<string>(), It.IsAny<IFeatureProvider>())).Returns(loader);

--- a/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/DefaultNamespaceProvider.cs
@@ -21,9 +21,9 @@ public class DefaultNamespaceProvider : INamespaceProvider
         string? version = null);
     private readonly ImmutableDictionary<string, GetNamespaceDelegate> providerLookup;
 
-    private readonly IAzResourceTypeLoaderFactory azResourceTypeLoaderFactory;
+    private readonly IResourceTypeLoaderFactory azResourceTypeLoaderFactory;
 
-    public DefaultNamespaceProvider(IAzResourceTypeLoaderFactory azResourceTypeLoaderFactory)
+    public DefaultNamespaceProvider(IResourceTypeLoaderFactory azResourceTypeLoaderFactory)
     {
         var builtInAzResourceTypeLoaderVersion = "1.0.0";
         var builtInAzResourceTypeProvider = new AzResourceTypeProvider(azResourceTypeLoaderFactory.GetBuiltInTypeLoader(), builtInAzResourceTypeLoaderVersion);

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoader.cs
@@ -11,7 +11,7 @@ using Bicep.Core.Resources;
 
 namespace Bicep.Core.TypeSystem.Az
 {
-    public class AzResourceTypeLoader : IAzResourceTypeLoader
+    public class AzResourceTypeLoader : IResourceTypeLoader
     {
         private readonly ITypeLoader typeLoader;
         private readonly AzResourceTypeFactory resourceTypeFactory;

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoaderFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoaderFactory.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace Bicep.Core.TypeSystem.Az
 {
-    public class AzResourceTypeLoaderFactory : IAzResourceTypeLoaderFactory
+    public class AzResourceTypeLoaderFactory : IResourceTypeLoaderFactory
     {
         private const string typesArtifactFilename = "types.tgz";
         private const string BuiltInLoaderKey = "builtin";

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoaderFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeLoaderFactory.cs
@@ -17,9 +17,9 @@ namespace Bicep.Core.TypeSystem.Az
 
         private readonly IFeatureProviderFactory featureProviderFactory;
 
-        private Dictionary<string, IAzResourceTypeLoader> resourceTypeLoaders;
+        private Dictionary<string, IResourceTypeLoader> resourceTypeLoaders;
 
-        public AzResourceTypeLoaderFactory(IFeatureProviderFactory featureProviderFactory, IAzResourceTypeLoader defaultAzResourceTypeLoader)
+        public AzResourceTypeLoaderFactory(IFeatureProviderFactory featureProviderFactory, IResourceTypeLoader defaultAzResourceTypeLoader)
         {
             this.featureProviderFactory = featureProviderFactory;
             this.resourceTypeLoaders = new() {
@@ -27,12 +27,12 @@ namespace Bicep.Core.TypeSystem.Az
             };
         }
 
-        public IAzResourceTypeLoader GetBuiltInTypeLoader()
+        public IResourceTypeLoader GetBuiltInTypeLoader()
         {
             return resourceTypeLoaders[BuiltInLoaderKey];
         }
 
-        public IAzResourceTypeLoader? GetResourceTypeLoader(string? providerVersion, IFeatureProvider features)
+        public IResourceTypeLoader? GetResourceTypeLoader(string? providerVersion, IFeatureProvider features)
         {
             if (!features.DynamicTypeLoadingEnabled || providerVersion is null)
             {

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeProvider.cs
@@ -71,7 +71,7 @@ namespace Bicep.Core.TypeSystem.Az
 
         public string Version { get; } = "1.0.0";
 
-        private readonly IAzResourceTypeLoader resourceTypeLoader;
+        private readonly IResourceTypeLoader resourceTypeLoader;
         private readonly ResourceTypeCache definedTypeCache;
         private readonly ResourceTypeCache generatedTypeCache;
 
@@ -191,7 +191,7 @@ namespace Bicep.Core.TypeSystem.Az
             }, null));
         }
 
-        public AzResourceTypeProvider(IAzResourceTypeLoader resourceTypeLoader, string providerVersion)
+        public AzResourceTypeProvider(IResourceTypeLoader resourceTypeLoader, string providerVersion)
             : base(resourceTypeLoader.GetAvailableTypes().ToImmutableHashSet())
         {
             this.Version = providerVersion;

--- a/src/Bicep.Core/TypeSystem/Az/IAzResourceTypeLoaderFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/IAzResourceTypeLoaderFactory.cs
@@ -7,8 +7,8 @@ namespace Bicep.Core.TypeSystem.Az
 {
     public interface IAzResourceTypeLoaderFactory
     {
-        IAzResourceTypeLoader? GetResourceTypeLoader(string? version, IFeatureProvider features);
+        IResourceTypeLoader? GetResourceTypeLoader(string? version, IFeatureProvider features);
 
-        IAzResourceTypeLoader GetBuiltInTypeLoader();
+        IResourceTypeLoader GetBuiltInTypeLoader();
     }
 }

--- a/src/Bicep.Core/TypeSystem/IResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/IResourceTypeLoader.cs
@@ -3,9 +3,9 @@
 using System.Collections.Generic;
 using Bicep.Core.Resources;
 
-namespace Bicep.Core.TypeSystem.Az
+namespace Bicep.Core.TypeSystem
 {
-    public interface IAzResourceTypeLoader
+    public interface IResourceTypeLoader
     {
         ResourceTypeComponents LoadType(ResourceTypeReference reference);
 

--- a/src/Bicep.Core/TypeSystem/IResourceTypeLoaderFactory.cs
+++ b/src/Bicep.Core/TypeSystem/IResourceTypeLoaderFactory.cs
@@ -3,9 +3,9 @@
 
 using Bicep.Core.Features;
 
-namespace Bicep.Core.TypeSystem.Az
+namespace Bicep.Core.TypeSystem
 {
-    public interface IAzResourceTypeLoaderFactory
+    public interface IResourceTypeLoaderFactory
     {
         IResourceTypeLoader? GetResourceTypeLoader(string? version, IFeatureProvider features);
 

--- a/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
@@ -15,7 +15,6 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Navigation;
 using Bicep.Core.Text;
 using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -58,7 +57,7 @@ namespace Bicep.LangServer.IntegrationTests
         private async Task<LanguageServerHelper> StartLanguageServer(
             Listeners listeners,
             IAzResourceProvider azResourceProvider,
-            IAzResourceTypeLoader azResourceTypeLoader)
+            IResourceTypeLoader azResourceTypeLoader)
         {
             return await LanguageServerHelper.StartServer(
                 this.TestContext,

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerHelper.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Bicep.Core;
 using Bicep.Core.Configuration;
-using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
@@ -93,7 +93,7 @@ namespace Bicep.LangServer.UnitTests
         public static ICompilationProvider CreateEmptyCompilationProvider(IConfigurationManager? configurationManager = null)
         {
             var helper = ServiceBuilder.Create(services => services
-                .AddSingleton<IAzResourceTypeLoader>(TestTypeHelper.CreateEmptyAzResourceTypeLoader())
+                .AddSingleton<IResourceTypeLoader>(TestTypeHelper.CreateEmptyAzResourceTypeLoader())
                 .AddSingletonIfNonNull<IConfigurationManager>(configurationManager)
                 .AddSingleton<BicepCompilationProvider>());
 

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -24,7 +24,7 @@ using Bicep.Core.Rewriters;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
-using Bicep.Core.TypeSystem.Az;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.Workspaces;
 using Bicep.LanguageServer.CompilationManager;
 using Bicep.LanguageServer.Extensions;
@@ -51,14 +51,14 @@ namespace Bicep.LanguageServer.Handlers
         private readonly ILanguageServerFacade server;
         private readonly ICompilationManager compilationManager;
         private readonly IAzResourceProvider azResourceProvider;
-        private readonly IAzResourceTypeLoaderFactory azResourceTypeLoaderFactory;
+        private readonly IResourceTypeLoaderFactory azResourceTypeLoaderFactory;
         private readonly TelemetryAndErrorHandlingHelper<Unit> helper;
 
         public InsertResourceHandler(
             ILanguageServerFacade server,
             ICompilationManager compilationManager,
             IAzResourceProvider azResourceProvider,
-            IAzResourceTypeLoaderFactory azResourceTypeLoaderFactory,
+            IResourceTypeLoaderFactory azResourceTypeLoaderFactory,
             ITelemetryProvider telemetryProvider)
         {
             this.server = server;

--- a/src/Bicep.LangServer/IServiceCollectionExtensions.cs
+++ b/src/Bicep.LangServer/IServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Bicep.Decompiler;
@@ -22,7 +23,7 @@ public static class IServiceCollectionExtensions
 {
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
-        .AddSingleton<IAzResourceTypeLoader, AzResourceTypeLoader>()
+        .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
         .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
         .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()

--- a/src/Bicep.LangServer/IServiceCollectionExtensions.cs
+++ b/src/Bicep.LangServer/IServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
         .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
-        .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
+        .AddSingleton<IResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
         .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()
         .AddSingleton<IModuleDispatcher, ModuleDispatcher>()

--- a/src/Bicep.RegistryModuleTool/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Bicep.RegistryModuleTool/Extensions/IServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,7 @@ namespace Bicep.RegistryModuleTool.Extensions
         public static IServiceCollection AddBicepCompiler(this IServiceCollection services) => services
             .AddSingleton<IFileSystem, FileSystem>()
             .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
-            .AddSingleton<IAzResourceTypeLoader, AzResourceTypeLoader>()
+            .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
             .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
             .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
             .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()

--- a/src/Bicep.RegistryModuleTool/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Bicep.RegistryModuleTool/Extensions/IServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace Bicep.RegistryModuleTool.Extensions
             .AddSingleton<IFileSystem, FileSystem>()
             .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
             .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
-            .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
+            .AddSingleton<IResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
             .AddSingleton<IContainerRegistryClientFactory, ContainerRegistryClientFactory>()
             .AddSingleton<ITemplateSpecRepositoryFactory, TemplateSpecRepositoryFactory>()
             .AddSingleton<IModuleDispatcher, ModuleDispatcher>()

--- a/src/Bicep.Wasm/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Wasm/IServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ public static class IServiceCollectionExtensions
 {
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
         .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
-        .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
+        .AddSingleton<IResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
         .AddSingleton<IModuleDispatcher, ModuleDispatcher>()
         .AddSingleton<IArtifactRegistryProvider, EmptyModuleRegistryProvider>()

--- a/src/Bicep.Wasm/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Wasm/IServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Az;
 using Bicep.Core.Utils;
 using Bicep.Decompiler;
@@ -22,7 +23,7 @@ namespace Bicep.Wasm;
 public static class IServiceCollectionExtensions
 {
     public static IServiceCollection AddBicepCore(this IServiceCollection services) => services
-        .AddSingleton<IAzResourceTypeLoader, AzResourceTypeLoader>()
+        .AddSingleton<IResourceTypeLoader, AzResourceTypeLoader>()
         .AddSingleton<IAzResourceTypeLoaderFactory, AzResourceTypeLoaderFactory>()
         .AddSingleton<INamespaceProvider, DefaultNamespaceProvider>()
         .AddSingleton<IModuleDispatcher, ModuleDispatcher>()


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12282)