### PR TITLE
Handle nested UDF calls during import migration

### DIFF
--- a/src/Bicep.Core/Emit/CompileTimeImports/ImportedSymbolDeclarationMigrator.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ImportedSymbolDeclarationMigrator.cs
@@ -84,7 +84,8 @@ internal class ImportedSymbolDeclarationMigrator : ExpressionRewriteVisitor
     public override Expression ReplaceUserDefinedFunctionCallExpression(UserDefinedFunctionCallExpression expression)
     {
         var (namespaceName, name) = GetFunctionName(declaredSymbolNames[expression.Symbol]);
-        return new SynthesizedUserDefinedFunctionCallExpression(sourceSyntax, namespaceName, name, expression.Parameters);
+        return new SynthesizedUserDefinedFunctionCallExpression(sourceSyntax, namespaceName, name,
+            expression.Parameters.Select(Replace).ToImmutableArray());
     }
 
     public override Expression ReplaceSynthesizedVariableReferenceExpression(SynthesizedVariableReferenceExpression expression)


### PR DESCRIPTION
Resolves #12542 

The logic that replaces references in imported types, variables, and functions is not currently handling UDF calls within UDF calls, e.g.,

```bicep
func foo(input string) => input

@export()
func bar(input string) => foo(foo(input))
```

In the definition of `bar`, the outer `foo` would be migrated (i.e., it would refer to a UDF in a closure namespace (`_1.foo`)), but the inner `foo` would not (i.e., it would refer to a UDF in the `__bicep` namespace).