### PR TITLE
Use a symbolic name target if any functions are imported

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -1745,4 +1745,24 @@ public class CompileTimeImportTests
         result.Should().NotHaveAnyCompilationBlockingDiagnostics();
         result.Template.Should().HaveValueAtPath("parameters.foo.items.$ref", "#/definitions/Foo");
     }
+
+    // https://github.com/Azure/bicep/issues/12401
+    [TestMethod]
+    public void Symbolic_name_target_is_used_when_function_import_closure_includes_a_user_defined_type()
+    {
+        var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImportsAndUserDefinedFunctions,
+            ("main.bicep", """
+                import { capitalizer } from 'function.bicep'
+                """),
+            ("function.bicep", """
+                type myString = string
+
+                @export()
+                func capitalizer(in myString) string => toUpper(in)
+                """));
+
+        result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+        result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
+        result.Template.Should().HaveValueAtPath("functions[0].members.capitalizer.parameters[0].$ref", "#/definitions/_1.myString");
+    }
 }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -25,6 +25,8 @@ namespace Bicep.Core.Emit
                 model.Root.TypeDeclarations.Any() ||
                 // there are any user-defined types imported
                 model.Root.ImportedTypes.Any() ||
+                // there are any functions imported (it's impossible to tell here if the functions use user-defined types for their parameter or output declarations)
+                model.Root.ImportedFunctions.Any() ||
                 // any user-defined type declaration syntax is used (e.g., in a `param` or `output` statement)
                 SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
                     seed: false,


### PR DESCRIPTION
Resolves #12401 

I went for a simpler fix here of just always using a symbolic name template target if user-defined functions are imported. Determining whether an imported function uses user-defined types requires calculating the full import closure, which is too expensive to do in the EmitterSettings constructor.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12408)