### PR TITLE
Add support for importing variables that enclose synthesized variables

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -1770,7 +1770,7 @@ public class CompileTimeImportTests
 
         result.Should().NotHaveAnyCompilationBlockingDiagnostics();
     }
-             
+
     // https://github.com/Azure/bicep/issues/12401
     [TestMethod]
     public void Symbolic_name_target_is_used_when_function_import_closure_includes_a_user_defined_type()
@@ -1789,5 +1789,106 @@ public class CompileTimeImportTests
         result.Should().NotHaveAnyCompilationBlockingDiagnostics();
         result.Template.Should().HaveValueAtPath("languageVersion", "2.0");
         result.Template.Should().HaveValueAtPath("functions[0].members.capitalizer.parameters[0].$ref", "#/definitions/_1.myString");
+    }
+
+    // https://github.com/Azure/bicep/issues/12464
+    [TestMethod]
+    public void Test_12464()
+    {
+        var result = CompilationHelper.CompileParams(ServicesWithCompileTimeTypeImports,
+            ("bicepconfig.json", """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "compileTimeImports": true
+                    }
+                }
+                """),
+            ("bicepconfig.bicep", """
+                @export()
+                var compileTimeImportsEnabled = loadJsonContent('bicepconfig.json').experimentalFeaturesEnabled.compileTimeImports
+                @export()
+                var literalTrue = true
+                @export()
+                var loadJsonContentTrue = compileTimeImportsEnabled
+                """),
+            ("test.bicep", """
+                param boolParamOne bool
+                param boolParamTwo bool
+                output bothTrue bool = boolParamOne && boolParamTwo
+                """),
+            ("parameters.bicepparam", """
+                using 'test.bicep'
+                import * as bicepconfig from 'bicepconfig.bicep'
+                // no error
+                param boolParamOne = bicepconfig.literalTrue
+                // Failed to evaluate parameter "boolParamTwo":
+                // Unhandled exception during evaluating template language function 'variables' is not handled.bicep(BCP338)
+                param boolParamTwo = bicepconfig.loadJsonContentTrue
+                """));
+
+        result.Diagnostics.Should().BeEmpty();
+        result.Parameters.Should().HaveValueAtPath("parameters.boolParamTwo.value", true);
+    }
+
+    [TestMethod]
+    public void Imported_variable_symbols_that_use_compile_time_functions_should_have_synthesized_variable_declarations_injected_into_compiled_template()
+    {
+        var result = CompilationHelper.Compile(ServicesWithCompileTimeTypeImports,
+            ("main.bicep", """
+                import {fizzBuzz} from 'mod.bicep'
+                """),
+            ("mod.bicep", """
+                var precalculatedFizzBuzz = loadJsonContent('fizz.json').values
+                @export()
+                var fizzBuzz = map(range(0, 100), i => precalculatedFizzBuzz[i % length(precalculatedFizzBuzz)])
+                """),
+            ("fizz.json", """
+                {
+                    "values": [
+                        "",
+                        "",
+                        "fizz",
+                        "",
+                        "buzz",
+                        "",
+                        "",
+                        "fizz",
+                        "",
+                        "buzz",
+                        "",
+                        "",
+                        "fizz",
+                        "",
+                        "fizzbuzz"
+                    ]
+                }
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveValueAtPath("variables", JToken.Parse($$"""
+            {
+                "_1._2": {
+                    "values": [
+                        "",
+                        "",
+                        "fizz",
+                        "",
+                        "buzz",
+                        "",
+                        "",
+                        "fizz",
+                        "",
+                        "buzz",
+                        "",
+                        "",
+                        "fizz",
+                        "",
+                        "fizzbuzz"
+                    ]
+                },
+                "_1.precalculatedFizzBuzz": "[variables('_1._2').values]",
+                "fizzBuzz": "[map(range(0, 100), lambda('i', variables('_1.precalculatedFizzBuzz')[mod(lambdaVariables('i'), length(variables('_1.precalculatedFizzBuzz')))]))]"
+            }
+            """));
     }
 }

--- a/src/Bicep.Core/Emit/CompileTimeImports/ImportedSymbolDeclarationMigrator.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ImportedSymbolDeclarationMigrator.cs
@@ -14,12 +14,17 @@ internal class ImportedSymbolDeclarationMigrator : ExpressionRewriteVisitor
 {
     private readonly SemanticModel sourceModel;
     private readonly ImmutableDictionary<DeclaredSymbol, string> declaredSymbolNames;
+    private readonly ImmutableDictionary<string, string> synthesizedVariableNames;
     private readonly SyntaxBase? sourceSyntax;
 
-    public ImportedSymbolDeclarationMigrator(SemanticModel sourceModel, ImmutableDictionary<DeclaredSymbol, string> declaredSymbolNames, SyntaxBase sourceSyntax)
+    public ImportedSymbolDeclarationMigrator(SemanticModel sourceModel,
+        ImmutableDictionary<DeclaredSymbol, string> declaredSymbolNames,
+        ImmutableDictionary<string, string> synthesizedVariableNames,
+        SyntaxBase sourceSyntax)
     {
         this.sourceModel = sourceModel;
         this.declaredSymbolNames = declaredSymbolNames;
+        this.synthesizedVariableNames = synthesizedVariableNames;
         this.sourceSyntax = sourceSyntax;
     }
 
@@ -81,6 +86,9 @@ internal class ImportedSymbolDeclarationMigrator : ExpressionRewriteVisitor
         var (namespaceName, name) = GetFunctionName(declaredSymbolNames[expression.Symbol]);
         return new SynthesizedUserDefinedFunctionCallExpression(sourceSyntax, namespaceName, name, expression.Parameters);
     }
+
+    public override Expression ReplaceSynthesizedVariableReferenceExpression(SynthesizedVariableReferenceExpression expression)
+        => new SynthesizedVariableReferenceExpression(sourceSyntax, synthesizedVariableNames[expression.Name]);
 
     private TypeAliasSymbol LookupTypeAliasByName(string name) => sourceModel.Root.TypeDeclarations
         .Where(NameEquals<TypeAliasSymbol>(name))


### PR DESCRIPTION
Resolves #12464 

Import closure calculation is not currently taking "synthesized" variables (i.e., the results of functions like `loadJsonContent`) into account.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12473)