### PR TITLE
Deprecate Bicep CLI parameters using camel case

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
@@ -227,7 +227,7 @@ namespace Bicep.Cli.IntegrationTests
                 // Skip if input file is empty
                 return;
             }
-            var (output, error, result) = await Bicep("format", bicepFilePath, "--newLine", "LF");
+            var (output, error, result) = await Bicep("format", bicepFilePath, "--newline", "LF");
 
             // Should format successfully
             using (new AssertionScope())
@@ -270,7 +270,7 @@ namespace Bicep.Cli.IntegrationTests
                 // Skip if input file is empty
                 return;
             }
-            var (output, error, result) = await Bicep("format", bicepFilePath, "--newLine", "CRLF", "--insertFinalNewline");
+            var (output, error, result) = await Bicep("format", bicepFilePath, "--newLine", "CRLF", "--insert-final-newline");
 
             // Should format successfully
             using (new AssertionScope())
@@ -354,7 +354,7 @@ namespace Bicep.Cli.IntegrationTests
                 // Skip if input file is empty
                 return;
             }
-            var (output, error, result) = await Bicep("format", bicepFilePath, "--newLine", "CRLF", "--indentSize", "4");
+            var (output, error, result) = await Bicep("format", bicepFilePath, "--newLine", "CRLF", "--indent-size", "4");
 
             // Should format successfully
             using (new AssertionScope())
@@ -438,11 +438,11 @@ output myOutput string = 'hello!'
 output myOutput string = 'hello!'
             ");
 
-            var (output, error, result) = await Bicep("format", "--indentSize", "2", "--indentKind", "Tab", bicepPath);
+            var (output, error, result) = await Bicep("format", "--indent-size", "2", "--indent-kind", "Tab", bicepPath);
 
             result.Should().Be(1);
             output.Should().BeEmpty();
-            error.Should().MatchRegex(@"The --indentSize cannot be used when --indentKind is ""Tab""");
+            error.Should().MatchRegex(@"The --indent-size cannot be used when --indent-kind is ""Tab""");
         }
 
         [TestMethod]
@@ -458,6 +458,23 @@ output myOutput string = 'hello!'
             result.Should().Be(1);
             output.Should().BeEmpty();
             error.Should().MatchRegex(@"The specified output directory "".*outputdir"" does not exist");
+        }
+
+        [TestMethod]
+        public async Task Format_WithDeprecatedParams_PrintsDeprecationMessage()
+        {
+            var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"
+output myOutput string = 'hello!'
+            ");
+
+            var outputFileDir = FileHelper.GetResultFilePath(TestContext, "outputdir");
+            var (output, error, result) = await Bicep("format", bicepPath, "--indentKind", "space", "--indentSize", "4", "--insertFinalNewline");
+
+            result.Should().Be(0);
+            output.Should().BeEmpty();
+            error.Should().MatchRegex(@"DEPRECATED: The parameter --indentKind is deprecated and will be removed in a future version of Bicpe CLI. Use --indent-kind instead.");
+            error.Should().MatchRegex(@"DEPRECATED: The parameter --indentSize is deprecated and will be removed in a future version of Bicpe CLI. Use --indent-size instead.");
+            error.Should().MatchRegex(@"DEPRECATED: The parameter --insertFinalNewline is deprecated and will be removed in a future version of Bicpe CLI. Use --insert-final-newline instead.");
         }
 
         [TestMethod]

--- a/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
@@ -460,22 +460,21 @@ output myOutput string = 'hello!'
             error.Should().MatchRegex(@"The specified output directory "".*outputdir"" does not exist");
         }
 
-        [TestMethod]
-        public async Task Format_WithDeprecatedParams_PrintsDeprecationMessage()
-        {
-            var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"
-output myOutput string = 'hello!'
-            ");
+        // TODO: Enable this test once Azure CLI is updated to support the new parameters.
+        //[TestMethod]
+        //public async Task Format_WithDeprecatedParams_PrintsDeprecationMessage()
+        //{
+        //    var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", "output myOutput string = 'hello!'");
 
-            var outputFileDir = FileHelper.GetResultFilePath(TestContext, "outputdir");
-            var (output, error, result) = await Bicep("format", bicepPath, "--indentKind", "space", "--indentSize", "4", "--insertFinalNewline");
+        //    var outputFileDir = FileHelper.GetResultFilePath(TestContext, "outputdir");
+        //    var (output, error, result) = await Bicep("format", bicepPath, "--indentKind", "space", "--indentSize", "4", "--insertFinalNewline");
 
-            result.Should().Be(0);
-            output.Should().BeEmpty();
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --indentKind is deprecated and will be removed in a future version of Bicpe CLI. Use --indent-kind instead.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --indentSize is deprecated and will be removed in a future version of Bicpe CLI. Use --indent-size instead.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --insertFinalNewline is deprecated and will be removed in a future version of Bicpe CLI. Use --insert-final-newline instead.");
-        }
+        //    result.Should().Be(0);
+        //    output.Should().BeEmpty();
+        //    error.Should().MatchRegex(@"DEPRECATED: The parameter --indentKind is deprecated and will be removed in a future version of Bicpe CLI. Use --indent-kind instead.");
+        //    error.Should().MatchRegex(@"DEPRECATED: The parameter --indentSize is deprecated and will be removed in a future version of Bicpe CLI. Use --indent-size instead.");
+        //    error.Should().MatchRegex(@"DEPRECATED: The parameter --insertFinalNewline is deprecated and will be removed in a future version of Bicpe CLI. Use --insert-final-newline instead.");
+        //}
 
         [TestMethod]
         [DynamicData(nameof(GetValidDataSets), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -108,11 +108,11 @@ namespace Bicep.Cli.IntegrationTests
         {
             var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true, PublishSourceEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
-            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentationUri");
+            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentation-uri");
 
             result.Should().Be(1);
             output.Should().BeEmpty();
-            error.Should().MatchRegex(@"The --documentationUri parameter expects an argument.");
+            error.Should().MatchRegex(@"The --documentation-uri parameter expects an argument.");
         }
 
         [TestMethod]
@@ -120,15 +120,27 @@ namespace Bicep.Cli.IntegrationTests
         {
             var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
-            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentationUri", "https://example.com", "--documentationUri", "https://example.com");
+            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentation-uri", "https://example.com", "--documentation-uri", "https://example.com");
 
             result.Should().Be(1);
             output.Should().BeEmpty();
-            error.Should().MatchRegex(@"The --documentationUri parameter cannot be specified more than once.");
+            error.Should().MatchRegex(@"The --documentation-uri parameter cannot be specified more than once.");
         }
 
         [TestMethod]
         public async Task Publish_WithInvalidDocumentUri_ShouldProduceExpectedError()
+        {
+            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
+            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentation-uri", "invalid_uri");
+
+            result.Should().Be(1);
+            output.Should().BeEmpty();
+            error.Should().MatchRegex(@"The --documentation-uri should be a well formed uri string.");
+        }
+
+        [TestMethod]
+        public async Task Publish_WithDeprecatedParameter_PrintsDeprecationMessage()
         {
             var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
             var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
@@ -137,6 +149,7 @@ namespace Bicep.Cli.IntegrationTests
             result.Should().Be(1);
             output.Should().BeEmpty();
             error.Should().MatchRegex(@"The --documentationUri should be a well formed uri string.");
+            error.Should().MatchRegex(@"DEPRECATED: The parameter --documentationUri is deprecated and will be removed in a future version of Bicpe CLI. Use --documentation-uri instead.");
         }
 
         [DataTestMethod]
@@ -166,7 +179,7 @@ namespace Bicep.Cli.IntegrationTests
 
             if (!string.IsNullOrWhiteSpace(documentationUri))
             {
-                requiredArgs.AddRange(new List<string> { "--documentationUri", documentationUri });
+                requiredArgs.AddRange(new List<string> { "--documentation-uri", documentationUri });
             }
             if (publishSource)
             {

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -139,18 +139,19 @@ namespace Bicep.Cli.IntegrationTests
             error.Should().MatchRegex(@"The --documentation-uri should be a well formed uri string.");
         }
 
-        [TestMethod]
-        public async Task Publish_WithDeprecatedParameter_PrintsDeprecationMessage()
-        {
-            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
-            var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
-            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentationUri", "invalid_uri");
+        // TODO: Enable this once Azure CLI is updated to support the new parameters.
+        //[TestMethod]
+        //public async Task Publish_WithDeprecatedParameter_PrintsDeprecationMessage()
+        //{
+        //    var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+        //    var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
+        //    var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentationUri", "invalid_uri");
 
-            result.Should().Be(1);
-            output.Should().BeEmpty();
-            error.Should().MatchRegex(@"The --documentationUri should be a well formed uri string.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --documentationUri is deprecated and will be removed in a future version of Bicpe CLI. Use --documentation-uri instead.");
-        }
+        //    result.Should().Be(1);
+        //    output.Should().BeEmpty();
+        //    error.Should().MatchRegex(@"The --documentationUri should be a well formed uri string.");
+        //    error.Should().MatchRegex(@"DEPRECATED: The parameter --documentationUri is deprecated and will be removed in a future version of Bicpe CLI. Use --documentation-uri instead.");
+        //}
 
         [DataTestMethod]
         [DynamicData(nameof(GetValidDataSetsWithDocUriAndPublishSource), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetTestDisplayName))]

--- a/src/Bicep.Cli.UnitTests/ArgumentParserTests.cs
+++ b/src/Bicep.Cli.UnitTests/ArgumentParserTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using System.IO;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Services;
 using FluentAssertions;
@@ -11,17 +12,19 @@ namespace Bicep.Cli.UnitTests
     [TestClass]
     public class ArgumentParserTests
     {
+        private static readonly IOContext IO = new(new StringWriter(), new StringWriter());
+
         [TestMethod]
         public void Empty_parameters_should_return_null()
         {
-            var arguments = ArgumentParser.TryParse(Array.Empty<string>());
+            var arguments = ArgumentParser.TryParse(Array.Empty<string>(), IO);
             arguments.Should().BeNull();
         }
 
         [TestMethod]
         public void Wrong_command_should_return_null()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "wrong" });
+            var arguments = ArgumentParser.TryParse(new[] { "wrong" }, IO);
             arguments.Should().BeNull();
         }
 
@@ -62,7 +65,7 @@ namespace Bicep.Cli.UnitTests
         [DataRow(new[] { "restore", "file1", "file2" }, "The input file path cannot be specified multiple times.")]
         public void Invalid_args_trigger_validation_exceptions(string[] parameters, string expectedException)
         {
-            Action parseFunc = () => ArgumentParser.TryParse(parameters);
+            Action parseFunc = () => ArgumentParser.TryParse(parameters, IO);
 
             parseFunc.Should().Throw<CommandLineException>().WithMessage(expectedException);
         }
@@ -70,7 +73,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFile_ShouldReturnOneFile()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "build", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "file1" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -85,7 +88,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFileStdOut_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "build", "--stdout", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "--stdout", "file1" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -100,7 +103,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFileStdOut_and_no_restore_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "build", "--stdout", "--no-restore", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "--stdout", "--no-restore", "file1" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -115,7 +118,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFileStdOutAllCaps_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "build", "--STDOUT", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "--STDOUT", "file1" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -131,7 +134,7 @@ namespace Bicep.Cli.UnitTests
         public void Build_with_outputdir_parameter_should_parse_correctly()
         {
             // Use relative . to ensure directory exists else the parser will throw.
-            var arguments = ArgumentParser.TryParse(new[] { "build", "--outdir", ".", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "--outdir", ".", "file1" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -147,7 +150,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Build_with_outputfile_parameter_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "build", "--outfile", "jsonFile", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "--outfile", "jsonFile", "file1" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -162,7 +165,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Build_with_outputfile_and_no_restore_parameter_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "build", "--outfile", "jsonFile", "file1", "--no-restore" });
+            var arguments = ArgumentParser.TryParse(new[] { "build", "--outfile", "jsonFile", "file1", "--no-restore" }, IO);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -177,7 +180,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void License_argument_should_return_appropriate_RootArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "--license" });
+            var arguments = ArgumentParser.TryParse(new[] { "--license" }, IO);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -192,7 +195,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Third_party_notices_argument_should_return_appropriate_RootArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "--third-party-notices" });
+            var arguments = ArgumentParser.TryParse(new[] { "--third-party-notices" }, IO);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -207,7 +210,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Version_argument_should_return_VersionArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "--version" });
+            var arguments = ArgumentParser.TryParse(new[] { "--version" }, IO);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -222,7 +225,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Help_argument_should_return_HelpArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "--help" });
+            var arguments = ArgumentParser.TryParse(new[] { "--help" }, IO);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -237,7 +240,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Version_argument_should_return_VersionShortArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "-v" });
+            var arguments = ArgumentParser.TryParse(new[] { "-v" }, IO);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -252,7 +255,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Help_argument_should_return_HelpShortArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "-h" });
+            var arguments = ArgumentParser.TryParse(new[] { "-h" }, IO);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -267,7 +270,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void DecompileOneFile_ShouldReturnOneFile()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "decompile", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "decompile", "file1" }, IO);
             var bulidOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -281,7 +284,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void DecompileOneFileStdOut_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--stdout", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--stdout", "file1" }, IO);
             var bulidOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -295,7 +298,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void DecompileOneFileStdOutAllCaps_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--STDOUT", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--STDOUT", "file1" }, IO);
             var bulidOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -310,7 +313,7 @@ namespace Bicep.Cli.UnitTests
         public void Decompile_with_outputdir_parameter_should_parse_correctly()
         {
             // Use relative . to ensure directory exists else the parser will throw.
-            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--outdir", ".", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--outdir", ".", "file1" }, IO);
             var bulidOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -324,7 +327,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Decompile_with_outputfile_parameter_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--outfile", "jsonFile", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "decompile", "--outfile", "jsonFile", "file1" }, IO);
             var bulidOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -338,7 +341,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Publish_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "publish", "file1", "--target", "target1" });
+            var arguments = ArgumentParser.TryParse(new[] { "publish", "file1", "--target", "target1" }, IO);
             arguments.Should().BeOfType<PublishArguments>();
             var typed = (PublishArguments)arguments!;
 
@@ -350,7 +353,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Publish_with_no_restore_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "publish", "file1", "--target", "target1", "--no-restore" });
+            var arguments = ArgumentParser.TryParse(new[] { "publish", "file1", "--target", "target1", "--no-restore" }, IO);
             arguments.Should().BeOfType<PublishArguments>();
             var typed = (PublishArguments)arguments!;
 
@@ -362,7 +365,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Restore__with_no_force_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "restore", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "restore", "file1" }, IO);
             arguments.Should().BeOfType<RestoreArguments>();
             var typed = (RestoreArguments)arguments!;
 
@@ -373,7 +376,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Restore_with_force_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(new[] { "restore", "--force", "file1" });
+            var arguments = ArgumentParser.TryParse(new[] { "restore", "--force", "file1" }, IO);
             arguments.Should().BeOfType<RestoreArguments>();
             var typed = (RestoreArguments)arguments!;
 

--- a/src/Bicep.Cli/Arguments/FormatArguments.cs
+++ b/src/Bicep.Cli/Arguments/FormatArguments.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Bicep.Cli.Extensions;
 using Bicep.Core.FileSystem;
 using Bicep.Core.PrettyPrint.Options;
 
@@ -10,7 +11,7 @@ namespace Bicep.Cli.Arguments
 {
     public class FormatArguments : ArgumentsBase
     {
-        public FormatArguments(string[] args) : base(Constants.Command.Format)
+        public FormatArguments(string[] args, IOContext io) : base(Constants.Command.Format)
         {
             for (var i = 0; i < args.Length; i++)
             {
@@ -64,6 +65,8 @@ namespace Bicep.Cli.Arguments
                         break;
 
                     case "--indentkind":
+                        io.WriteParameterDeprecationWarning("--indentKind", "--indent-kind");
+
                         if (args.Length == i + 1)
                         {
                             throw new CommandLineException($"The --indentKind parameter expects an argument");
@@ -72,15 +75,33 @@ namespace Bicep.Cli.Arguments
                         {
                             throw new CommandLineException($"The --indentKind parameter cannot be specified twice");
                         }
-                        if (!Enum.TryParse<IndentKindOption>(args[i + 1], true, out var indentKind) || !Enum.IsDefined<IndentKindOption>(indentKind))
+                        if (!Enum.TryParse<IndentKindOption>(args[i + 1], true, out var indentKind) || !Enum.IsDefined(indentKind))
                         {
                             throw new CommandLineException($"The --indentKind parameter only accepts values: {string.Join(" | ", Enum.GetNames(typeof(IndentKindOption)))}");
                         }
                         IndentKind = indentKind;
                         i++;
                         break;
+                    case "--indent-kind":
+                        if (args.Length == i + 1)
+                        {
+                            throw new CommandLineException($"The --indent-kind parameter expects an argument");
+                        }
+                        if (IndentKind is not null)
+                        {
+                            throw new CommandLineException($"The --indent-kind parameter cannot be specified twice");
+                        }
+                        if (!Enum.TryParse(args[i + 1], true, out indentKind) || !Enum.IsDefined(indentKind))
+                        {
+                            throw new CommandLineException($"The --indent-kind parameter only accepts values: {string.Join(" | ", Enum.GetNames(typeof(IndentKindOption)))}");
+                        }
+                        IndentKind = indentKind;
+                        i++;
+                        break;
 
                     case "--indentsize":
+                        io.WriteParameterDeprecationWarning("--indentSize", "--indent-size");
+
                         if (args.Length == i + 1)
                         {
                             throw new CommandLineException($"The --indentSize parameter expects an argument");
@@ -96,11 +117,36 @@ namespace Bicep.Cli.Arguments
                         IndentSize = indentSize;
                         i++;
                         break;
+                    case "--indent-size":
+                        if (args.Length == i + 1)
+                        {
+                            throw new CommandLineException($"The --indent-size parameter expects an argument");
+                        }
+                        if (IndentSize is not null)
+                        {
+                            throw new CommandLineException($"The --indent-size parameter cannot be specified twice");
+                        }
+                        if (!int.TryParse(args[i + 1], out indentSize))
+                        {
+                            throw new CommandLineException($"The --indent-size parameter only accepts integer values");
+                        }
+                        IndentSize = indentSize;
+                        i++;
+                        break;
 
                     case "--insertfinalnewline":
+                        io.WriteParameterDeprecationWarning("--insertFinalNewline", "--insert-final-newline");
+
                         if (InsertFinalNewline is not null)
                         {
                             throw new CommandLineException($"The --insertFinalNewline parameter cannot be specified twice");
+                        }
+                        InsertFinalNewline = true;
+                        break;
+                    case "--insert-final-newline":
+                        if (InsertFinalNewline is not null)
+                        {
+                            throw new CommandLineException($"The --insert-final-newline parameter cannot be specified twice");
                         }
                         InsertFinalNewline = true;
                         break;
@@ -141,7 +187,7 @@ namespace Bicep.Cli.Arguments
 
             if (IndentSize is not null && IndentKind == IndentKindOption.Tab)
             {
-                throw new CommandLineException($"The --indentSize cannot be used when --indentKind is \"Tab\"");
+                throw new CommandLineException($"The --indent-size cannot be used when --indent-kind is \"Tab\"");
             }
 
             if (OutputDir is not null)

--- a/src/Bicep.Cli/Arguments/FormatArguments.cs
+++ b/src/Bicep.Cli/Arguments/FormatArguments.cs
@@ -65,7 +65,8 @@ namespace Bicep.Cli.Arguments
                         break;
 
                     case "--indentkind":
-                        io.WriteParameterDeprecationWarning("--indentKind", "--indent-kind");
+                        // TODO: Uncomment this once Azure CLI is updated to support the new parameter.
+                        //io.WriteParameterDeprecationWarning("--indentKind", "--indent-kind");
 
                         if (args.Length == i + 1)
                         {
@@ -100,7 +101,8 @@ namespace Bicep.Cli.Arguments
                         break;
 
                     case "--indentsize":
-                        io.WriteParameterDeprecationWarning("--indentSize", "--indent-size");
+                        // TODO: Uncomment this once Azure CLI is updated to support the new parameter.
+                        //io.WriteParameterDeprecationWarning("--indentSize", "--indent-size");
 
                         if (args.Length == i + 1)
                         {
@@ -135,7 +137,8 @@ namespace Bicep.Cli.Arguments
                         break;
 
                     case "--insertfinalnewline":
-                        io.WriteParameterDeprecationWarning("--insertFinalNewline", "--insert-final-newline");
+                        // TODO: Uncomment this once Azure CLI is updated to support the new parameter.
+                        //io.WriteParameterDeprecationWarning("--insertFinalNewline", "--insert-final-newline");
 
                         if (InsertFinalNewline is not null)
                         {

--- a/src/Bicep.Cli/Arguments/PublishArguments.cs
+++ b/src/Bicep.Cli/Arguments/PublishArguments.cs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using Bicep.Cli.Extensions;
 
 namespace Bicep.Cli.Arguments
 {
     public class PublishArguments : ArgumentsBase
     {
-        public PublishArguments(string[] args) : base(Constants.Command.Publish)
+        public PublishArguments(string[] args, IOContext io) : base(Constants.Command.Publish)
         {
             for (int i = 0; i < args.Length; i++)
             {
@@ -33,6 +34,8 @@ namespace Bicep.Cli.Arguments
                         break;
 
                     case "--documentationuri":
+                        io.WriteParameterDeprecationWarning("--documentationUri", "--documentation-uri");
+
                         if (isLast)
                         {
                             throw new CommandLineException("The --documentationUri parameter expects an argument.");
@@ -48,6 +51,26 @@ namespace Bicep.Cli.Arguments
                         if (!Uri.IsWellFormedUriString(DocumentationUri, UriKind.Absolute))
                         {
                             throw new CommandLineException("The --documentationUri should be a well formed uri string.");
+                        }
+
+                        i++;
+                        break;
+                    case "--documentation-uri":
+                        if (isLast)
+                        {
+                            throw new CommandLineException("The --documentation-uri parameter expects an argument.");
+                        }
+
+                        if (this.DocumentationUri is not null)
+                        {
+                            throw new CommandLineException("The --documentation-uri parameter cannot be specified more than once.");
+                        }
+
+                        DocumentationUri = args[i + 1];
+
+                        if (!Uri.IsWellFormedUriString(DocumentationUri, UriKind.Absolute))
+                        {
+                            throw new CommandLineException("The --documentation-uri should be a well formed uri string.");
                         }
 
                         i++;

--- a/src/Bicep.Cli/Arguments/PublishArguments.cs
+++ b/src/Bicep.Cli/Arguments/PublishArguments.cs
@@ -34,7 +34,8 @@ namespace Bicep.Cli.Arguments
                         break;
 
                     case "--documentationuri":
-                        io.WriteParameterDeprecationWarning("--documentationUri", "--documentation-uri");
+                        // TODO: Uncomment this once Azure CLI is updated to support the new parameter.
+                        //io.WriteParameterDeprecationWarning("--documentationUri", "--documentation-uri");
 
                         if (isLast)
                         {

--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -88,16 +88,16 @@ Usage:
       --outfile <file>      Saves the output as the specified file path.
       --stdout              Prints the output to stdout.
       --newline             Set newline char. Valid values are ( Auto | LF | CRLF | CR ).
-      --indentKind          Set indentation kind. Valid values are ( Space | Tab ).
-      --indentSize          Number of spaces to indent with (Only valid with --indentKind set to Space).
-      --insertFinalNewline  Insert a final newline.
+      --indent-kind          Set indentation kind. Valid values are ( Space | Tab ).
+      --indent-size          Number of spaces to indent with (Only valid with --indentKind set to Space).
+      --insert-final-newline  Insert a final newline.
 
     Examples:
       bicep format file.bicep
       bicep format file.bicep --stdout
       bicep format file.bicep --outdir dir1
       bicep format file.bicep --outfile file.json
-      bicep format file.bicep --indentKind Tab
+      bicep format file.bicep --indent-kind Tab
 
   {exeName} decompile [options] <file>
     Attempts to decompile a template .json file to .bicep.
@@ -184,15 +184,15 @@ Usage:
       <ref>         The module reference
 
     Options:
-      --documentationUri  Module documentation uri
+      --documentation-uri  Module documentation uri
       --with-source       [Experimental] Publish source code with the module
       --force             Overwrite existing published module or file
 
     Examples:
       bicep publish file.bicep --target br:example.azurecr.io/hello/world:v1
       bicep publish file.bicep --target br:example.azurecr.io/hello/world:v1 --force
-      bicep publish file.bicep --target br:example.azurecr.io/hello/world:v1 --documentationUri https://github.com/hello-world/README.md --with-source
-      bicep publish file.json --target br:example.azurecr.io/hello/world:v1 --documentationUri https://github.com/hello-world/README.md
+      bicep publish file.bicep --target br:example.azurecr.io/hello/world:v1 --documentation-uri https://github.com/hello-world/README.md --with-source
+      bicep publish file.json --target br:example.azurecr.io/hello/world:v1 --documentation-uri https://github.com/hello-world/README.md
 
   {exeName} restore <file>
     Restores external modules from the specified Bicep file to the local module cache.

--- a/src/Bicep.Cli/Extensions/IOContextExtensions.cs
+++ b/src/Bicep.Cli/Extensions/IOContextExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Cli.Extensions
+{
+    public static class IOContextExtensions
+    {
+        public static void WriteParameterDeprecationWarning(this IOContext io, string deprecatingParameter, string newParameter)
+        {
+            io.Error.Write($"DEPRECATED: The parameter {deprecatingParameter} is deprecated and will be removed in a future version of Bicpe CLI. Use {newParameter} instead.");
+        }
+    }
+}

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -69,7 +69,7 @@ namespace Bicep.Cli
 
             try
             {
-                switch (ArgumentParser.TryParse(args))
+                switch (ArgumentParser.TryParse(args, this.io))
                 {
                     case BuildArguments buildArguments when buildArguments.CommandName == Constants.Command.Build: // bicep build [options]
                         return await services.GetRequiredService<BuildCommand>().RunAsync(buildArguments);

--- a/src/Bicep.Cli/Services/ArgumentParser.cs
+++ b/src/Bicep.Cli/Services/ArgumentParser.cs
@@ -8,7 +8,7 @@ namespace Bicep.Cli.Services
 {
     public static class ArgumentParser
     {
-        public static ArgumentsBase? TryParse(string[] args)
+        public static ArgumentsBase? TryParse(string[] args, IOContext io)
         {
             if (args.Length < 1)
             {
@@ -30,11 +30,11 @@ namespace Bicep.Cli.Services
                 Constants.Command.Build => new BuildArguments(args[1..]),
                 Constants.Command.Test => new TestArguments(args[1..]),
                 Constants.Command.BuildParams => new BuildParamsArguments(args[1..]),
-                Constants.Command.Format => new FormatArguments(args[1..]),
+                Constants.Command.Format => new FormatArguments(args[1..], io),
                 Constants.Command.GenerateParamsFile => new GenerateParametersFileArguments(args[1..]),
                 Constants.Command.Decompile => new DecompileArguments(args[1..]),
                 Constants.Command.DecompileParams => new DecompileParamsArguments(args[1..]),
-                Constants.Command.Publish => new PublishArguments(args[1..]),
+                Constants.Command.Publish => new PublishArguments(args[1..], io),
                 Constants.Command.Restore => new RestoreArguments(args[1..]),
                 Constants.Command.Lint => new LintArguments(args[1..]),
                 _ => null,


### PR DESCRIPTION
Added new CLI parameters that use kebab case to replace the existing ones using camel case. While those parameters with wrong casing have been excluded from the help message, their implementation remains intact to facilitate a soft deprecation process. A warning message will be printed if any of the deprecated parameters are used by the user.

Closes #12117.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12469)