### PR TITLE
Import completion improvements

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ImportTests.cs
@@ -70,7 +70,7 @@ provider 'br/public:az@1.0.0'
 provider
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP201", DiagnosticLevel.Error, "Expected a provider specification string of format \"<providerName>@<providerVersion>\", the \"*\" character, or the \"{\" character at this location."),
+                ("BCP201", DiagnosticLevel.Error, "Expected a provider specification string of format \"<providerName>@<providerVersion>\" at this location."),
             });
 
             result = CompilationHelper.Compile(ServicesWithImports, @"

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1220,10 +1220,10 @@ namespace Bicep.Core.Diagnostics
                 "BCP200",
                 $"{BuildInvalidOciArtifactReferenceClause(aliasName, badRef)} The registry \"{badRegistry}\" exceeds the maximum length of {maxLength} characters.");
 
-            public ErrorDiagnostic ExpectedProviderSpecificationOrCompileTimeImportExpression() => new(
+            public ErrorDiagnostic ExpectedProviderSpecification() => new(
                 TextSpan,
                 "BCP201",
-                "Expected a provider specification string of format \"<providerName>@<providerVersion>\", the \"*\" character, or the \"{\" character at this location.");
+                "Expected a provider specification string of format \"<providerName>@<providerVersion>\" at this location.");
 
             public ErrorDiagnostic ExpectedProviderAliasName() => new(
                 TextSpan,

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -4124,6 +4124,21 @@ var arr6 = [
         }
 
         [TestMethod]
+        public async Task Compile_time_imports_offer_import_expression_completions()
+        {
+            var fileWithCursors = """
+              import |
+              """;
+
+            var (text, cursor) = ParserHelper.GetFileWithSingleCursor(fileWithCursors, '|');
+            var file = await new ServerRequestHelper(TestContext, ServerWithCompileTimeImportsEnabled).OpenFile(text);
+
+            var completions = await file.RequestCompletion(cursor);
+            completions.Should().Contain(x => x.Label == "{}");
+            completions.Should().Contain(x => x.Label == "* as");
+        }
+
+        [TestMethod]
         public async Task Compile_time_imports_offer_as_keyword_completions()
         {
             var fileWithCursors = """

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -29,24 +29,24 @@ namespace Bicep.LanguageServer.Completions
 
         private static readonly CompositeSyntaxPattern ExpectingImportSpecification = CompositeSyntaxPattern.Create(
             cursor: '|',
-            "import |",
-            "import |'kuber'",
-            "import 'kuber|'");
+            "provider |",
+            "provider |'kuber'",
+            "provider 'kuber|'");
 
         private static readonly CompositeSyntaxPattern ExpectingImportWithOrAsKeyword = CompositeSyntaxPattern.Create(
             cursor: '|',
-            "import 'kubernetes@1.0.0' |",
-            "import 'kubernetes@1.0.0' a|",
-            "import 'kubernetes@1.0.0' |b");
+            "provider 'kubernetes@1.0.0' |",
+            "provider 'kubernetes@1.0.0' a|",
+            "provider 'kubernetes@1.0.0' |b");
 
         private static readonly CompositeSyntaxPattern ExpectingImportConfig = CompositeSyntaxPattern.Create(
             cursor: '|',
-            "import 'kubernetes@1.0.0' with |",
-            "import 'kubernetes@1.0.0' with | as foo");
+            "provider 'kubernetes@1.0.0' with |",
+            "provider 'kubernetes@1.0.0' with | as foo");
 
         private static readonly SyntaxPattern ExpectingImportAsKeyword = SyntaxPattern.Create(
             cursor: '|',
-            "import 'kubernetes@1.0.0' with { foo: true } |");
+            "provider 'kubernetes@1.0.0' with { foo: true } |");
 
         // completions will replace only these token types
         // all others will result in an insertion upon completion commit

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -789,13 +789,10 @@ namespace Bicep.LanguageServer.Completions
 
         private static bool IsImportIdentifierContext(List<SyntaxBase> matchingNodes, int offset) =>
             // import |
-            // because extensibility and compile-time imports share a keyword at present, an incomplete statement will be parsed as a ProviderDeclarationSyntax node instead of a CompileTimeImportDeclarationSyntax node
-            SyntaxMatcher.IsTailMatch<ProviderDeclarationSyntax>(matchingNodes, declaration => declaration.SpecificationString is SkippedTriviaSyntax &&
-                declaration.SpecificationString.Span.ContainsInclusive(offset) &&
-                declaration.WithClause is SkippedTriviaSyntax &&
-                declaration.WithClause.Span.Length == 0 &&
-                declaration.AsClause is SkippedTriviaSyntax &&
-                declaration.AsClause.Span.Length == 0);
+            SyntaxMatcher.IsTailMatch<CompileTimeImportDeclarationSyntax>(matchingNodes, declaration => declaration.ImportExpression is SkippedTriviaSyntax &&
+                declaration.ImportExpression.Span.ContainsInclusive(offset) &&
+                declaration.FromClause is SkippedTriviaSyntax &&
+                declaration.FromClause.Span.Length == 0);
 
         private static bool IsImportedSymbolListItemContext(List<SyntaxBase> matchingNodes, int offset) =>
             SyntaxMatcher.IsTailMatch<ImportedSymbolsListItemSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, token) => token.Type == TokenType.Identifier) ||


### PR DESCRIPTION
Small follow-up to #12281 to improve error messaging on incomplete `import` statements
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12289)