### PR TITLE
Update UseResourceIdFunctionsRule to account for nullable and aggregate types

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseResourceIdFunctionsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseResourceIdFunctionsRuleTests.cs
@@ -1643,6 +1643,149 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             },
             DisplayName = "Regress #8424"
         )]
+        [DataRow("""
+            param location string = resourceGroup().location
+
+            param webSiteName string
+
+            param appServicePlanId string
+
+            param acrPullMI {
+              clientId: string
+              id: string
+            }
+
+            resource appService 'Microsoft.Web/sites@2022-09-01' = {
+              name: webSiteName
+              location: location
+              properties: {
+                serverFarmId: appServicePlanId
+                siteConfig: {
+                  acrUseManagedIdentityCreds: true
+                  acrUserManagedIdentityID: acrPullMI.clientId
+                }
+              }
+              identity: {
+                type: 'UserAssigned'
+                userAssignedIdentities: {
+                  '${acrPullMI.id}': {}
+                }
+              }
+            }
+            """,
+            new string[]
+            {
+                // pass
+            },
+            DisplayName = "Parameter properties"
+        )]
+        [DataRow("""
+            param location string = resourceGroup().location
+
+            param webSiteName string
+
+            param appServicePlanId string
+
+            param acrPullMI {
+              clientId: string?
+              id: string
+            }
+
+            resource appService 'Microsoft.Web/sites@2022-09-01' = {
+              name: webSiteName
+              location: location
+              properties: {
+                serverFarmId: appServicePlanId
+                siteConfig: {
+                  acrUseManagedIdentityCreds: true
+                  acrUserManagedIdentityID: (acrPullMI.clientId!)
+                }
+              }
+              identity: {
+                type: 'UserAssigned'
+                userAssignedIdentities: {
+                  '${acrPullMI.id}': {}
+                }
+              }
+            }
+            """,
+            new string[]
+            {
+                // pass
+            },
+            DisplayName = "Nullable parameter properties"
+        )]
+        [DataRow("""
+            param location string = resourceGroup().location
+
+            param webSiteName string
+
+            param appServicePlanId string
+
+            param acrPullMIId string
+
+            param acrPullMIClientId string?
+
+            resource appService 'Microsoft.Web/sites@2022-09-01' = {
+              name: webSiteName
+              location: location
+              properties: {
+                serverFarmId: appServicePlanId
+                siteConfig: {
+                  acrUseManagedIdentityCreds: true
+                  acrUserManagedIdentityID: acrPullMIClientId!
+                }
+              }
+              identity: {
+                type: 'UserAssigned'
+                userAssignedIdentities: {
+                  '${acrPullMIId}': {}
+                }
+              }
+            }
+            """,
+            new string[]
+            {
+                // pass
+            },
+            DisplayName = "Nullable parameters"
+        )]
+        [DataRow("""
+            param location string = resourceGroup().location
+
+            param webSiteName string
+
+            param appServicePlanId string
+
+            param acrPullMIId string
+
+            @minLength(1)
+            param acrPullMIClientIds string[]
+
+            resource appService 'Microsoft.Web/sites@2022-09-01' = {
+              name: webSiteName
+              location: location
+              properties: {
+                serverFarmId: appServicePlanId
+                siteConfig: {
+                  acrUseManagedIdentityCreds: true
+                  acrUserManagedIdentityID: acrPullMIClientIds[0]
+                }
+              }
+              identity: {
+                type: 'UserAssigned'
+                userAssignedIdentities: {
+                  '${acrPullMIId}': {}
+                }
+              }
+            }
+            """,
+            new string[]
+            {
+                // pass
+            },
+            DisplayName = "Array parameter elements"
+        )]
         [DataTestMethod]
         public void Test(string text, string[] expectedMessages)
         {

--- a/src/Bicep.Core/Analyzers/Linter/Common/TypeExtensions.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/TypeExtensions.cs
@@ -17,6 +17,12 @@ namespace Bicep.Core.Analyzers.Linter.Common
         }
 
         /// <summary>
+        /// True if the given type symbol is a nullable string type (and not "any")
+        /// </summary>
+        public static bool IsNullableString(this TypeSymbol typeSymbol)
+            => TypeHelper.TryRemoveNullability(typeSymbol) is TypeSymbol nonNull && nonNull.IsString();
+
+        /// <summary>
         /// True if the given type symbol is an object type (and not "any")
         /// </summary>
         public static bool IsObject(this TypeSymbol typeSymbol)

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
@@ -10,8 +10,6 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
-using Bicep.Core.TypeSystem;
-using Microsoft.Extensions.FileSystemGlobbing.Internal;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 
 namespace Bicep.Core.Analyzers.Linter.Rules
@@ -240,7 +238,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             private static Failure? AnalyzeIdProperty(SemanticModel model, ObjectPropertySyntax propertySyntax)
             {
                 var type = model.GetTypeInfo(propertySyntax.Value);
-                if (type.IsString() || (TypeHelper.TryRemoveNullability(type) is TypeSymbol nonNull && nonNull.IsString()))
+                if (type.IsString() || type.IsNullableString())
                 {
                     return AnalyzeIdPropertyValue(model, propertySyntax, propertySyntax.Value, Array.Empty<DeclaredSymbol>());
                 }


### PR DESCRIPTION
Resolves #12419 

The `UseResourceIdFunctionsRule` linter rule doesn't report any diagnostics if a parameter is supplied for a resource property that expects a resource ID, but this exemption doesn't apply directly to parameter _properties_. This didn't raise any issues in the past because prior to the introduction of user-defined types, parameter properties would always have an `any` type, and the linter rule will only raise diagnostics on `string`-typed values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12421)