### PR TITLE
Update bicepconfig.json schema

### DIFF
--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -245,7 +245,7 @@
           "title": "Bicep Registry Module Aliases",
           "description": "Bicep Registry module alias definitions",
           "additionalProperties": {
-            "$ref": "#/definitions/bicepRegistryProviderAlias",
+            "$ref": "#/definitions/bicepRegistryModuleAlias",
             "additionalProperties": false
           }
         }

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -237,14 +237,16 @@
           "description": "Template Spec module alias definitions",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/templateSpecModuleAlias"
+            "$ref": "#/definitions/templateSpecModuleAlias",
+            "additionalProperties": false
           }
         },
         "br": {
           "title": "Bicep Registry Module Aliases",
           "description": "Bicep Registry module alias definitions",
           "additionalProperties": {
-            "$ref": "#/definitions/bicepRegistryModuleAlias"
+            "$ref": "#/definitions/bicepRegistryProviderAlias",
+            "additionalProperties": false
           }
         }
       }
@@ -254,7 +256,6 @@
       "type": "object",
       "additionalProperties": false,
       "default": {
-        "ts": {},
         "br": {}
       },
       "properties": {

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -249,6 +249,24 @@
         }
       }
     },
+    "providerAliases": {
+      "title": "Module Aliases",
+      "type": "object",
+      "additionalProperties": false,
+      "default": {
+        "ts": {},
+        "br": {}
+      },
+      "properties": {
+        "br": {
+          "title": "Bicep Registry Provider Aliases",
+          "description": "Bicep Registry provider alias definitions",
+          "additionalProperties": {
+            "$ref": "#/definitions/bicepRegistryProviderAlias"
+          }
+        }
+      }
+    },
     "analyzers": {
       "title": "Analyzers",
       "type": "object",


### PR DESCRIPTION
## Changes
- Fixes schema so that IntelliSense is available for `providerAlias` section.
- adds `additionalProperties: false` to prevent confusion between `modulePath` and `providerPath`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/12593)