### PR TITLE
Skip live tests if CI is triggered manually from a branch that is not `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -650,7 +650,7 @@ jobs:
     name: Check secret access
     runs-on: ubuntu-latest
     outputs:
-      access_verified: ${{ steps.check-access.outputs.verified }}
+      access_verified: ${{ steps.check-access.outputs.verified && !(github.event_name == 'workflow_dispatch' && github.ref != 'refs/head/main') }}
       
     steps:
       - id: check-access


### PR DESCRIPTION
Confirmed that live tests are skipped with this CI run triggered manually from the PR branch: https://github.com/Azure/bicep/actions/runs/6775785709.

Closes #12392.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12393)