### PR TITLE
Dispose named pipe in Lang server

### DIFF
--- a/src/Bicep.LangServer/Program.cs
+++ b/src/Bicep.LangServer/Program.cs
@@ -80,7 +80,8 @@ namespace Bicep.LanguageServer
                 server = new(
                     options => options
                         .WithInput(clientPipe)
-                        .WithOutput(clientPipe));
+                        .WithOutput(clientPipe)
+                        .RegisterForDisposal(clientPipe));
             }
             else if (options.Socket is { } port)
             {


### PR DESCRIPTION
I noticed we're not currently doing this - feels like a possible explanation for why we sometimes leave orphaned language server processes running on OSX. This is pure speculation, but feels like disposing correctly can't be a bad thing!

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12332)