### PR TITLE
Block direct resource access in top level properties

### DIFF
--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
@@ -117,14 +117,6 @@ namespace Bicep.Core.TypeSystem
                 }
             }
 
-            if (this.DeployTimeConstantContainer is not IfConditionSyntax and not ForSyntax)
-            {
-                // We can skip validation if we are inside a resource/module body or a function call, because the
-                // type checker should be able to produce type errors if the reference is invalid. There are also
-                // locations where referencing an entire resource/module module body is expected (e.g., scope).
-                return;
-            }
-
             switch (this.SemanticModel.Binder.GetParent(syntax))
             {
                 // var foo = [for x in [...]: {


### PR DESCRIPTION
Update DTC validation logic to ensure direct resource access is blocked in top level resource properties.

Fixes #11958.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12291)